### PR TITLE
fix: 修改WebView2数据存储位置防止权限问题并且直接使用管理员启动

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-mod maa_commands;
+pub mod maa_commands;
 mod maa_ffi;
 
 use maa_commands::MaaState;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,6 +21,49 @@ fn main() {
         if !webview2::ensure_webview2() {
             std::process::exit(1);
         }
+
+        // 启动时自动请求管理员权限：如果当前不是管理员，则自提权重启并退出当前进程
+        // 说明：用户取消 UAC 时 ShellExecuteW 会失败，此时继续以普通权限启动。
+        if !mxu_lib::maa_commands::is_elevated() {
+            use std::ffi::OsStr;
+            use std::os::windows::ffi::OsStrExt;
+            use windows::core::PCWSTR;
+            use windows::Win32::Foundation::HWND;
+            use windows::Win32::UI::Shell::ShellExecuteW;
+            use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+            let exe_path = match std::env::current_exe() {
+                Ok(p) => p,
+                Err(_) => {
+                    // 获取路径失败就按普通权限继续
+                    mxu_lib::run();
+                    return;
+                }
+            };
+
+            fn to_wide(s: &str) -> Vec<u16> {
+                OsStr::new(s).encode_wide().chain(Some(0)).collect()
+            }
+
+            let operation = to_wide("runas");
+            let file = to_wide(&exe_path.to_string_lossy());
+
+            unsafe {
+                let result = ShellExecuteW(
+                    HWND::default(),
+                    PCWSTR::from_raw(operation.as_ptr()),
+                    PCWSTR::from_raw(file.as_ptr()),
+                    PCWSTR::null(),
+                    PCWSTR::null(),
+                    SW_SHOWNORMAL,
+                );
+
+                if result.0 as usize > 32 {
+                    // 新的管理员进程已启动，退出当前普通权限进程
+                    std::process::exit(0);
+                }
+            }
+        }
     }
 
     mxu_lib::run()


### PR DESCRIPTION
怎么会有用户连自己的appdata都访问不了的，调了一堆备选也没用，没招了
我建议直接管理员启动避免一些奇奇怪怪的权限问题

## Summary by Sourcery

更新 Windows 启动行为，以避免 WebView2 数据目录的权限问题，并优先以提升权限运行应用程序。

错误修复（Bug Fixes）:
- 将 WebView2 用户数据文件夹设置为与可执行文件同级的 `webview_data` 目录，以避免使用用户特定 AppData 路径时出现的路径和权限问题。

增强功能（Enhancements）:
- 尝试在 Windows 上通过 UAC 提权以管理员权限重新启动应用程序；如果提权被拒绝或无法解析可执行文件路径，则回退为以普通权限执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Windows startup behavior to avoid WebView2 data directory permission issues and prefer running the app with elevated privileges.

Bug Fixes:
- Set the WebView2 user data folder to a webview_data directory alongside the executable to avoid path and permission problems with user-specific AppData locations.

Enhancements:
- Attempt to restart the application with administrator privileges on Windows using UAC elevation, falling back to normal execution if elevation is denied or the executable path cannot be resolved.

</details>