### PR TITLE
fix: 下载整体请求超时时间从半分钟改为十分钟

### DIFF
--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -54,6 +54,7 @@ pub async fn download_file(
     // 构建 HTTP 客户端和请求
     let mut client_builder = reqwest::Client::builder()
         .user_agent(build_user_agent())
+        .timeout(std::time::Duration::from_secs(600)) // 10 分钟超时，足够下载大文件但防止无限挂起
         .connect_timeout(std::time::Duration::from_secs(10));
 
     // 配置代理（如果提供）


### PR DESCRIPTION
fix https://github.com/MaaEnd/MaaEnd/issues/557

## Summary by Sourcery

Bug Fixes:
- 通过不再强制执行 30 秒的整体 HTTP 请求超时（同时保留连接超时），避免下载过早失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid premature download failures by no longer enforcing a 30-second overall HTTP request timeout while retaining the connection timeout.

</details>