### PR TITLE
fix: 手动检查更新后自动开始下载

### DIFF
--- a/src/components/settings/UpdateSection.tsx
+++ b/src/components/settings/UpdateSection.tsx
@@ -327,6 +327,7 @@ export function UpdateSection() {
             addDebugLog(
               `下载来源: ${result.downloadSource === 'github' ? 'GitHub' : 'Mirror酱 CDN'}`,
             );
+            startDownload(result);
           } else {
             addDebugLog('无可用下载链接');
           }


### PR DESCRIPTION
## 问题

在设置页面手动点击「检查更新」后，发现新版本且有下载链接，但不会自动开始下载，UI 一直显示「准备下载」转圈。

## 原因

`UpdateSection.tsx` 的 `handleCheckUpdate` 检查到更新后只调用了 `setShowUpdateDialog(true)` 打开对话框，没有调用 `startDownload` 启动下载。`downloadStatus` 一直是 `idle`，触发了「准备下载」的 spinner 状态。

而 `App.tsx` 中自动更新检查的逻辑在发现更新后会调用 `startAutoDownload(updateResult)` 自动开始下载。

## 修复

在 `handleCheckUpdate` 中，检查到有下载链接时调用 `startDownload(result)` 开始下载，与自动更新行为保持一致。

Closes https://github.com/MistEO/MXU/issues/8

## Summary by Sourcery

Bug Fixes:
- 在手动检查发现存在可用版本且具有有效下载链接后，自动开始更新下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Start the update download automatically after a manual check finds an available version with a valid download link.

</details>