### PR TITLE
feat: select option with icon

### DIFF
--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -65,7 +65,7 @@ function OptionLabel({
 }) {
   return (
     <div className="flex items-center gap-1.5 min-w-[80px]">
-      <AsyncIcon icon={icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />
+      {icon && <AsyncIcon icon={icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />}
       <span className="text-sm text-text-secondary">{label}</span>
     </div>
   );
@@ -198,11 +198,13 @@ function InputField({
     <div className="space-y-1">
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-1.5 min-w-[80px]">
-          <AsyncIcon
-            icon={input.icon}
-            basePath={basePath}
-            className="w-4 h-4 object-contain flex-shrink-0"
-          />
+          {input.icon && (
+            <AsyncIcon
+              icon={input.icon}
+              basePath={basePath}
+              className="w-4 h-4 object-contain flex-shrink-0"
+            />
+          )}
           <span className="text-sm text-text-tertiary">{inputLabel}</span>
           {inputDescription && (
             <Tooltip content={inputDescription} side="top" align="start" maxWidth="max-w-[200px]">
@@ -585,7 +587,7 @@ function OptionSelectDropdown({
         aria-controls={listboxId}
       >
         <span className="flex items-center gap-1.5 truncate">
-          <AsyncIcon icon={selectedOption?.icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />
+          {selectedOption?.icon && <AsyncIcon icon={selectedOption.icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />}
           {selectedOption?.label}
         </span>
         <ChevronDown
@@ -628,7 +630,7 @@ function OptionSelectDropdown({
                 aria-selected={isSelected}
               >
                 <span className="flex items-center gap-1.5 truncate">
-                  <AsyncIcon icon={opt.icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />
+                  {opt.icon && <AsyncIcon icon={opt.icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />}
                   {opt.label}
                 </span>
                 {isSelected && <Check className="w-4 h-4 flex-shrink-0" />}
@@ -789,7 +791,7 @@ function OptionSelectComboBox({
         aria-controls={listboxId}
       >
         <span className="flex items-center gap-1.5 truncate">
-          <AsyncIcon icon={selectedOption?.icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />
+          {selectedOption?.icon && <AsyncIcon icon={selectedOption.icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />}
           {selectedOption?.label}
         </span>
         <ChevronDown
@@ -857,7 +859,7 @@ function OptionSelectComboBox({
                     aria-selected={isSelected}
                   >
                     <span className="flex items-center gap-1.5 truncate">
-                      <AsyncIcon icon={opt.icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />
+                      {opt.icon && <AsyncIcon icon={opt.icon} basePath={basePath} className="w-4 h-4 object-contain flex-shrink-0" />}
                       {opt.label}
                     </span>
                     {isSelected && <Check className="w-4 h-4 flex-shrink-0" />}


### PR DESCRIPTION
#74

疯狂地vibe（

## 由 Sourcery 提供的概要

为选项选择组件添加图标支持，并向下传递基础资源路径，以便在选项标签旁渲染图标。

新功能：
- 允许编辑器中的选项包含可选图标，这些图标会显示在下拉选择和组合框选择中。

增强：
- 通过选项选择组件传递 `basePath` 属性，以支持通过 `AsyncIcon` 加载图标，并将其显示在触发器和列表中的选项标签旁。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add icon support to option selection components and propagate base asset path for rendering icons alongside option labels.

New Features:
- Allow options in the editor to include optional icons that are displayed in both dropdown and combobox selects.

Enhancements:
- Pass a basePath prop through option selection components to support loading icons via AsyncIcon and display them next to option labels in triggers and lists.

</details>