### PR TITLE
feat: pin

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,8 @@
     "core:window:allow-unminimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-is-maximized",
+    "core:window:allow-set-always-on-top",
+    "core:window:allow-is-always-on-top",
     "core:window:allow-set-focus",
     "core:window:allow-close",
     "core:window:allow-start-dragging",

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Minus, Square, X, Copy, Box, Pin } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
@@ -18,7 +18,7 @@ export function TitleBar() {
   const [iconUrl, setIconUrl] = useState<string | undefined>(undefined);
   const windowRef = useRef<Awaited<ReturnType<typeof import('@tauri-apps/api/window').getCurrentWindow>> | null>(null);
 
-  const { projectInterface, language, resolveI18nText, basePath, interfaceTranslations } =
+  const { projectInterface, language, resolveI18nText, basePath, interfaceTranslations, instances, activeInstanceId } =
     useAppStore();
 
   const langKey = getInterfaceLangKey(language);
@@ -40,6 +40,27 @@ export function TitleBar() {
     }
     loadIconAsDataUrl(projectInterface.icon, basePath, translations).then(setIconUrl);
   }, [projectInterface?.icon, basePath, translations]);
+
+  // 检测是否使用前台截图（前台截图时禁用置顶）
+  const isPinDisabled = useMemo(() => {
+    if (!projectInterface || !activeInstanceId) return false;
+
+    const activeInstance = instances.find((i) => i.id === activeInstanceId);
+    if (!activeInstance?.controllerName) return false;
+
+    const controller = projectInterface.controller.find((c) => c.name === activeInstance.controllerName);
+    if (!controller) return false;
+
+    // 仅 Win32 的特定前台截图方法需要禁用置顶
+    if (controller.type === 'Win32' && controller.win32?.screencap) {
+      const screencap = controller.win32.screencap;
+      const foregroundMethods = new Set(['GDI', '1', 'DXGI_DesktopDup', '4', 'DXGI_DesktopDup_Window', '8', 'ScreenDC', '32']);
+      return foregroundMethods.has(screencap);
+    }
+
+    // 其他情况（ADB、PlayCover、Gamepad 或 Win32 后台截图）均支持置顶
+    return false;
+  }, [projectInterface, instances, activeInstanceId]);
 
   // 监听窗口最大化状态变化（仅 Windows，用于切换最大化/还原按钮图标）
   useEffect(() => {
@@ -158,12 +179,21 @@ export function TitleBar() {
         <div className="flex h-full">
           <button
             onClick={handleToggleAlwaysOnTop}
+            disabled={isPinDisabled}
             className={`w-12 h-full flex items-center justify-center transition-colors ${
-              isAlwaysOnTop
-                ? 'text-accent bg-accent/10 hover:bg-accent/20'
-                : 'text-text-secondary hover:bg-bg-hover'
+              isPinDisabled
+                ? 'text-text-tertiary cursor-not-allowed'
+                : isAlwaysOnTop
+                  ? 'text-accent bg-accent/10 hover:bg-accent/20'
+                  : 'text-text-secondary hover:bg-bg-hover'
             }`}
-            title={isAlwaysOnTop ? t('windowControls.unpin') : t('windowControls.pin')}
+            title={
+              isPinDisabled
+                ? t('windowControls.pinDisabled')
+                : isAlwaysOnTop
+                  ? t('windowControls.unpin')
+                  : t('windowControls.pin')
+            }
           >
             <Pin className={`w-4 h-4 transition-transform ${isAlwaysOnTop ? '' : 'rotate-45'}`} />
           </button>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -10,6 +10,9 @@ import { isTauri } from '@/utils/paths';
 // 平台类型
 type Platform = 'windows' | 'macos' | 'linux' | 'unknown';
 
+// Win32 前台截图方法（需要禁用置顶）
+const FOREGROUND_SCREENCAP_METHODS = new Set(['GDI', '1', 'DXGI_DesktopDup', '4', 'DXGI_DesktopDup_Window', '8', 'ScreenDC', '32']);
+
 export function TitleBar() {
   const { t } = useTranslation();
   const [isMaximized, setIsMaximized] = useState(false);
@@ -54,8 +57,7 @@ export function TitleBar() {
     // 仅 Win32 的特定前台截图方法需要禁用置顶
     if (controller.type === 'Win32' && controller.win32?.screencap) {
       const screencap = controller.win32.screencap;
-      const foregroundMethods = new Set(['GDI', '1', 'DXGI_DesktopDup', '4', 'DXGI_DesktopDup_Window', '8', 'ScreenDC', '32']);
-      return foregroundMethods.has(screencap);
+      return FOREGROUND_SCREENCAP_METHODS.has(screencap);
     }
 
     // 其他情况（ADB、PlayCover、Gamepad 或 Win32 后台截图）均支持置顶
@@ -72,9 +74,9 @@ export function TitleBar() {
     }
   }, [isPinDisabled, isAlwaysOnTop]);
 
-  // 监听窗口最大化状态变化（仅 Windows，用于切换最大化/还原按钮图标）
+  // 初始化 Tauri 窗口引用，并在 Windows 上监听最大化状态变化
   useEffect(() => {
-    if (!isTauri() || platform !== 'windows') return;
+    if (!isTauri()) return;
 
     let unlisten: (() => void) | null = null;
 
@@ -85,13 +87,16 @@ export function TitleBar() {
         windowRef.current = appWindow;
 
         // 获取初始状态
-        setIsMaximized(await appWindow.isMaximized());
         setIsAlwaysOnTop(await appWindow.isAlwaysOnTop());
 
-        // 监听窗口状态变化
-        unlisten = await appWindow.onResized(async () => {
+        // 仅 Windows 需要追踪最大化状态（macOS/Linux 使用原生标题栏）
+        if (platform === 'windows') {
           setIsMaximized(await appWindow.isMaximized());
-        });
+
+          unlisten = await appWindow.onResized(async () => {
+            setIsMaximized(await appWindow.isMaximized());
+          });
+        }
       } catch (err) {
         loggers.ui.warn('Failed to setup window state listener:', err);
       }

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Minus, Square, X, Copy, Box } from 'lucide-react';
+import { Minus, Square, X, Copy, Box, Pin } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
 import { getInterfaceLangKey } from '@/i18n';
 import { loadIconAsDataUrl } from '@/services/contentResolver';
@@ -13,6 +13,7 @@ type Platform = 'windows' | 'macos' | 'linux' | 'unknown';
 export function TitleBar() {
   const { t } = useTranslation();
   const [isMaximized, setIsMaximized] = useState(false);
+  const [isAlwaysOnTop, setIsAlwaysOnTop] = useState(false);
   const [platform, setPlatform] = useState<Platform>('unknown');
   const [iconUrl, setIconUrl] = useState<string | undefined>(undefined);
 
@@ -52,6 +53,7 @@ export function TitleBar() {
 
         // 获取初始状态
         setIsMaximized(await appWindow.isMaximized());
+        setIsAlwaysOnTop(await appWindow.isAlwaysOnTop());
 
         // 监听窗口状态变化
         unlisten = await appWindow.onResized(async () => {
@@ -76,6 +78,18 @@ export function TitleBar() {
       await getCurrentWindow().minimize();
     } catch (err) {
       loggers.ui.warn('Failed to minimize window:', err);
+    }
+  };
+
+  const handleToggleAlwaysOnTop = async () => {
+    if (!isTauri()) return;
+    try {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window');
+      const newState = !isAlwaysOnTop;
+      await getCurrentWindow().setAlwaysOnTop(newState);
+      setIsAlwaysOnTop(newState);
+    } catch (err) {
+      loggers.ui.warn('Failed to toggle always on top:', err);
     }
   };
 
@@ -142,6 +156,17 @@ export function TitleBar() {
       {/* 右侧：窗口控制按钮（仅 Windows/Linux 显示） */}
       {isTauri() && (
         <div className="flex h-full">
+          <button
+            onClick={handleToggleAlwaysOnTop}
+            className={`w-12 h-full flex items-center justify-center transition-colors ${
+              isAlwaysOnTop
+                ? 'text-accent bg-accent/10 hover:bg-accent/20'
+                : 'text-text-secondary hover:bg-bg-hover'
+            }`}
+            title={isAlwaysOnTop ? t('windowControls.unpin') : t('windowControls.pin')}
+          >
+            <Pin className={`w-4 h-4 transition-transform ${isAlwaysOnTop ? '' : 'rotate-45'}`} />
+          </button>
           <button
             onClick={handleMinimize}
             className="w-12 h-full flex items-center justify-center text-text-secondary hover:bg-bg-hover transition-colors"

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -62,6 +62,16 @@ export function TitleBar() {
     return false;
   }, [projectInterface, instances, activeInstanceId]);
 
+  // 当置顶被禁用时，自动取消置顶
+  useEffect(() => {
+    if (isPinDisabled && isAlwaysOnTop && windowRef.current) {
+      setIsAlwaysOnTop(false);
+      windowRef.current.setAlwaysOnTop(false).catch((err: unknown) => {
+        loggers.ui.warn('Failed to disable always on top:', err);
+      });
+    }
+  }, [isPinDisabled, isAlwaysOnTop]);
+
   // 监听窗口最大化状态变化（仅 Windows，用于切换最大化/还原按钮图标）
   useEffect(() => {
     if (!isTauri() || platform !== 'windows') return;

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Minus, Square, X, Copy, Box, Pin } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
@@ -16,6 +16,7 @@ export function TitleBar() {
   const [isAlwaysOnTop, setIsAlwaysOnTop] = useState(false);
   const [platform, setPlatform] = useState<Platform>('unknown');
   const [iconUrl, setIconUrl] = useState<string | undefined>(undefined);
+  const windowRef = useRef<Awaited<ReturnType<typeof import('@tauri-apps/api/window').getCurrentWindow>> | null>(null);
 
   const { projectInterface, language, resolveI18nText, basePath, interfaceTranslations } =
     useAppStore();
@@ -50,6 +51,7 @@ export function TitleBar() {
       try {
         const { getCurrentWindow } = await import('@tauri-apps/api/window');
         const appWindow = getCurrentWindow();
+        windowRef.current = appWindow;
 
         // 获取初始状态
         setIsMaximized(await appWindow.isMaximized());
@@ -68,46 +70,44 @@ export function TitleBar() {
 
     return () => {
       if (unlisten) unlisten();
+      windowRef.current = null;
     };
   }, [platform]);
 
   const handleMinimize = async () => {
-    if (!isTauri()) return;
+    if (!windowRef.current) return;
     try {
-      const { getCurrentWindow } = await import('@tauri-apps/api/window');
-      await getCurrentWindow().minimize();
+      await windowRef.current.minimize();
     } catch (err) {
       loggers.ui.warn('Failed to minimize window:', err);
     }
   };
 
   const handleToggleAlwaysOnTop = async () => {
-    if (!isTauri()) return;
+    if (!windowRef.current) return;
+    const newState = !isAlwaysOnTop;
+    setIsAlwaysOnTop(newState); // Optimistic update
     try {
-      const { getCurrentWindow } = await import('@tauri-apps/api/window');
-      const newState = !isAlwaysOnTop;
-      await getCurrentWindow().setAlwaysOnTop(newState);
-      setIsAlwaysOnTop(newState);
+      await windowRef.current.setAlwaysOnTop(newState);
     } catch (err) {
+      setIsAlwaysOnTop(!newState); // Revert on error
       loggers.ui.warn('Failed to toggle always on top:', err);
     }
   };
 
   const handleToggleMaximize = async () => {
-    if (!isTauri()) return;
+    if (!windowRef.current) return;
     try {
-      const { getCurrentWindow } = await import('@tauri-apps/api/window');
-      await getCurrentWindow().toggleMaximize();
+      await windowRef.current.toggleMaximize();
     } catch (err) {
       loggers.ui.warn('Failed to toggle maximize:', err);
     }
   };
 
   const handleClose = async () => {
-    if (!isTauri()) return;
+    if (!windowRef.current) return;
     try {
-      const { getCurrentWindow } = await import('@tauri-apps/api/window');
-      await getCurrentWindow().close();
+      await windowRef.current.close();
     } catch (err) {
       loggers.ui.warn('Failed to close window:', err);
     }

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -39,6 +39,8 @@ export default {
     maximize: 'Maximize',
     restore: 'Restore',
     close: 'Close',
+    pin: 'Pin',
+    unpin: 'Unpin',
   },
 
   // Settings

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -41,6 +41,7 @@ export default {
     close: 'Close',
     pin: 'Pin',
     unpin: 'Unpin',
+    pinDisabled: 'Pin disabled (foreground screenshot)',
   },
 
   // Settings

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -38,6 +38,8 @@ export default {
     maximize: '最大化',
     restore: '元に戻す',
     close: '閉じる',
+    pin: '常に手前に表示',
+    unpin: '常に手前に表示を解除',
   },
 
   // 設定

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -40,6 +40,7 @@ export default {
     close: '閉じる',
     pin: '常に手前に表示',
     unpin: '常に手前に表示を解除',
+    pinDisabled: 'フォアグラウンドスクリーンショットのため固定不可',
   },
 
   // 設定

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -38,6 +38,8 @@ export default {
     maximize: '최대화',
     restore: '복원',
     close: '닫기',
+    pin: '항상 위',
+    unpin: '항상 위 해제',
   },
 
   // 설정

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -40,6 +40,7 @@ export default {
     close: '닫기',
     pin: '항상 위',
     unpin: '항상 위 해제',
+    pinDisabled: '전면 스크린샷 사용 중, 고정 불가',
   },
 
   // 설정

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -39,6 +39,8 @@ export default {
     maximize: '最大化',
     restore: '还原',
     close: '关闭',
+    pin: '置顶',
+    unpin: '取消置顶',
   },
 
   // 设置

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -41,6 +41,7 @@ export default {
     close: '关闭',
     pin: '置顶',
     unpin: '取消置顶',
+    pinDisabled: '当前控制器使用前台截图，无法置顶',
   },
 
   // 设置

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -38,6 +38,8 @@ export default {
     maximize: '最大化',
     restore: '還原',
     close: '關閉',
+    pin: '置頂',
+    unpin: '取消置頂',
   },
 
   // 設定

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -40,6 +40,7 @@ export default {
     close: '關閉',
     pin: '置頂',
     unpin: '取消置頂',
+    pinDisabled: '目前控制器使用前台截圖，無法置頂',
   },
 
   // 設定


### PR DESCRIPTION
## Summary by Sourcery

在自定义的 Tauri 标题栏中添加一个“始终置顶”的固定控制按钮，并将其与窗口状态和控制器行为集成。

新功能：
- 在 Tauri 窗口标题栏中新增“始终置顶”固定切换按钮。

改进：
- 通过共享的窗口引用来跟踪并初始化窗口的“始终置顶”状态，该引用会在所有窗口控制操作中复用。
- 当根据当前控制器配置使用与前台截图不兼容的方法时，禁用并自动清除“始终置顶”状态。
- 为固定、取消固定以及固定被禁用时的工具提示，在所有支持的语言中添加本地化标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an always-on-top pin control to the custom Tauri title bar while integrating it with window state and controller behavior.

New Features:
- Introduce an always-on-top pin toggle button in the Tauri window title bar.

Enhancements:
- Track and initialize the window's always-on-top state via a shared window reference reused by all window control actions.
- Disable and auto-clear the always-on-top state when using incompatible foreground screenshot methods based on the active controller configuration.
- Add localized labels for pin, unpin, and pin-disabled tooltips across all supported languages.

</details>

新功能：
- 在 Tauri 窗口的标题栏中新增一个始终置顶的固定切换按钮。

增强内容：
- 在现有窗口状态的基础上，初始化并跟踪窗口的始终置顶状态。
- 为所有受支持的语言环境添加窗口控件的“固定”和“取消固定”本地化标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在自定义的 Tauri 标题栏中添加一个“始终置顶”的固定控制按钮，并将其与窗口状态和控制器行为集成。

新功能：
- 在 Tauri 窗口标题栏中新增“始终置顶”固定切换按钮。

改进：
- 通过共享的窗口引用来跟踪并初始化窗口的“始终置顶”状态，该引用会在所有窗口控制操作中复用。
- 当根据当前控制器配置使用与前台截图不兼容的方法时，禁用并自动清除“始终置顶”状态。
- 为固定、取消固定以及固定被禁用时的工具提示，在所有支持的语言中添加本地化标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an always-on-top pin control to the custom Tauri title bar while integrating it with window state and controller behavior.

New Features:
- Introduce an always-on-top pin toggle button in the Tauri window title bar.

Enhancements:
- Track and initialize the window's always-on-top state via a shared window reference reused by all window control actions.
- Disable and auto-clear the always-on-top state when using incompatible foreground screenshot methods based on the active controller configuration.
- Add localized labels for pin, unpin, and pin-disabled tooltips across all supported languages.

</details>

</details>