### PR TITLE
fix: 开机自启动 UAC 弹窗导致无法启动

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -302,8 +302,9 @@ pub fn is_autostart() -> bool {
 #[cfg(windows)]
 pub fn migrate_legacy_autostart() {
     if has_legacy_registry_autostart() {
-        let _ = create_schtask_autostart();
-        remove_legacy_registry_autostart();
+        if create_schtask_autostart().is_ok() {
+            remove_legacy_registry_autostart();
+        }
     }
 }
 
@@ -430,6 +431,12 @@ pub fn autostart_is_enabled() -> bool {
 #[tauri::command]
 pub fn get_arch() -> String {
     std::env::consts::ARCH.to_string()
+}
+
+/// 获取操作系统类型
+#[tauri::command]
+pub fn get_os() -> String {
+    std::env::consts::OS.to_string()
 }
 
 /// 获取系统信息

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -183,6 +183,7 @@ pub fn run() {
             commands::system::autostart_disable,
             commands::system::autostart_is_enabled,
             commands::system::get_arch,
+            commands::system::get_os,
             commands::system::get_system_info,
             // 托盘相关命令
             commands::tray::set_minimize_to_tray,


### PR DESCRIPTION
## 问题

开机自启动时，由于应用需要管理员权限（main.rs 中 runas 提权），注册表方式的自启动会触发 UAC 弹窗，导致无法正常自启动。

Closes https://github.com/MaaEnd/MaaEnd/issues/638

## 解决方案

Windows 平台使用任务计划程序（`schtasks`，`/rl highest`）代替 `tauri-plugin-autostart` 的注册表方式，任务计划程序以最高权限运行时不会弹 UAC。

## 改动

- **system.rs**：新增 `autostart_enable`/`autostart_disable`/`autostart_is_enabled` 命令，通过 `schtasks` 管理自启动；新增 `migrate_legacy_autostart` 自动迁移旧版注册表条目
- **lib.rs**：注册新命令，启动时调用迁移逻辑
- **GeneralSection.tsx**：Windows 平台使用新命令，其他平台保留原插件

## 兼容性

- 旧版用户更新后，首次启动自动将注册表条目迁移到任务计划程序
- 禁用/查询时同时检查任务计划程序和旧版注册表
- macOS/Linux 不受影响，仍使用 tauri-plugin-autostart

## Summary by Sourcery

替换 Windows 自启动实现以避免在启动时出现 UAC 提示，并将现有用户迁移到新的机制。

New Features:
- 暴露新的 Tauri 命令，以通过 Windows 任务计划程序启用、禁用和查询自启动。

Bug Fixes:
- 修复使用基于注册表的启动项时，由于 UAC 提示导致 Windows 自启动在开机时失败的问题。

Enhancements:
- 在 Windows 上自动将旧的基于注册表的自启动项迁移到任务计划程序，同时在 macOS/Linux 上继续使用现有的基于插件的自启动方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace Windows autostart implementation to avoid UAC prompts at startup and migrate existing users to the new mechanism.

New Features:
- Expose new Tauri commands to enable, disable, and query autostart via Windows Task Scheduler.

Bug Fixes:
- Fix Windows autostart failing at boot due to UAC prompts when using registry-based startup entries.

Enhancements:
- Automatically migrate legacy registry-based autostart entries to Task Scheduler on Windows and keep macOS/Linux on the existing plugin-based autostart path.

</details>