### PR TITLE
fix:自启动可能导致的白屏以及倒计时任务无法停止

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -564,6 +564,8 @@ fn create_schtask_autostart() -> Result<(), String> {
             &format!("\"{}\" --autostart", exe),
             "/sc",
             "onlogon",
+            // 强制交互式运行，确保进程绑定到用户桌面会话，避免登录早期会话未就绪导致 WebView 白屏
+            "/it",
             "/rl",
             "highest",
             "/f",


### PR DESCRIPTION
自启动这个只是试着修了，我这复现不出来
fixed MaaEnd/MaaEnd/issues/737

fixed MaaEnd/MaaEnd/issues/789

## Summary by Sourcery

使与 MXU 睡眠相关的自定义操作能够响应任务停止请求，并调整 Windows 自启动任务配置，以减少登录时出现白屏的问题。

Bug 修复：
- 允许在任务器（tasker）停止时中断 `MXU_SLEEP` 自定义操作的等待，防止出现无法中断的倒计时。
- 允许在任务器停止时中断 `MXU_WAITUNTIL` 自定义操作的等待，防止出现无法中断的计划等待。
- 以交互模式运行 Windows 自启动计划任务，从而更好地将进程绑定到用户桌面，并缓解登录时 WebView 白屏的问题。

增强：
- 引入一个共享的辅助工具，用于在 MXU 自定义操作中执行对停止状态感知的等待，并定期检查任务器状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make MXU sleep-related custom actions responsive to task stop requests and adjust Windows autostart task configuration to reduce login-time white screen issues.

Bug Fixes:
- Allow MXU_SLEEP custom action waits to be interrupted when the tasker is stopping, preventing uninterruptible countdowns.
- Allow MXU_WAITUNTIL custom action waits to be interrupted when the tasker is stopping, preventing uninterruptible scheduled waits.
- Run the Windows autostart scheduled task in interactive mode to better bind the process to the user desktop and mitigate WebView white screen on login.

Enhancements:
- Introduce a shared helper to perform stop-aware waiting with periodic checks of the tasker state for MXU custom actions.

</details>