### PR TITLE
Support cached update package detection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import {
   getUpdateSavePath,
   findCachedUpdatePackage,
   consumeUpdateCompleteInfo,
-  savePendingUpdateInfo,
+  savePendingUpdate,
   getPendingUpdateInfo,
   clearPendingUpdateInfo,
   isDebugVersion,
@@ -348,20 +348,7 @@ function App() {
         if (cachedPackagePath) {
           setDownloadSavePath(cachedPackagePath);
           setDownloadStatus('completed');
-          log.info('检测到 cache 中已有更新包，跳过下载');
-
-          savePendingUpdateInfo({
-            versionName: updateResult.versionName,
-            releaseNote: updateResult.releaseNote,
-            channel: updateResult.channel,
-            downloadSavePath: cachedPackagePath,
-            fileSize: updateResult.fileSize,
-            updateType: updateResult.updateType,
-            downloadSource: updateResult.downloadSource,
-            timestamp: Date.now(),
-          });
-
-          tryAutoInstallUpdate();
+          savePendingUpdate(updateResult, cachedPackagePath);
           return;
         }
 
@@ -391,19 +378,7 @@ function App() {
           log.info('更新下载完成');
 
           // 保存待安装更新信息，以便下次启动时自动安装
-          savePendingUpdateInfo({
-            versionName: updateResult.versionName,
-            releaseNote: updateResult.releaseNote,
-            channel: updateResult.channel,
-            downloadSavePath: result.actualSavePath,
-            fileSize: updateResult.fileSize,
-            updateType: updateResult.updateType,
-            downloadSource: updateResult.downloadSource,
-            timestamp: Date.now(),
-          });
-
-          // 尝试自动安装更新
-          tryAutoInstallUpdate();
+          savePendingUpdate(updateResult, result.actualSavePath);
         } else {
           setDownloadStatus('failed');
           // 下载失败时重置标志，允许后续重新下载（如填入 CDK 后切换下载源）

--- a/src/components/UpdatePanel.tsx
+++ b/src/components/UpdatePanel.tsx
@@ -15,7 +15,7 @@ import {
   downloadUpdate,
   getUpdateSavePath,
   MIRRORCHYAN_ERROR_CODES,
-  savePendingUpdateInfo,
+  savePendingUpdate,
   findCachedUpdatePackage,
 } from '@/services/updateService';
 import { DownloadProgressBar } from './UpdateInfoCard';
@@ -61,16 +61,7 @@ export function UpdatePanel({ onClose, anchorRef }: UpdatePanelProps) {
       if (cachedPackagePath) {
         setDownloadSavePath(cachedPackagePath);
         setDownloadStatus('completed');
-        savePendingUpdateInfo({
-          versionName: updateInfo.versionName,
-          releaseNote: updateInfo.releaseNote,
-          channel: updateInfo.channel,
-          downloadSavePath: cachedPackagePath,
-          fileSize: updateInfo.fileSize,
-          updateType: updateInfo.updateType,
-          downloadSource: updateInfo.downloadSource,
-          timestamp: Date.now(),
-        });
+        savePendingUpdate(updateInfo, cachedPackagePath);
         return;
       }
 
@@ -91,16 +82,7 @@ export function UpdatePanel({ onClose, anchorRef }: UpdatePanelProps) {
         setDownloadSavePath(result.actualSavePath);
         setDownloadStatus('completed');
         // 保存待安装更新信息，以便下次启动时自动安装
-        savePendingUpdateInfo({
-          versionName: updateInfo.versionName,
-          releaseNote: updateInfo.releaseNote,
-          channel: updateInfo.channel,
-          downloadSavePath: result.actualSavePath,
-          fileSize: updateInfo.fileSize,
-          updateType: updateInfo.updateType,
-          downloadSource: updateInfo.downloadSource,
-          timestamp: Date.now(),
-        });
+        savePendingUpdate(updateInfo, result.actualSavePath);
       } else {
         setDownloadStatus('failed');
       }

--- a/src/components/settings/UpdateSection.tsx
+++ b/src/components/settings/UpdateSection.tsx
@@ -23,7 +23,7 @@ import {
   downloadUpdate,
   getUpdateSavePath,
   findCachedUpdatePackage,
-  savePendingUpdateInfo,
+  savePendingUpdate,
   cancelDownload,
   MIRRORCHYAN_ERROR_CODES,
   isDebugVersion,
@@ -134,16 +134,7 @@ export function UpdateSection() {
         if (cachedPackagePath) {
           setDownloadSavePath(cachedPackagePath);
           setDownloadStatus('completed');
-          savePendingUpdateInfo({
-            versionName: info.versionName,
-            releaseNote: info.releaseNote,
-            channel: info.channel,
-            downloadSavePath: cachedPackagePath,
-            fileSize: info.fileSize,
-            updateType: info.updateType,
-            downloadSource: info.downloadSource,
-            timestamp: Date.now(),
-          });
+          savePendingUpdate(info, cachedPackagePath);
           return;
         }
 
@@ -168,16 +159,7 @@ export function UpdateSection() {
           // 使用实际保存路径（可能与请求路径不同，如果从 302 重定向检测到正确文件名）
           setDownloadSavePath(result.actualSavePath);
           setDownloadStatus('completed');
-          savePendingUpdateInfo({
-            versionName: info.versionName,
-            releaseNote: info.releaseNote,
-            channel: info.channel,
-            downloadSavePath: result.actualSavePath,
-            fileSize: info.fileSize,
-            updateType: info.updateType,
-            downloadSource: info.downloadSource,
-            timestamp: Date.now(),
-          });
+          savePendingUpdate(info, result.actualSavePath);
         } else {
           setDownloadStatus('failed');
         }

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -677,7 +677,8 @@ interface DownloadUpdateOptions {
 
 /**
  * 查找已存在于 cache 目录中的更新包。
- * 仅接受更新接口返回的文件名，并要求 cache 中存在同名文件。
+ * 从更新接口返回的信息对象中读取 filename 字段，并要求 cache 中存在同名文件。
+ * 缓存命中日志统一在此函数内记录，调用方无需重复记录。
  */
 export async function findCachedUpdatePackage(
   info: Pick<UpdateInfo, 'filename'>,
@@ -1111,6 +1112,40 @@ export interface PendingUpdateInfo {
   updateType?: 'incremental' | 'full';
   downloadSource?: 'mirrorchyan' | 'github';
   timestamp: number;
+}
+
+type PendingUpdateSource = Pick<
+  UpdateInfo,
+  'versionName' | 'releaseNote' | 'channel' | 'fileSize' | 'updateType' | 'downloadSource'
+>;
+
+/**
+ * 根据更新信息和本地包路径构建待安装更新信息。
+ */
+export function buildPendingUpdateInfo(
+  info: PendingUpdateSource,
+  downloadSavePath: string,
+): PendingUpdateInfo {
+  return {
+    versionName: info.versionName,
+    releaseNote: info.releaseNote,
+    channel: info.channel,
+    downloadSavePath,
+    fileSize: info.fileSize,
+    updateType: info.updateType,
+    downloadSource: info.downloadSource,
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * 保存待安装更新信息到本地存储（下载完成后调用）
+ */
+export function savePendingUpdate(
+  info: PendingUpdateSource,
+  downloadSavePath: string,
+): void {
+  savePendingUpdateInfo(buildPendingUpdateInfo(info, downloadSavePath));
 }
 
 /**


### PR DESCRIPTION
在开始下载更新前，先检查 cache 目录中是否已经存在更新包
仅在本地文件名与更新检查返回的 filename 完全一致时，才直接复用该更新包
命中本地缓存包后，复用现有的待安装更新与安装流程，跳过实际下载

## 使用方式
- 用户先将最新版压缩包放入 cache/{filename}
- 启动 MXU 后，自动检查更新命中同名文件时会直接进入后续安装流程

总有可以从网上奇奇怪怪方法下下来的人，为这些人留一个方便，得和api检查的最新文件名一样，姑且认为没有改成新版文件名的，所以不至于会更新安装成旧版

fix #106

## Summary by Sourcery

在更新检查结果中的文件名与本地缓存的更新包文件名匹配时，支持复用本地缓存的更新包，在保留既有安装流程的同时跳过下载步骤。

新功能：
- 当缓存目录中已存在更新包且其文件名与更新元数据匹配时，检测并复用该更新包。
- 在发现或下载更新包时持久化待处理的更新元数据，以实现一致的安装处理流程。

增强改进：
- 将缓存更新包检测集成到主应用更新流程和设置/更新面板中，使自动安装在无需重新下载的情况下即可继续进行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for reusing a locally cached update package when its filename matches the update check result, skipping the download step while preserving the existing installation flow.

New Features:
- Detect and reuse update packages already present in the cache directory when the filename matches the update metadata.
- Persist pending update metadata whenever an update package is found or downloaded to enable consistent installation handling.

Enhancements:
- Integrate cached update detection into the main app update flow and settings/update panel so auto-install can proceed without a fresh download.

</details>