### PR TITLE
fix:强调色按钮大小不一致

### DIFF
--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -198,7 +198,7 @@ export function AppearanceSection({
                 className="flex items-center justify-center px-3 py-2 rounded-lg text-sm font-medium bg-bg-tertiary border-2 border-dashed border-border hover:bg-bg-hover text-text-muted transition-colors"
                 title={t('settings.addCustomAccent')}
               >
-                <span className="text-xl">+</span>
+                <span className="text-sm">+</span>
               </button>
             </div>
           </SortableContext>


### PR DESCRIPTION
有点难绷
before:
<img width="1002" height="636" alt="image" src="https://github.com/user-attachments/assets/3fee4c6c-f683-47f9-a111-a675da76a15f" />
after:
<img width="1002" height="636" alt="image" src="https://github.com/user-attachments/assets/945eecc5-b14c-4f49-92ed-3066d48912e1" />

## Summary by Sourcery

Bug Fixes:
- 修复外观设置面板中，自定义强调色添加按钮上的加号图标尺寸不一致的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix inconsistent size of the plus icon on the custom accent color add button in the appearance settings panel.

</details>