### PR TITLE
docs: fix markdown warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
 ```
 
+<!-- markdownlint-disable MD036 -->
 **项目依赖**
+<!-- markdownlint-enable MD036 -->
 
 ```bash
 pnpm install
@@ -125,7 +127,8 @@ pnpm tauri build
 
 ## ☕ 赞助
 
-<!-- markdownlint-disable MD045 -->
+<!-- markdownlint-disable MD033 MD045 -->
 <a href="https://afdian.com/a/misteo">
   <img width="200" src="https://pic1.afdiancdn.com/static/img/welcome/button-sponsorme.png">
 </a>
+<!-- markdownlint-enable MD033 MD045 -->


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 更新 README，在特定标题和 HTML 区块外包裹 markdownlint 的 disable/enable 注释，以消除 MD033、MD036 和 MD045 警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update README to wrap specific headings and HTML blocks with markdownlint disable/enable comments to silence MD033, MD036, and MD045 warnings.

</details>