### PR TITLE
feat: 下载完成后自动安装更新

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,21 +199,18 @@ function App() {
 
   const initialized = useRef(false);
   const downloadStartedRef = useRef(false);
-  const autoInstallTriggeredRef = useRef(false);
-
   // 尝试自动安装更新（非自启动模式 且 无任务运行中）
   const tryAutoInstallUpdate = useCallback(() => {
-    if (autoInstallTriggeredRef.current) return;
     const state = useAppStore.getState();
     if (state.isAutoStartMode) return;
     if (state.downloadStatus !== 'completed') return;
     if (state.installStatus !== 'idle') return;
+    if (state.autoInstallPending) return;
     if (state.instances.some((i) => i.isRunning)) return;
 
-    autoInstallTriggeredRef.current = true;
-    log.info('自动安装更新：条件满足，开始安装');
+    log.info('自动安装更新：条件满足，弹出安装');
+    state.setAutoInstallPending(true);
     state.setShowInstallConfirmModal(true);
-    state.setInstallStatus('installing');
   }, []);
 
   // 监听任务结束 或 下载完成 后自动安装更新

--- a/src/components/InstallConfirmModal.tsx
+++ b/src/components/InstallConfirmModal.tsx
@@ -41,6 +41,8 @@ export function InstallConfirmModal() {
     setInstallError,
     setJustUpdatedInfo,
     resetInstallState,
+    autoInstallPending,
+    setAutoInstallPending,
   } = useAppStore();
 
   const currentVersion = projectInterface?.version || '';
@@ -204,6 +206,14 @@ export function InstallConfirmModal() {
     setInstallError,
     t,
   ]);
+
+  // 自动安装：由 tryAutoInstallUpdate 触发，通过 autoInstallPending 标记
+  useEffect(() => {
+    if (showInstallConfirmModal && autoInstallPending && installStatus === 'idle') {
+      setAutoInstallPending(false);
+      handleInstall();
+    }
+  }, [showInstallConfirmModal, autoInstallPending, installStatus, setAutoInstallPending, handleInstall]);
 
   // 判断当前是否为可执行安装程序（exe/dmg）
   const isExeInstaller = downloadSavePath && isExecutableInstaller(downloadSavePath);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1400,10 +1400,13 @@ export const useAppStore = create<AppState>()(
     setInstallStatus: (status) => set({ installStatus: status }),
     setInstallError: (error) => set({ installError: error }),
     setJustUpdatedInfo: (info) => set({ justUpdatedInfo: info }),
+    autoInstallPending: false,
+    setAutoInstallPending: (pending) => set({ autoInstallPending: pending }),
     resetInstallState: () =>
       set({
         installStatus: 'idle',
         installError: null,
+        autoInstallPending: false,
       }),
 
     // 最近关闭的实例

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -376,10 +376,13 @@ export interface AppState {
   installStatus: InstallStatus;
   installError: string | null;
   justUpdatedInfo: JustUpdatedInfo | null;
+  /** 自动安装待执行标记（由 tryAutoInstallUpdate 设置，InstallConfirmModal 消费） */
+  autoInstallPending: boolean;
   setShowInstallConfirmModal: (show: boolean) => void;
   setInstallStatus: (status: InstallStatus) => void;
   setInstallError: (error: string | null) => void;
   setJustUpdatedInfo: (info: JustUpdatedInfo | null) => void;
+  setAutoInstallPending: (pending: boolean) => void;
   resetInstallState: () => void;
 
   // 最近关闭的实例


### PR DESCRIPTION
当更新下载完成时，自动触发安装，无需用户手动点击。

## 自动安装条件

- 非开机自启动模式（避免无人值守时弹出 UAC）
- 当前没有任务在运行中

## 实现逻辑

- 新增 `isAutoStartMode` 状态，在检测到开机自启动时标记
- 新增 `tryAutoInstallUpdate()` 函数，检查条件后触发安装
- 通过 `useAppStore.subscribe` 监听两个触发时机：
  1. 下载状态变为 `completed` 时立即尝试
  2. 所有实例任务从运行变为停止时再次尝试（覆盖下载完成时有任务在跑的场景）

## Summary by Sourcery

在安全的情况下，当下载完成后自动触发更新安装。

新功能：
- 在非自动启动模式且没有实例运行时，当下载完成后添加自动执行更新安装的功能。

改进：
- 在全局存储中记录应用是否处于自动启动模式，并在启动时初始化该状态。
- 订阅应用状态变化，使在转变为下载完成或所有实例停止时，会重新检查并触发符合条件的自动安装。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically trigger update installation after downloads complete when safe to do so.

New Features:
- Add automatic update installation that runs after a download completes when not in auto-start mode and no instances are running.

Enhancements:
- Track whether the app is running in auto-start mode in the global store and initialize this state on startup.
- Subscribe to app state changes so that transitions to download completion or all instances stopping will re-check and trigger eligible auto installations.

</details>