### PR TITLE
feat: 支持 HTTP/SOCKS5 代理设置

### DIFF
--- a/src-tauri/src/maa_commands.rs
+++ b/src-tauri/src/maa_commands.rs
@@ -2466,6 +2466,7 @@ pub async fn download_file(
     url: String,
     save_path: String,
     total_size: Option<u64>,
+    proxy_url: Option<String>,
 ) -> Result<u64, String> {
     use futures_util::StreamExt;
     use std::io::Write;
@@ -2490,8 +2491,27 @@ pub async fn download_file(
     let temp_path = format!("{}.downloading", save_path);
 
     // 构建 HTTP 客户端和请求
-    let client = reqwest::Client::builder()
+    let mut client_builder = reqwest::Client::builder()
         .user_agent(build_user_agent())
+        .timeout(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(10));
+
+    // 配置代理（如果提供）
+    if let Some(proxy) = proxy_url {
+        if !proxy.is_empty() {
+            info!("使用代理: {}", proxy);
+            let reqwest_proxy = reqwest::Proxy::all(&proxy).map_err(|e| {
+                error!("代理配置失败: {} (代理地址: {})", e, proxy);
+                format!(
+                    "代理配置失败: {}。请检查代理格式是否正确（支持 http:// 或 socks5://）",
+                    e
+                )
+            })?;
+            client_builder = client_builder.proxy(reqwest_proxy);
+        }
+    }
+
+    let client = client_builder
         .build()
         .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))?;
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -24,6 +24,7 @@ import {
   Trash2,
   Paintbrush,
   Info,
+  Network,
 } from 'lucide-react';
 import {
   checkAndPrepareDownload,
@@ -35,7 +36,7 @@ import {
   isDebugVersion,
 } from '@/services/updateService';
 import { clearAllCache, getCacheStats } from '@/services/cacheService';
-import type { DownloadProgress } from '@/stores/appStore';
+
 import { defaultWindowSize } from '@/types/config';
 import { useAppStore } from '@/stores/appStore';
 import { setLanguage as setI18nLanguage, getInterfaceLangKey } from '@/i18n';
@@ -50,6 +51,7 @@ import { maaService } from '@/services/maaService';
 import { ReleaseNotes, DownloadProgressBar } from './UpdateInfoCard';
 import { loggers } from '@/utils/logger';
 import { FrameRateSelector } from './FrameRateSelector';
+import { createProxySettings, shouldUseProxy } from '@/services/proxyService';
 import clsx from 'clsx';
 
 // 检测是否在 Tauri 环境中
@@ -84,6 +86,8 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     mirrorChyanSettings,
     setMirrorChyanCdk,
     setMirrorChyanChannel,
+    proxySettings,
+    setProxySettings,
     updateInfo,
     updateCheckLoading,
     setUpdateInfo,
@@ -125,10 +129,49 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
   const [exeDir, setExeDir] = useState<string | null>(null);
   const [cwd, setCwd] = useState<string | null>(null);
 
+  // 代理设置相关状态
+  const [proxyInput, setProxyInput] = useState(proxySettings?.url || '');
+  const [proxyError, setProxyError] = useState(false);
+
   // 调试：添加日志（提前定义以便在 handleCdkChange 中使用）
   const addDebugLog = useCallback((msg: string) => {
     setDebugLog((prev) => [...prev, `[${new Date().toLocaleTimeString()}] ${msg}`]);
   }, []);
+
+  // 处理代理输入框失焦事件
+  const handleProxyBlur = useCallback(() => {
+    const trimmed = proxyInput.trim();
+
+    // 如果为空，清空代理设置
+    if (trimmed === '') {
+      setProxySettings(undefined);
+      setProxyError(false);
+      return;
+    }
+
+    // 验证并创建代理设置（createProxySettings 内部会规范化）
+    const settings = createProxySettings(trimmed);
+
+    if (settings) {
+      setProxySettings(settings);
+      setProxyInput(settings.url); // 使用规范化后的 URL
+      setProxyError(false);
+    } else {
+      setProxyError(true);
+    }
+  }, [proxyInput, setProxySettings]);
+
+  // 同步 proxySettings 到 proxyInput
+  useEffect(() => {
+    if (proxySettings?.url && proxySettings.url !== proxyInput) {
+      setProxyInput(proxySettings.url);
+    }
+  }, [proxySettings]);
+
+  // 检查是否禁用代理（填写了 MirrorChyan CDK）
+  const isProxyDisabled = useMemo(() => {
+    return mirrorChyanSettings.cdk && mirrorChyanSettings.cdk.trim() !== '';
+  }, [mirrorChyanSettings.cdk]);
 
   // 开始下载（支持指定 updateInfo，用于切换下载源后重新下载）
   const startDownload = useCallback(
@@ -148,11 +191,17 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
         const savePath = await getUpdateSavePath(basePath, info.filename);
         setDownloadSavePath(savePath);
 
+        // 仅在 GitHub 下载时使用代理
+        const useProxy =
+          info.downloadSource === 'github' &&
+          shouldUseProxy(proxySettings, mirrorChyanSettings.cdk);
+
         const success = await downloadUpdate({
           url: info.downloadUrl,
           savePath,
           totalSize: info.fileSize,
-          onProgress: (progress: DownloadProgress) => {
+          proxySettings: useProxy ? proxySettings : undefined,
+          onProgress: (progress) => {
             setDownloadProgress(progress);
           },
         });
@@ -925,6 +974,43 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
                           </p>
                         </div>
                       </div>
+
+                      {/* 代理设置 */}
+                      {!isProxyDisabled && (
+                        <div className="pt-4 border-t border-border">
+                          <div className="flex items-center gap-3 mb-3">
+                            <Network className="w-5 h-5 text-accent" />
+                            <span className="font-medium text-text-primary">
+                              {t('proxy.title')}
+                            </span>
+                          </div>
+                          <div className="relative">
+                            <input
+                              type="text"
+                              value={proxyInput}
+                              onChange={(e) => {
+                                setProxyInput(e.target.value);
+                                setProxyError(false);
+                              }}
+                              onBlur={handleProxyBlur}
+                              placeholder={t('proxy.urlPlaceholder')}
+                              className={clsx(
+                                'w-full px-3 py-2.5 rounded-lg bg-bg-tertiary border text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50',
+                                proxyError ? 'border-error' : 'border-border',
+                              )}
+                            />
+                          </div>
+                          {proxyError && (
+                            <p className="mt-2 text-xs text-error flex items-center gap-1">
+                              <AlertCircle className="w-3 h-3" />
+                              {t('proxy.invalid')}
+                            </p>
+                          )}
+                          <div className="mt-3 text-xs text-text-muted leading-relaxed space-y-1">
+                            <p>{t('proxy.urlHint')}</p>
+                          </div>
+                        </div>
+                      )}
 
                       {/* 检查更新按钮 */}
                       <div className="pt-4 border-t border-border space-y-4">

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -408,6 +408,17 @@ export default {
     },
   },
 
+  // 代理设置
+  proxy: {
+    title: '网络代理',
+    url: '代理地址',
+    urlPlaceholder: '例如：http://127.0.0.1:7890',
+    urlHint: '支持 HTTP/SOCKS5，留空则不使用代理',
+    urlHintDisabled: '已填写 Mirror酱 CDK，代理功能已禁用',
+    invalid: '代理地址格式不正确',
+    examples: '示例格式',
+  },
+
   // 定时执行
   schedule: {
     title: '定时执行',

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -4,3 +4,4 @@ export * from './contentResolver';
 export * from './maaService';
 export * from './updateService';
 export * from './cacheService';
+export * from './proxyService';

--- a/src/services/proxyService.ts
+++ b/src/services/proxyService.ts
@@ -1,0 +1,169 @@
+// 代理服务模块
+// 提供代理验证、解析和统一的下载接口
+
+import type { ProxySettings } from '@/types/config';
+import { invoke } from '@tauri-apps/api/core';
+import { loggers } from '@/utils/logger';
+
+const log = loggers.app;
+
+type ProxyType = 'http' | 'socks5';
+
+/**
+ * 代理 URL 正则表达式
+ * 支持格式：
+ * - http://host:port
+ * - http://user:pass@host:port
+ * - socks5://host:port
+ * - socks5://user:pass@host:port
+ *
+ * 改进点：
+ * - 用户名/密码使用 URL 安全字符集
+ * - 主机名符合 RFC 规范（不允许开头/结尾为 -）
+ * - 支持 IPv6 地址
+ */
+const PROXY_URL_REGEX =
+  /^(http|socks5):\/\/(?:([a-zA-Z0-9._~!$&'()*+,;=-]+):([a-zA-Z0-9._~!$&'()*+,;=:-]+)@)?([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*|\[[\da-fA-F:]+\]):(\d{1,5})$/;
+
+/**
+ * 验证代理 URL 格式
+ * @param url 代理 URL
+ * @returns 是否有效
+ */
+export function isValidProxyUrl(url: string): boolean {
+  if (!url || url.trim() === '') {
+    return false;
+  }
+
+  const match = url.trim().match(PROXY_URL_REGEX);
+  if (!match) {
+    return false;
+  }
+
+  const port = parseInt(match[8], 10);
+  return port > 0 && port <= 65535;
+}
+
+/**
+ * 解析代理 URL
+ * @param url 代理 URL
+ * @returns 解析后的代理信息，如果无效则返回 null
+ */
+export function parseProxyUrl(url: string): {
+  type: ProxyType;
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+} | null {
+  if (!url || url.trim() === '') {
+    return null;
+  }
+
+  const match = url.trim().match(PROXY_URL_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const [, type, username, password, host, , , , portStr] = match;
+  const port = parseInt(portStr, 10);
+
+  if (port <= 0 || port > 65535) {
+    return null;
+  }
+
+  return {
+    type: type as ProxyType,
+    host,
+    port,
+    username: username || undefined,
+    password: password || undefined,
+  };
+}
+
+/**
+ * 创建代理设置对象（优化为单次解析）
+ * @param url 代理 URL
+ * @returns 代理设置对象，如果无效则返回 undefined
+ */
+export function createProxySettings(url: string): ProxySettings | undefined {
+  const parsed = parseProxyUrl(url);
+  if (!parsed) {
+    return undefined;
+  }
+
+  const { type, host, port, username, password } = parsed;
+  const auth = username && password ? `${username}:${password}@` : '';
+  const normalized = `${type}://${auth}${host}:${port}`;
+
+  return {
+    url: normalized,
+  };
+}
+
+/**
+ * 检查是否应该使用代理（简化版）
+ * @param proxySettings 代理设置
+ * @param mirrorChyanCdk MirrorChyan CDK
+ * @returns 是否应该使用代理
+ */
+export function shouldUseProxy(
+  proxySettings: ProxySettings | undefined,
+  mirrorChyanCdk: string,
+): boolean {
+  return (
+    !mirrorChyanCdk?.trim() &&
+    !!proxySettings?.url?.trim() &&
+    isValidProxyUrl(proxySettings.url)
+  );
+}
+
+/**
+ * 格式化代理 URL 用于显示（隐藏密码）
+ * @param url 代理 URL
+ * @returns 格式化后的 URL
+ */
+export function formatProxyUrlForDisplay(url: string): string {
+  const parsed = parseProxyUrl(url);
+  if (!parsed) {
+    return url;
+  }
+
+  const { type, host, port, username } = parsed;
+  const auth = username ? `${username}:****@` : '';
+  return `${type}://${auth}${host}:${port}`;
+}
+
+/**
+ * 统一的带代理下载接口
+ * 自动处理代理参数并记录日志
+ *
+ * @param url 下载 URL
+ * @param savePath 保存路径
+ * @param options 可选参数
+ * @returns Session ID
+ */
+export async function downloadWithProxy(
+  url: string,
+  savePath: string,
+  options?: {
+    totalSize?: number;
+    proxyUrl?: string | null;
+  },
+): Promise<number> {
+  const hasProxy = options?.proxyUrl && options.proxyUrl.trim() !== '';
+
+  if (hasProxy) {
+    const parsed = parseProxyUrl(options.proxyUrl!);
+    if (parsed) {
+      log.info(`使用代理下载: ${parsed.type}://${parsed.host}:${parsed.port}`);
+    }
+  }
+
+  return invoke<number>('download_file', {
+    url,
+    savePath,
+    totalSize: options?.totalSize || null,
+    proxyUrl: options?.proxyUrl || null,
+  });
+}

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -14,6 +14,7 @@ import type {
   WindowSize,
   UpdateChannel,
   MirrorChyanSettings,
+  ProxySettings,
   RecentlyClosedInstance,
   ScreenshotFrameRate,
 } from '@/types/config';
@@ -55,8 +56,8 @@ interface AppState {
   accentColor: AccentColor;
   language: Language;
   setTheme: (theme: Theme) => void;
-  setAccentColor: (accent: AccentColor) => void;
-  setLanguage: (lang: Language) => void;
+  setAccentColor: (color: AccentColor) => void;
+  setLanguage: (language: Language) => void;
 
   // 当前页面
   currentPage: PageView;
@@ -225,6 +226,10 @@ interface AppState {
   mirrorChyanSettings: MirrorChyanSettings;
   setMirrorChyanCdk: (cdk: string) => void;
   setMirrorChyanChannel: (channel: UpdateChannel) => void;
+
+  // 代理设置
+  proxySettings: ProxySettings | undefined;
+  setProxySettings: (settings: ProxySettings | undefined) => void;
 
   // 任务选项预览显示设置
   showOptionPreview: boolean;
@@ -1088,6 +1093,7 @@ export const useAppStore = create<AppState>()(
         nextInstanceNumber: maxNumber + 1,
         windowSize: config.settings.windowSize || defaultWindowSize,
         mirrorChyanSettings: config.settings.mirrorChyan || defaultMirrorChyanSettings,
+        proxySettings: config.settings.proxy,
         showOptionPreview: config.settings.showOptionPreview ?? true,
         sidePanelExpanded: config.settings.sidePanelExpanded ?? true,
         rightPanelWidth: config.settings.rightPanelWidth ?? 320,
@@ -1325,6 +1331,10 @@ export const useAppStore = create<AppState>()(
       set((state) => ({
         mirrorChyanSettings: { ...state.mirrorChyanSettings, channel },
       })),
+
+    // 代理设置
+    proxySettings: undefined,
+    setProxySettings: (settings) => set({ proxySettings: settings }),
 
     // 任务选项预览显示设置
     showOptionPreview: true,
@@ -1676,6 +1686,7 @@ function generateConfig(): MxuConfig {
       language: state.language,
       windowSize: state.windowSize,
       mirrorChyan: state.mirrorChyanSettings,
+      proxy: state.proxySettings,
       showOptionPreview: state.showOptionPreview,
       sidePanelExpanded: state.sidePanelExpanded,
       rightPanelWidth: state.rightPanelWidth,
@@ -1720,6 +1731,7 @@ useAppStore.subscribe(
     language: state.language,
     windowSize: state.windowSize,
     mirrorChyanSettings: state.mirrorChyanSettings,
+    proxySettings: state.proxySettings,
     showOptionPreview: state.showOptionPreview,
     sidePanelExpanded: state.sidePanelExpanded,
     rightPanelWidth: state.rightPanelWidth,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -79,6 +79,11 @@ export interface MirrorChyanSettings {
   channel: UpdateChannel; // 更新频道：stable(正式版) / beta(公测版)
 }
 
+// 代理设置
+export interface ProxySettings {
+  url: string; // 代理地址，格式：http://host:port 或 socks5://host:port
+}
+
 // 应用设置
 export interface AppSettings {
   theme: 'light' | 'dark' | 'system';
@@ -86,6 +91,7 @@ export interface AppSettings {
   language: 'zh-CN' | 'zh-TW' | 'en-US' | 'ja-JP' | 'ko-KR';
   windowSize?: WindowSize;
   mirrorChyan?: MirrorChyanSettings;
+  proxy?: ProxySettings; // 代理设置
   showOptionPreview?: boolean; // 是否在任务列表显示选项预览
   sidePanelExpanded?: boolean; // 右侧面板是否展开（连接+截图）
   connectionPanelExpanded?: boolean; // 连接设置卡片是否展开


### PR DESCRIPTION
## 说明
为MXU添加模块化代理 `src/services/proxyService.ts`
## 内容实现
- 配置的检测，持久化，热重载
- UI更新
### 接口调用：

```
import { downloadWithProxy } from '@/services/proxyService';

await downloadWithProxy(url, savePath, {
  totalSize: fileSize,
  proxyUrl: proxySettings?.url // <--
});
```
### 手动调用：
```
import { invoke } from '@tauri-apps/api/core';

await invoke('download_file', {
  url,
  savePath,
  totalSize: null,
  proxyUrl: proxySettings?.url || null  // <--
});
```
后端：
```
#[tauri::command]
pub async fn download_file(
    url: String,
    save_path: String,
    total_size: Option<u64>,
    proxy_url: Option<String>,  // ← 接收代理参数
) -> Result<u64, String> {
    let mut client_builder = reqwest::Client::builder();
    
    // 配置代理
    if let Some(proxy) = proxy_url {
        if !proxy.is_empty() {
            let reqwest_proxy = reqwest::Proxy::all(&proxy)?;
            client_builder = client_builder.proxy(reqwest_proxy);
        }
    }
    
    let client = client_builder.build()?;
    // ...
}
```



### 截图
mirror cdk为空
<img width="1002" height="768" alt="image" src="https://github.com/user-attachments/assets/db01316e-7d5c-4137-96d6-e73b7503fa7f" />
填写了mirror cdk
<img width="1002" height="768" alt="image" src="https://github.com/user-attachments/assets/8f6c26bb-e6b1-47e6-bba2-80427d59c008" />


## Summary by Sourcery

添加可配置的 HTTP/SOCKS5 代理支持，并通过统一的后端 HTTP 客户端路由与更新相关的网络请求。

新功能：
- 在后端引入全局代理配置，并通过 Tauri 命令对外暴露，用于设置代理以及执行 HTTP GET 请求。
- 在设置界面中新增代理输入字段，包括相应的 i18n 文案，以及在应用配置和 store 中持久化该配置。

改进：
- 重构更新获取逻辑，使用新的后端 HTTP GET 辅助方法，统一处理 User-Agent，并支持使用代理。
- 扩展 reqwest 配置以支持 SOCKS 代理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable HTTP/SOCKS5 proxy support and route update-related network requests through a unified backend HTTP client.

New Features:
- Introduce a global proxy configuration in the backend, exposed via Tauri commands for setting the proxy and performing HTTP GET requests.
- Add a proxy input field in the settings UI, including i18n strings and persistence in the app configuration and store.

Enhancements:
- Refactor update fetching to use the new backend HTTP GET helper, centralizing User-Agent handling and enabling proxy usage.
- Extend reqwest configuration to support SOCKS proxies.

</details>