### PR TITLE
fix: escape regex special chars in input placeholder replacement

### DIFF
--- a/src/utils/pipelineOverride.ts
+++ b/src/utils/pipelineOverride.ts
@@ -63,16 +63,17 @@ const collectOptionOverrides = (
       const inputVal = optionValue.values[inputName] ?? inputDef.default ?? '';
       const pipelineType = inputDef.pipeline_type || 'string';
       const placeholder = `{${inputName}}`;
-      const placeholderRegex = new RegExp(placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+      const escapedPlaceholder = placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const placeholderRegex = new RegExp(escapedPlaceholder, 'g');
 
       if (pipelineType === 'int') {
-        overrideStr = overrideStr.replace(new RegExp(`"${placeholder}"`, 'g'), inputVal || '0');
+        overrideStr = overrideStr.replace(new RegExp(`"${escapedPlaceholder}"`, 'g'), inputVal || '0');
         overrideStr = overrideStr.replace(placeholderRegex, inputVal || '0');
       } else if (pipelineType === 'bool') {
         const boolVal = ['true', '1', 'yes', 'y'].includes((inputVal || '').toLowerCase())
           ? 'true'
           : 'false';
-        overrideStr = overrideStr.replace(new RegExp(`"${placeholder}"`, 'g'), boolVal);
+        overrideStr = overrideStr.replace(new RegExp(`"${escapedPlaceholder}"`, 'g'), boolVal);
         overrideStr = overrideStr.replace(placeholderRegex, boolVal);
       } else {
         overrideStr = overrideStr.replace(placeholderRegex, inputVal || '');


### PR DESCRIPTION
## 问题

interface 中使用 `input` 选项调整 `post_delay` 时任务会无限卡住（#86）。

## 原因

`pipelineOverride.ts` 中，对 `int`/`bool` 类型的 placeholder 做带引号替换时（去掉 JSON 引号使其成为数字/布尔值），直接将 placeholder 传入 `new RegExp()` 而未转义。

当 input name 包含正则特殊字符（如 `远征检查等待时间(ms)` 中的括号）时，`(ms)` 被解释为捕获组而非字面量，导致匹配失败。结果只有不去引号的兜底替换生效，`post_delay` 变成了字符串 `"5000"` 而非数字 `5000`，MaaFramework 无法正确处理，任务无限挂起。

## 修复

将 placeholder 的正则转义提取为 `escapedPlaceholder` 变量，在所有 `new RegExp()` 调用中统一使用转义后的版本。

Closes #86

## Summary by Sourcery

Bug Fixes:
- 通过在所有正则表达式构造中一致地使用已转义的占位符，修复了当输入名称包含正则表达式特殊字符时，流水线占位符替换不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect pipeline placeholder replacement when input names contain regex special characters by consistently using an escaped placeholder in all regex constructions.

</details>