### PR TITLE
fix: 增加窗口标题最大宽度以完整显示标题

### DIFF
--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -135,7 +135,7 @@ export function TitleBar() {
           )}
         </div>
         <span
-          className="text-xs text-text-secondary px-2 truncate max-w-[200px]"
+          className="text-xs text-text-secondary px-2 truncate max-w-lg"
           data-tauri-drag-region
         >
           {getWindowTitle()}


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 放宽标题栏文本的最大宽度限制，以减少窗口标题被截断的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Relax the max width constraint on the title bar text so window titles are less likely to be truncated.

</details>