### PR TITLE
fix:修复快捷键的小问题

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -918,12 +918,13 @@ function App() {
     // Ctrl -> CommandOrControl
     const toTauriKey = (k: string) => k.replace(/^Ctrl\+/i, 'CommandOrControl+');
 
+    const GLOBAL_HOTKEY_THROTTLE_MS = 1000;
     let lastStartTime = 0;
     const registerKeys = async () => {
       try {
         await register(toTauriKey(startKey), () => {
           const now = Date.now();
-          if (now - lastStartTime < 1000) return;
+          if (now - lastStartTime < GLOBAL_HOTKEY_THROTTLE_MS) return;
           lastStartTime = now;
           document.dispatchEvent(
             new CustomEvent('mxu-start-tasks', {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1083,11 +1083,12 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
     }
   };
 
+  const hotkeyStartingRef = useRef(false);
+
   // 监听来自 App 的全局快捷键事件：F10 开始任务，F11 结束任务
   useEffect(() => {
-    let starting = false;
     const handleStartTasks = async (evt: Event) => {
-      if (starting) return;
+      if (hotkeyStartingRef.current) return;
       const currentInstance = useAppStore.getState().getActiveInstance();
       if (!currentInstance) return;
 
@@ -1112,7 +1113,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
       }
 
       // 直接使用从 store 获取的最新 instance，避免闭包捕获旧的 selectedTasks
-      starting = true;
+      hotkeyStartingRef.current = true;
       try {
         const success = await startTasksForInstance(currentInstance, {
           onPhaseChange: setAutoConnectPhase,
@@ -1124,7 +1125,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
             : t('logs.messages.hotkeyStartFailed'),
         });
       } finally {
-        starting = false;
+        hotkeyStartingRef.current = false;
       }
     };
 


### PR DESCRIPTION
<img width="361" height="379" alt="image" src="https://github.com/user-attachments/assets/52551b4b-9117-4502-9627-33dc6ca0401d" />
之前第一次启动没解析

改了任务，快捷键执行的还是之前的
fixed MaaEnd/MaaEnd/issues/513

按下启动，如果按下时间稍长，可能启动多次任务
fixed MaaEnd/MaaEnd/issues/620

## Summary by Sourcery

改进用于快捷键的任务启动行为，并修正资源显示名称。

Bug Fixes:
- 修复工具栏资源显示名称，以在可用时遵循本地化标签。
- 防止全局和应用内启动快捷键在短时间内触发多次任务启动。
- 确保由快捷键触发的任务启动始终使用最新的实例/任务状态，而不是过期的闭包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve task start behavior for hotkeys and correct resource display naming.

Bug Fixes:
- Fix toolbar resource display name to respect localized labels when available.
- Prevent global and in-app start hotkeys from triggering multiple rapid task starts.
- Ensure hotkey-triggered task starts always use the latest instance/task state instead of stale closures.

</details>