### PR TITLE
feat: 添加Controller实例引用

### DIFF
--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -3,6 +3,7 @@
 //! 提供 MaaFramework 初始化、版本检查、设备搜索、控制器、资源和任务管理
 
 use log::{debug, error, info, warn};
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -22,6 +23,49 @@ use super::utils::{emit_callback_event, get_maafw_dir, normalize_path};
 
 /// MaaFramework 最小支持版本
 const MIN_MAAFW_VERSION: &str = "5.5.0-beta.1";
+
+/// ControllerPool 复用时的合成 conn_id（负数，避免与 MaaFramework 正数 ID 冲突）
+static SYNTHETIC_CONN_ID: AtomicI64 = AtomicI64::new(-1);
+
+fn next_synthetic_conn_id() -> i64 {
+    SYNTHETIC_CONN_ID.fetch_sub(1, Ordering::Relaxed)
+}
+
+/// 更新实例的 Controller 并清理不再使用的旧 Pool 条目
+fn update_instance_controller(
+    state: &super::types::MaaState,
+    instance_id: &str,
+    controller: maa_framework::controller::Controller,
+    new_config: super::types::ControllerConfig,
+) -> Result<(), String> {
+    let cleanup_config = {
+        let mut instances = state.instances.lock().map_err(|e| e.to_string())?;
+        let instance = instances
+            .get_mut(instance_id)
+            .ok_or("Instance not found")?;
+
+        let old_config = instance.controller_config.clone();
+        instance.controller = Some(controller);
+        instance.controller_config = Some(new_config.clone());
+        instance.tasker = None;
+
+        old_config.filter(|old| {
+            *old != new_config
+                && !instances
+                    .values()
+                    .any(|inst| inst.controller_config.as_ref() == Some(old))
+        })
+    };
+
+    if let Some(old_cfg) = cleanup_config {
+        if let Ok(mut pool) = state.controller_pool.lock() {
+            pool.remove(&old_cfg);
+            info!("ControllerPool: removed unused entry for old config");
+        }
+    }
+
+    Ok(())
+}
 
 // ============================================================================
 // 初始化和版本命令
