### PR TITLE
feat: number input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# maafw
+interface.json

--- a/src/components/FormControls.tsx
+++ b/src/components/FormControls.tsx
@@ -71,6 +71,10 @@ interface TextInputProps {
   disabled?: boolean;
   hasError?: boolean;
   className?: string;
+  type?: 'text' | 'number';
+  inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
+  step?: number;
+  integerOnly?: boolean;
 }
 
 export function TextInput({
@@ -80,14 +84,34 @@ export function TextInput({
   disabled,
   hasError,
   className,
+  type = 'text',
+  inputMode,
+  step,
+  integerOnly,
 }: TextInputProps) {
   return (
     <input
-      type="text"
+      type={type}
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e) => {
+        if (!integerOnly) {
+          onChange(e.target.value);
+          return;
+        }
+        const raw = e.target.value;
+        if (raw === '' || raw === '-') {
+          onChange(raw);
+          return;
+        }
+        const cleaned = raw.replace(/[^\d-]/g, '');
+        const hasLeadingMinus = cleaned.startsWith('-');
+        const normalized = `${hasLeadingMinus ? '-' : ''}${cleaned.replace(/-/g, '')}`;
+        onChange(normalized);
+      }}
       placeholder={placeholder}
       disabled={disabled}
+      inputMode={inputMode}
+      step={step}
       className={clsx(
         'px-3 py-1.5 text-sm rounded-md border',
         'bg-bg-secondary text-text-primary',

--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -263,6 +263,10 @@ function InputField({
             disabled={disabled}
             hasError={!!validationError}
             className="flex-1"
+            type={input.pipeline_type === 'int' ? 'number' : 'text'}
+            inputMode={input.pipeline_type === 'int' ? 'numeric' : undefined}
+            step={input.pipeline_type === 'int' ? 1 : undefined}
+            integerOnly={input.pipeline_type === 'int'}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary by Sourcery

为共享的 TextInput 组件添加仅限整数验证的数值输入支持，并将其接入用于整数类型流水线字段的选项编辑器。

New Features:
- 允许将 TextInput 配置为带有 `inputMode` 和 `step` 属性的数字字段。
- 在 TextInput 中引入仅限整数的输入处理逻辑，用于规范化并限制用户输入为有效的整数值。
- 在选项编辑器 UI 中，对整数类型的流水线选项使用数值型 TextInput 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for numeric inputs with integer-only validation to the shared TextInput component and wire it into the option editor for integer pipeline fields.

New Features:
- Allow TextInput to be configured as a number field with inputMode and step attributes.
- Introduce integer-only input handling that normalizes and restricts user input to valid integer values in TextInput.
- Use the numeric TextInput configuration for integer-typed pipeline options in the option editor UI.

</details>