### PR TITLE
fix: 修复 #103、#96 及 MaaEnd #928/#938 的关键问题

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -2,7 +2,7 @@
 //!
 //! 提供权限检查、系统信息查询、全局选项设置等功能
 
-use log::info;
+use log::{info, warn};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::types::SystemInfo;
@@ -546,7 +546,9 @@ pub fn migrate_legacy_autostart() {
     }
     // 兼容迁移：老版本已创建的计划任务可能缺少交互式运行或启动延迟，自动重建为新配置
     if schtask_autostart_needs_refresh() {
-        let _ = create_schtask_autostart();
+        if let Err(err) = create_schtask_autostart() {
+            warn!("重建自启动计划任务失败: {}", err);
+        }
     }
 }
 
@@ -591,6 +593,8 @@ fn create_schtask_autostart() -> Result<(), String> {
 /// 判断现有 MXU 自启动计划任务是否需要刷新参数
 #[cfg(windows)]
 fn schtask_autostart_needs_refresh() -> bool {
+    use regex::Regex;
+
     let output = match std::process::Command::new("schtasks")
         .args(["/query", "/tn", "MXU", "/xml"])
         .output()
@@ -599,16 +603,27 @@ fn schtask_autostart_needs_refresh() -> bool {
         _ => return false, // 不存在任务或查询失败，不做迁移
     };
 
-    let xml = String::from_utf8_lossy(&output.stdout).to_lowercase();
+    let xml = String::from_utf8_lossy(&output.stdout);
+    let tag_equals = |tag: &str, expected: &str| -> bool {
+        let pattern = format!(
+            r"(?is)<\s*{}\s*>\s*{}\s*<\s*/\s*{}\s*>",
+            regex::escape(tag),
+            regex::escape(expected),
+            regex::escape(tag)
+        );
+        Regex::new(&pattern)
+            .map(|re| re.is_match(&xml))
+            .unwrap_or(false)
+    };
 
     // 尊重用户手动禁用：禁用状态下不自动重建
-    let enabled = xml.contains("<enabled>true</enabled>");
+    let enabled = tag_equals("Enabled", "true");
     if !enabled {
         return false;
     }
 
-    let has_interactive = xml.contains("<logontype>interactivetoken</logontype>");
-    let has_delay_30s = xml.contains("<delay>pt30s</delay>");
+    let has_interactive = tag_equals("LogonType", "InteractiveToken");
+    let has_delay_30s = tag_equals("Delay", "PT30S");
     !(has_interactive && has_delay_30s)
 }
 

--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -51,9 +51,13 @@ interface OptionEditorProps {
   depth?: number;
   /** 是否禁用编辑（只读模式） */
   disabled?: boolean;
-  /** 是否继承父级不兼容状态（控制器/资源） */
+  /** 是否继承父级不兼容状态 */
   controllerIncompatible?: boolean;
+  /** 父级不兼容原因（用于嵌套提示文案） */
+  parentIncompatibilityReason?: IncompatibilityReason;
 }
+
+type IncompatibilityReason = 'controller' | 'resource';
 
 /** 显示带图标的标签（仅标签本身） */
 function OptionLabel({
@@ -305,6 +309,7 @@ export function OptionEditor({
   depth = 0,
   disabled = false,
   controllerIncompatible = false,
+  parentIncompatibilityReason,
 }: OptionEditorProps) {
   const { t } = useTranslation();
   const {
@@ -352,12 +357,18 @@ export function OptionEditor({
   const selfResourceIncompatible = isOptionResourceIncompatible(optionDef, currentResourceName);
   const isOptionIncompatible =
     controllerIncompatible || selfControllerIncompatible || selfResourceIncompatible;
-  const incompatibleReason = selfControllerIncompatible
-    ? t('optionEditor.incompatibleController')
+  const incompatibleReasonType: IncompatibilityReason | undefined = selfControllerIncompatible
+    ? 'controller'
     : selfResourceIncompatible
-      ? t('optionEditor.incompatibleResource')
+      ? 'resource'
       : controllerIncompatible
-        ? t('optionEditor.incompatibleController')
+        ? parentIncompatibilityReason
+        : undefined;
+  const incompatibleReason =
+    incompatibleReasonType === 'controller'
+      ? t('optionEditor.incompatibleController')
+      : incompatibleReasonType === 'resource'
+        ? t('optionEditor.incompatibleResource')
         : undefined;
   const effectiveDisabled = disabled || isOptionIncompatible;
 
@@ -427,6 +438,7 @@ export function OptionEditor({
                 depth={depth + 1}
                 disabled={effectiveDisabled}
                 controllerIncompatible={isOptionIncompatible}
+                parentIncompatibilityReason={incompatibleReasonType}
               />
             ))}
           </div>
@@ -615,6 +627,7 @@ export function OptionEditor({
               depth={depth + 1}
               disabled={effectiveDisabled}
               controllerIncompatible={isOptionIncompatible}
+              parentIncompatibilityReason={incompatibleReasonType}
             />
           ))}
         </div>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -290,6 +290,11 @@ function OptionListRenderer({
           currentResourceName,
         );
         const optionIncompatible = optionControllerIncompatible || optionResourceIncompatible;
+        const parentIncompatibilityReason = optionControllerIncompatible
+          ? 'controller'
+          : optionResourceIncompatible
+            ? 'resource'
+            : undefined;
         return (
           <OptionEditor
             key={group.optionKey}
@@ -299,6 +304,7 @@ function OptionListRenderer({
             value={optionValues[group.optionKey]}
             disabled={disabled || optionIncompatible}
             controllerIncompatible={optionIncompatible}
+            parentIncompatibilityReason={parentIncompatibilityReason}
           />
         );
       })}

--- a/src/utils/pipelineOverride.ts
+++ b/src/utils/pipelineOverride.ts
@@ -144,8 +144,11 @@ const collectOptionOverrides = (
     try {
       overrides.push(JSON.parse(overrideStr));
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      loggers.task.warn(`解析选项覆盖失败: ${message}`);
+      loggers.task.warn('解析选项覆盖失败:', {
+        errorMessage: e instanceof Error ? e.message : String(e),
+        errorStack: e instanceof Error ? e.stack : undefined,
+        overrideStr,
+      });
     }
   }
 };


### PR DESCRIPTION
﻿## 变更说明

本 PR 包含 3 组修复：

1. 修复 #103：子选择框下 controller/resource 限制未生效
- 在 `OptionEditor` 内部增加当前 controller/resource 兼容性计算
- 子选项递归渲染时继承并继续应用不兼容状态
- 不兼容提示支持区分 controller/resource

2. 修复 #96：开机自启在登录早期容易卡住/启动失败
- Windows 计划任务增加 `/delay 0000:30`，降低桌面会话未就绪导致的失败概率
- 增加旧任务参数兼容迁移：检测并自动重建缺少 InteractiveToken/Delay 的 MXU 任务

3. 修复 MaaEnd #928 / #938（第2点）：自定义程序任务直接失败
- 修复 `pipeline_override` 字符串占位替换未做 JSON 转义的问题
- 避免 Windows 路径（含 `\`）导致 JSON 解析失败，从而丢失 `custom_action_param.program`
- 解析失败日志输出具体错误信息，便于排障

## 验证

- `pnpm -s tsc --noEmit`
- `cargo check --manifest-path src-tauri/Cargo.toml -q`

## 关联

- closes #103
- closes #96
- refs https://github.com/MaaEnd/MaaEnd/issues/928
- refs https://github.com/MaaEnd/MaaEnd/issues/938
