### PR TITLE
feat: 新增游戏路径设置，未找到游戏窗口时自动打开游戏并延时重试

### DIFF
--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -9,6 +9,7 @@ import {
   Power,
   Play,
   Rocket,
+  Gamepad2,
   ChevronDown,
   Check,
 } from 'lucide-react';
@@ -16,7 +17,7 @@ import {
 import { useAppStore } from '@/stores/appStore';
 import { defaultWindowSize } from '@/types/config';
 import { isTauri } from '@/utils/paths';
-import { SwitchButton } from '@/components/FormControls';
+import { FileField, SwitchButton } from '@/components/FormControls';
 import { FrameRateSelector } from '../FrameRateSelector';
 
 export function GeneralSection() {
@@ -36,6 +37,8 @@ export function GeneralSection() {
     autoRunOnLaunch,
     setAutoRunOnLaunch,
     autoStartRemovedInstanceName,
+    gamePath,
+    setGamePath,
   } = useAppStore();
 
   // 开机自启动状态（直接从 Tauri 插件查询，不走 store）
@@ -232,6 +235,27 @@ export function GeneralSection() {
             disabled={!autoStartInstanceId}
           />
         </div>
+      </div>
+
+      {/* 游戏路径（用于未找到窗口时自动拉起游戏） */}
+      <div className="bg-bg-secondary rounded-xl p-4 border border-border">
+        <div className="flex items-center gap-3 mb-3">
+          <Gamepad2 className="w-5 h-5 text-accent" />
+          <div>
+            <span className="font-medium text-text-primary">{t('settings.gamePath')}</span>
+            <p className="text-xs text-text-muted mt-0.5">{t('settings.gamePathHint')}</p>
+          </div>
+        </div>
+        <FileField
+          label={t('settings.gamePath')}
+          value={gamePath}
+          onChange={(value) => setGamePath(value.trim())}
+          placeholder={t('settings.gamePathPlaceholder')}
+          filters={[
+            { name: 'Executable', extensions: ['exe', 'bat', 'cmd', 'ps1', 'sh'] },
+            { name: 'All Files', extensions: ['*'] },
+          ]}
+        />
       </div>
 
       {/* ④ 最小化到托盘 */}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -97,6 +97,10 @@ export default {
     autoRunOnLaunch: 'Also auto-execute on manual launch',
     autoRunOnLaunchHint:
       'Automatically execute the selected configuration when manually opening the app (if disabled, only triggers on system startup)',
+    gamePath: 'Game Path',
+    gamePathHint:
+      'If no game window is found when starting tasks, launch this path and retry after 60 seconds',
+    gamePathPlaceholder: 'Select game executable path (e.g. xxx.exe)',
     confirmBeforeDelete: 'Confirm delete actions',
     confirmBeforeDeleteHint: 'Show confirmation before delete/clear list/import overwrite, etc.',
     maxLogsPerInstance: 'Max logs per instance',
@@ -286,6 +290,11 @@ export default {
     preActionFailed: 'Pre-program failed: {{error}}',
     preActionExitCode: 'Pre-program exit code: {{code}}',
     preActionConnectDelay: 'Waiting {{seconds}} seconds before connecting...',
+    gamePathNotSet: 'Game path is not set, cannot auto launch and retry',
+    autoLaunchGameStarting: 'Game window not found, launching game: {{path}}',
+    autoLaunchGameWaiting: 'Game launched, waiting {{seconds}} seconds before retry...',
+    autoLaunchGameRetrying: 'Retrying to find game window {{name}}',
+    autoLaunchGameFailed: 'Failed to auto launch game: {{error}}',
   },
 
   // Option Editor

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -96,6 +96,9 @@ export default {
     autoRunOnLaunch: '手动启动时也自动执行',
     autoRunOnLaunchHint:
       '每次手动打开程序时，也自动执行上方选定的配置（关闭则仅在开机自启动时触发）',
+    gamePath: '游戏路径',
+    gamePathHint: '开始任务时若未找到游戏窗口，将启动此路径并等待 60 秒后重试',
+    gamePathPlaceholder: '选择游戏可执行文件路径（如 xxx.exe）',
     confirmBeforeDelete: '删除操作需要二次确认',
     confirmBeforeDeleteHint: '删除任务、清空列表、导入覆盖等操作会先弹出确认对话框',
     maxLogsPerInstance: '每个实例保留的日志上限',
@@ -280,6 +283,11 @@ export default {
     preActionFailed: '前置程序执行失败: {{error}}',
     preActionExitCode: '前置程序退出码: {{code}}',
     preActionConnectDelay: '等待 {{seconds}} 秒后连接...',
+    gamePathNotSet: '未设置游戏路径，无法自动拉起游戏重试',
+    autoLaunchGameStarting: '未找到游戏窗口，正在启动游戏：{{path}}',
+    autoLaunchGameWaiting: '游戏已启动，等待 {{seconds}} 秒后重试...',
+    autoLaunchGameRetrying: '正在重试查找游戏窗口{{name}}',
+    autoLaunchGameFailed: '自动启动游戏失败：{{error}}',
   },
 
   // 选项编辑器

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -971,6 +971,7 @@ export const useAppStore = create<AppState>()(
         autoRunOnLaunch: config.settings.autoRunOnLaunch ?? false,
         autoStartRemovedInstanceName: config.settings.autoStartRemovedInstanceName,
         minimizeToTray: config.settings.minimizeToTray ?? false,
+        gamePath: config.settings.gamePath ?? '',
         onboardingCompleted: config.settings.onboardingCompleted ?? false,
         preActionConnectDelaySec: config.settings.preActionConnectDelaySec ?? 5,
         hotkeys: config.settings.hotkeys ?? {
@@ -1280,6 +1281,10 @@ export const useAppStore = create<AppState>()(
         loggers.app.error('设置托盘选项失败:', err);
       }
     },
+
+    // 游戏路径设置（窗口未找到时自动启动游戏）
+    gamePath: '',
+    setGamePath: (path) => set({ gamePath: path }),
 
     // 新用户引导
     onboardingCompleted: false,
@@ -1662,6 +1667,7 @@ function generateConfig(): MxuConfig {
       autoRunOnLaunch: state.autoRunOnLaunch,
       autoStartRemovedInstanceName: state.autoStartRemovedInstanceName,
       minimizeToTray: state.minimizeToTray,
+      gamePath: state.gamePath,
       onboardingCompleted: state.onboardingCompleted,
       preActionConnectDelaySec: state.preActionConnectDelaySec,
       hotkeys: state.hotkeys,
@@ -1721,6 +1727,7 @@ useAppStore.subscribe(
     autoRunOnLaunch: state.autoRunOnLaunch,
     autoStartRemovedInstanceName: state.autoStartRemovedInstanceName,
     minimizeToTray: state.minimizeToTray,
+    gamePath: state.gamePath,
     onboardingCompleted: state.onboardingCompleted,
     hotkeys: state.hotkeys,
     recentlyClosed: state.recentlyClosed,

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -321,6 +321,8 @@ export interface AppState {
   // 托盘设置
   minimizeToTray: boolean;
   setMinimizeToTray: (enabled: boolean) => void;
+  gamePath: string;
+  setGamePath: (path: string) => void;
 
   // 启动后自动执行的实例 ID
   autoStartInstanceId: string | undefined;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -134,6 +134,8 @@ export interface AppSettings {
   autoStartRemovedInstanceName?: string; // 被删除的自动执行配置名称（用于提示用户）
   /** 前置动作轮询设备就绪后、连接前的额外延迟秒数（默认 5，仅通过编辑 mxu.json 修改） */
   preActionConnectDelaySec?: number;
+  /** 游戏可执行文件路径（用于未找到窗口时自动拉起游戏） */
+  gamePath?: string;
 }
 
 // MXU 配置文件完整结构


### PR DESCRIPTION
在设置中添加了游戏路径的选项, 从而可以自动打开游戏并开始任务
例如 C:\Program Files\Hypergryph Launcher\games\EndField Game\Endfield.exe

## Summary by Sourcery

添加可配置的游戏可执行文件路径，并使用该路径在未找到游戏窗口时自动启动游戏并重试连接。

新功能：
- 在常规设置中添加游戏路径设置，允许用户选择游戏可执行文件。
- 当无法找到目标游戏窗口时，自动启动已配置的游戏，并在延迟后重试任务启动。

改进：
- 在全局应用存储和配置文件中持久化新的游戏路径设置，并为英文和中文界面文本提供国际化（i18n）支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable game executable path and use it to auto-launch the game and retry connecting when no game window is found.

New Features:
- Introduce a game path setting in the general settings that lets users select the game executable.
- Automatically launch the configured game and retry task start after a delay when the target game window cannot be found.

Enhancements:
- Persist the new game path setting in the global app store and configuration file, including i18n support for English and Chinese UI texts.

</details>