@@ -338,17 +382,37 @@ pub fn maa_destroy_instance(
 ) -> Result<(), String> {
     info!("maa_destroy_instance called, instance_id: {}", instance_id);
 
-    let mut instances = state.instances.lock().map_err(|e| e.to_string())?;
-    let removed = instances.remove(&instance_id).is_some();
+    let cleanup_config = {
+        let mut instances = state.instances.lock().map_err(|e| e.to_string())?;
+        let old_config = instances
+            .get(&instance_id)
+            .and_then(|inst| inst.controller_config.clone());
+        let removed = instances.remove(&instance_id).is_some();
 
-    if removed {
-        info!("maa_destroy_instance success, instance_id: {}", instance_id);
-    } else {
-        warn!(
-            "maa_destroy_instance: instance not found, instance_id: {}",
-            instance_id
-        );
+        if removed {
+            info!("maa_destroy_instance success, instance_id: {}", instance_id);
+            old_config.filter(|cfg| {
+                !instances
+                    .values()
+                    .any(|inst| inst.controller_config.as_ref() == Some(cfg))
+            })
+        } else {
+            warn!(
+                "maa_destroy_instance: instance not found, instance_id: {}",
+                instance_id
+            );
+            None
+        }
+    };
+
+    // ControllerPool: 清理不再被任何实例使用的条目
+    if let Some(cfg) = cleanup_config {
+        if let Ok(mut pool) = state.controller_pool.lock() {
+            pool.remove(&cfg);
+            info!("ControllerPool: cleaned up entry after instance destroy");
+        }
     }
+
     Ok(())
 }
 
@@ -375,6 +439,41 @@ pub async fn maa_connect_controller(
 
     // Move blocking controller creation and connection to spawn_blocking
     tauri::async_runtime::spawn_blocking(move || {
+        // ControllerPool: 检查是否有可复用的已连接控制器
+        let pooled = {
+            let pool = state_arc.controller_pool.lock().map_err(|e| e.to_string())?;
+            pool.get(&config).filter(|c| c.connected()).cloned()
+        };
+
+        if let Some(pooled_ctrl) = pooled {
+            info!(
+                "ControllerPool hit: reusing connected controller for {:?}",
+                config
+            );
+
+            let conn_id = next_synthetic_conn_id();
+
+            update_instance_controller(&state_arc, &instance_id, pooled_ctrl, config)?;
+
+            // 发送合成回调事件，前端无感知
+            let details = format!(r#"{{"ctrl_id":{},"action":"Connect"}}"#, conn_id);
+            emit_callback_event(&app_handle, "Controller.Action.Starting", &details);
+            emit_callback_event(&app_handle, "Controller.Action.Succeeded", &details);
+
+            return Ok(conn_id);
+        }
+
+        // Pool 中无可用控制器（不存在或已断连），移除过期条目
+        {
+            let mut pool = state_arc.controller_pool.lock().map_err(|e| e.to_string())?;
+            pool.remove(&config);
+        }
+
+        info!(
+            "ControllerPool miss: creating new controller for {:?}",
+            config
+        );
+
         let controller = match &config {
             ControllerConfig::Adb {
                 adb_path,
@@ -383,7 +482,6 @@ pub async fn maa_connect_controller(
                 input_methods,
                 config,
             } => {
-                // 将字符串解析为 u64
                 let screencap = screencap_methods.parse::<u64>().map_err(|e| {
                     format!("Invalid screencap_methods '{}': {}", screencap_methods, e)
                 })?;
@@ -443,7 +541,6 @@ pub async fn maa_connect_controller(
                     }
                     _ => maa_framework::common::GamepadType::Xbox360,
                 };
-                // bitflags
                 let screencap = screencap_method
                     .map(|v| maa_framework::common::Win32ScreencapMethod::from_bits_truncate(v))
                     .unwrap_or(maa_framework::common::Win32ScreencapMethod::DXGI_DESKTOP_DUP);
@@ -468,17 +565,15 @@ pub async fn maa_connect_controller(
         // 发起连接
         let conn_id = controller.post_connection().map_err(|e| e.to_string())?;
 
+        // 存入 ControllerPool
+        {
+            let mut pool = state_arc.controller_pool.lock().map_err(|e| e.to_string())?;
+            pool.insert(config.clone(), controller.clone());
+        }
+
         // 更新实例状态
         debug!("Updating instance state...");
-        {
-            let mut instances = state_arc.instances.lock().map_err(|e| e.to_string())?;
-            let instance = instances
-                .get_mut(&instance_id)
-                .ok_or("Instance not found")?;
-
-            instance.controller = Some(controller);
-            instance.tasker = None;
-        }
+        update_instance_controller(&state_arc, &instance_id, controller, config)?;
 
         Ok(conn_id)
     })

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -61,7 +61,7 @@ pub struct Win32Window {
 }
 
 /// 控制器类型
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(tag = "type")]
 pub enum ControllerConfig {
     Adb {
@@ -137,6 +137,8 @@ pub struct AllInstanceStates {
 pub struct InstanceRuntime {
     pub resource: Option<Resource>,
     pub controller: Option<Controller>,
+    /// 当前控制器的配置（用于 ControllerPool 引用管理）
+    pub controller_config: Option<ControllerConfig>,
     pub tasker: Option<Tasker>,
     pub agent_clients: Vec<AgentClient>,
     pub agent_children: Vec<Child>,
@@ -180,6 +182,8 @@ pub struct MaaState {
     pub lib_dir: Mutex<Option<PathBuf>>,
     pub resource_dir: Mutex<Option<PathBuf>>,
     pub instances: Mutex<HashMap<String, InstanceRuntime>>,
+    /// Controller 连接池：相同配置的 Controller 复用同一个 MaaControllerHandle
+    pub controller_pool: Mutex<HashMap<ControllerConfig, Controller>>,
     /// 缓存的 ADB 设备列表（全局共享，避免重复搜索）
     pub cached_adb_devices: Mutex<Vec<AdbDevice>>,
     /// 缓存的 Win32 窗口列表（全局共享）


### PR DESCRIPTION
## Summary by Sourcery

引入一个共享的控制器池，以在多个 Maa 实例之间复用控制器实例，同时保持实例状态与池条目的同步。

新功能：
- 添加一个以 `ControllerConfig` 为键的全局 `ControllerPool`，以便在多个 Maa 实例之间共享已连接的控制器实例。
- 在运行时状态中跟踪每个实例当前的 `ControllerConfig`，以支持控制器池引用管理。

缺陷修复：
- 当实例被销毁或其控制器配置发生变化时，清理未使用的控制器池条目，避免出现过期的池化控制器。

优化改进：
- 在复用池化控制器时返回合成的负连接 ID，使前端能够透明地处理复用的连接，而不会与 MaaFramework 的 ID 发生冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a shared controller pool to reuse controller instances across Maa instances while keeping instance state and pool entries in sync.

New Features:
- Add a global ControllerPool keyed by ControllerConfig to allow sharing connected controller instances between multiple Maa instances.
- Track each instance's current ControllerConfig in runtime state to support controller pool reference management.

Bug Fixes:
- Clean up unused controller pool entries when an instance is destroyed or its controller configuration changes to avoid stale pooled controllers.

Enhancements:
- Return synthetic negative connection IDs when reusing pooled controllers so the frontend can transparently handle reused connections without clashing with MaaFramework IDs.

</details>

新功能：
- 添加一个以 `ControllerConfig` 为键的全局 `ControllerPool`，用于在多个 Maa 实例之间复用控制器实例。
- 跟踪每个实例当前使用的 `ControllerConfig`，以支持基于控制器池的引用管理。

错误修复：
- 在实例被销毁或其控制器配置发生变化时，清理未使用的控制器池条目，防止过期的池化控制器残留。

改进：
- 在复用池化控制器时返回合成的负连接 ID，使前端可以透明地处理复用连接，而不会与 MaaFramework 的 ID 发生冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个共享的控制器池，以在多个 Maa 实例之间复用控制器实例，同时保持实例状态与池条目的同步。

新功能：
- 添加一个以 `ControllerConfig` 为键的全局 `ControllerPool`，以便在多个 Maa 实例之间共享已连接的控制器实例。
- 在运行时状态中跟踪每个实例当前的 `ControllerConfig`，以支持控制器池引用管理。

缺陷修复：
- 当实例被销毁或其控制器配置发生变化时，清理未使用的控制器池条目，避免出现过期的池化控制器。

优化改进：
- 在复用池化控制器时返回合成的负连接 ID，使前端能够透明地处理复用的连接，而不会与 MaaFramework 的 ID 发生冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a shared controller pool to reuse controller instances across Maa instances while keeping instance state and pool entries in sync.

New Features:
- Add a global ControllerPool keyed by ControllerConfig to allow sharing connected controller instances between multiple Maa instances.
- Track each instance's current ControllerConfig in runtime state to support controller pool reference management.

Bug Fixes:
- Clean up unused controller pool entries when an instance is destroyed or its controller configuration changes to avoid stale pooled controllers.

Enhancements:
- Return synthetic negative connection IDs when reusing pooled controllers so the frontend can transparently handle reused connections without clashing with MaaFramework IDs.

</details>

</details>