### PR TITLE
ci(git-cliff): 跳过包含 [skip changelog] 的 commit

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -71,6 +71,9 @@ split_commits = false
 # 保留完整的 commit body
 protect_breaking_commits = false
 commit_parsers = [
+    # 跳过包含 [skip changelog] 的 commit
+    { message = ".*\\[skip changelog\\].*", skip = true },
+    { body = ".*\\[skip changelog\\].*", skip = true },
     { message = "^feat", group = "<!-- 0 -->✨ 新功能" },
     { message = "^fix", group = "<!-- 1 -->🐛 Bug修复" },
     { message = "^docs", group = "<!-- 4 -->📚 文档" },


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 更新 git-cliff 配置，以跳过提交消息或正文中包含 `[skip changelog]` 的提交。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update git-cliff configuration to skip commits whose message or body contains [skip changelog].

</details>