### PR TITLE
run_action 支持含空格的参数

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -447,11 +447,12 @@ pub async fn run_action(
         program, args, wait_for_exit
     );
 
-    // 解析参数字符串为参数数组（简单按空格分割，不处理引号）
-    let args_vec: Vec<&str> = if args.trim().is_empty() {
+    // 使用 shell 语义解析参数至数组（支持引号）
+    let args_vec: Vec<String> = if args.trim().is_empty() {
         vec![]
     } else {
-        args.split_whitespace().collect()
+        shell_words::split(&args)
+            .map_err(|e| format!("Failed to parse args: {}", e))?
     };
 
     let mut cmd = Command::new(&program);


### PR DESCRIPTION
Cargo.toml 中已经引入了shell-words = "1.1.1"，因此采用 shell_words 解析参数，从而支持带有空格的参数

## Summary by Sourcery

增强内容：
- 在 `run_action` 中，将原本基于空白字符的朴素参数拆分方式替换为使用 `shell_words` 解析，以支持带引号和包含空格的参数，并在解析失败时返回具有描述性的错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace naive whitespace-based argument splitting in run_action with shell_words parsing to support quoted and space-containing arguments, returning a descriptive error on parse failure.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强内容：
- 在 `run_action` 中，将原本基于空白字符的朴素参数拆分方式替换为使用 `shell_words` 解析，以支持带引号和包含空格的参数，并在解析失败时返回具有描述性的错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace naive whitespace-based argument splitting in run_action with shell_words parsing to support quoted and space-containing arguments, returning a descriptive error on parse failure.

</details>

</details>