### PR TITLE
fix: 启动时拉起的更新不会走代理

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   resolveI18nText,
   checkAndPrepareDownload,
   maaService,
+  shouldUseProxy,
 } from '@/services';
 import {
   downloadUpdate,
@@ -274,10 +275,17 @@ function App() {
         const savePath = await getUpdateSavePath(downloadBasePath, updateResult.filename);
         setDownloadSavePath(savePath);
 
+        const appState = useAppStore.getState();
+        // 仅在 GitHub 下载时尝试使用代理（如果配置了的话）
+        const useProxy =
+          updateResult.downloadSource === 'github' &&
+          shouldUseProxy(appState.proxySettings, appState.mirrorChyanSettings.cdk || '');
+
         const success = await downloadUpdate({
           url: updateResult.downloadUrl,
           savePath,
           totalSize: updateResult.fileSize,
+          proxySettings: useProxy ? appState.proxySettings : undefined,
           onProgress: (progress: DownloadProgress) => {
             setDownloadProgress(progress);
           },


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保在启动时发起的应用更新，对托管在 GitHub 上的下载使用已配置的代理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure app updates initiated at startup use the configured proxy for GitHub-hosted downloads.

</details>