### PR TITLE
fix: 修复 optionValues 为空时未遵循 default_case 的问题

### DIFF
--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -719,14 +719,25 @@ export const useAppStore = create<AppState>()(
         // 恢复已保存的任务，过滤掉无效任务（taskName 在 interface 中不存在的），并清理已删除的 option
         const savedTasks: SelectedTask[] = inst.tasks
           .filter((t) => validTaskNames.has(t.taskName))
-          .map((t) => ({
-            id: t.id,
-            taskName: t.taskName,
-            customName: t.customName,
-            enabled: t.enabled,
-            optionValues: cleanOptionValues(t.optionValues),
-            expanded: false,
-          }));
+          .map((t) => {
+            const taskDef = pi?.task.find((td) => td.name === t.taskName);
+            const cleanedValues = cleanOptionValues(t.optionValues);
+            // 为缺失的 option 添加默认值（根据 default_case）
+            const defaultValues =
+              taskDef?.option && pi?.option
+                ? initializeAllOptionValues(taskDef.option, pi.option)
+                : {};
+            // 用户保存的值优先，缺失的使用默认值
+            const mergedValues = { ...defaultValues, ...cleanedValues };
+            return {
+              id: t.id,
+              taskName: t.taskName,
+              customName: t.customName,
+              enabled: t.enabled,
+              optionValues: mergedValues,
+              expanded: false,
+            };
+          });
 
         return {
           id: inst.id,

--- a/src/stores/helpers.ts
+++ b/src/stores/helpers.ts
@@ -15,7 +15,7 @@ export const createDefaultOptionValue = (optionDef: OptionDefinition): OptionVal
   }
 
   if (optionDef.type === 'switch') {
-    const defaultCase = optionDef.default_case || optionDef.cases[1]?.name || 'No';
+    const defaultCase = optionDef.default_case || optionDef.cases[0]?.name || 'Yes';
     const isYes = ['Yes', 'yes', 'Y', 'y'].includes(defaultCase);
     return { type: 'switch', value: isYes };
   }

--- a/src/utils/pipelineOverride.ts
+++ b/src/utils/pipelineOverride.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/types/interface';
 import { loggers } from './logger';
 import { findSwitchCase } from './optionHelpers';
+import { createDefaultOptionValue } from '@/stores/helpers';
 
 /**
  * 递归处理选项的 pipeline_override，收集到数组中
@@ -23,8 +24,8 @@ const collectOptionOverrides = (
   allOptions: Record<string, OptionDefinition>,
 ) => {
   const optionDef = allOptions[optionKey];
-  const optionValue = optionValues[optionKey];
-  if (!optionDef || !optionValue) return;
+  if (!optionDef) return;
+  const optionValue = optionValues[optionKey] || createDefaultOptionValue(optionDef);
 
   if ((optionValue.type === 'select' || optionValue.type === 'switch') && 'cases' in optionDef) {
     // 找到当前选中的 case
@@ -56,9 +57,10 @@ const collectOptionOverrides = (
     const inputDefs = optionDef.inputs || [];
     let overrideStr = JSON.stringify(optionDef.pipeline_override);
 
-    for (const [inputName, inputVal] of Object.entries(optionValue.values)) {
-      const inputDef = inputDefs.find((i) => i.name === inputName);
-      const pipelineType = inputDef?.pipeline_type || 'string';
+    for (const inputDef of inputDefs) {
+      const inputName = inputDef.name;
+      const inputVal = optionValue.values[inputName] ?? inputDef.default ?? '';
+      const pipelineType = inputDef.pipeline_type || 'string';
       const placeholder = `{${inputName}}`;
       const placeholderRegex = new RegExp(placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
 


### PR DESCRIPTION
## 问题描述

当配置文件中 `optionValues` 为空 `{}` 时，代码没有遵循任务定义中的 `default_case`，导致选项值不正确。

## 修复内容

fix：https://github.com/MaaEnd/MaaEnd/issues/322

1. **pipelineOverride.ts**
   - 当 `optionValue` 不存在时，使用 `createDefaultOptionValue` 创建默认值
   - input 类型遍历所有定义的字段，缺失的使用默认值

2. **helpers.ts**
   - switch 类型没有 `default_case` 时默认为"开"（使用 `cases[0]` 而非 `cases[1]`）

3. **appStore.ts**
   - `importConfig` 时为缺失的 option 添加默认值（根据 `default_case`）
   - 用户保存的值优先，缺失的使用默认值

## Summary by Sourcery

确保在已保存的配置和流水线（pipeline）覆盖中缺失的选项能正确回退到默认值。

Bug 修复：
- 修复在收集流水线覆盖时，缺失的选项值未遵循 `default_case` 的问题。
- 更正开关选项（switch option）的默认值逻辑：当未提供 `default_case` 时，使用第一个分支作为隐式默认值。
- 在导入配置时，从默认值中填充缺失的选项值，同时保留用户已保存的值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure options correctly fall back to default values when missing in saved configurations and pipeline overrides.

Bug Fixes:
- Fix missing option values not respecting default_case when collecting pipeline overrides.
- Correct switch option defaults to use the first case as the implicit default when default_case is not provided.
- Populate missing option values from defaults during config import while preserving user-saved values.

</details>