### PR TITLE
feat(controller): 添加Mac PlayCover识别支持，使用 MaaFramework 原生 PlayCover 控制器

### DIFF
--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -82,6 +82,9 @@ pub enum ControllerConfig {
     },
     PlayCover {
         address: String,
+        /// 应用 Bundle Identifier，可选，默认 "maa.playcover"
+        #[serde(default)]
+        uuid: Option<String>,
     },
 }
 

--- a/src-tauri/src/maa_ffi.rs
+++ b/src-tauri/src/maa_ffi.rs
@@ -152,6 +152,8 @@ type FnMaaGamepadControllerCreate = unsafe extern "C" fn(
     MaaGamepadType,
     MaaWin32ScreencapMethod,
 ) -> *mut MaaController;
+type FnMaaPlayCoverControllerCreate =
+    unsafe extern "C" fn(*const c_char, *const c_char) -> *mut MaaController;
 type FnMaaControllerDestroy = unsafe extern "C" fn(*mut MaaController);
 type FnMaaControllerPostConnection = unsafe extern "C" fn(*mut MaaController) -> MaaId;
 type FnMaaControllerStatus = unsafe extern "C" fn(*mut MaaController, MaaId) -> MaaStatus;
@@ -277,6 +279,8 @@ pub struct MaaLibrary {
     pub maa_adb_controller_create: FnMaaAdbControllerCreate,
     pub maa_win32_controller_create: FnMaaWin32ControllerCreate,
     pub maa_gamepad_controller_create: FnMaaGamepadControllerCreate,
+    /// PlayCover 控制器（仅 macOS，旧版 MaaFramework 可能无此符号）
+    pub maa_playcover_controller_create: Option<FnMaaPlayCoverControllerCreate>,
     pub maa_controller_destroy: FnMaaControllerDestroy,
     pub maa_controller_post_connection: FnMaaControllerPostConnection,
     pub maa_controller_status: FnMaaControllerStatus,
@@ -475,6 +479,10 @@ impl MaaLibrary {
                 maa_gamepad_controller_create: load_fn!(
                     framework_lib,
                     "MaaGamepadControllerCreate"
+                ),
+                maa_playcover_controller_create: load_fn_optional!(
+                    framework_lib,
+                    "MaaPlayCoverControllerCreate"
                 ),
                 maa_controller_destroy: load_fn!(framework_lib, "MaaControllerDestroy"),
                 maa_controller_post_connection: load_fn!(


### PR DESCRIPTION
- maa_ffi: 绑定 MaaPlayCoverControllerCreate
- types: PlayCover 配置增加可选 uuid 字段
- maa_core: macOS 使用 MaaPlayCoverControllerCreate（PlayTools）

## 由 Sourcery 提供的概要

使用原生 MaaFramework 的 PlayCover 控制器入口，在 macOS 上添加对 PlayCover 控制器的支持。

新功能：
- 通过 MaaFramework 的原生 PlayCover 控制器创建 API，在 macOS 上支持连接 PlayCover 控制器。

增强内容：
- 扩展控制器配置，增加可选的 PlayCover 应用 UUID 字段，并默认使用一个标准标识符。
- 以可选符号的方式从 MaaFramework 加载 `MaaPlayCoverControllerCreate`，以保持与旧版本框架的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add macOS PlayCover controller support using the native MaaFramework PlayCover controller entrypoint.

New Features:
- Support connecting to PlayCover controllers on macOS via MaaFramework's native PlayCover controller creation API.

Enhancements:
- Extend controller configuration with an optional PlayCover application UUID field defaulting to a standard identifier.
- Load MaaPlayCoverControllerCreate from MaaFramework as an optional symbol to maintain compatibility with older framework versions.

</details>