### PR TITLE
fix: 拖曳 TaskItem 拉伸渲染问题

### DIFF
--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -492,8 +492,16 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
     disabled: !canReorder,
   });
 
-  // 禁止 X 方向位移，仅允许垂直拖动
-  const constrainedTransform = transform ? { ...transform, x: 0 } : null;
+  // 禁止 X 方向位移，仅允许垂直拖动；同时忽略 dnd-kit 的缩放分量，
+  // 避免拖拽中的半透明项在高度变化时把文本一起纵向拉伸。
+  const constrainedTransform = transform
+    ? {
+        ...transform,
+        x: 0,
+        scaleX: 1,
+        scaleY: 1,
+      }
+    : null;
 
   const style = {
     transform: CSS.Transform.toString(constrainedTransform),


### PR DESCRIPTION
修复前

<img width="1500" height="927" alt="image" src="https://github.com/user-attachments/assets/68da0f07-3455-4816-88fb-fb62333a35aa" />

修复后

<img width="750" height="464" alt="Snipaste_2026-03-13_02-15-47" src="https://github.com/user-attachments/assets/f62d2641-1bb6-4ce5-ae20-9f5b2c1ebefc" />

## Summary by Sourcery

Bug Fixes:
- 在重新排序过程中，当拖动的 TaskItem 元素的高度发生变化时，防止其被垂直拉伸。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop dragged TaskItem elements from being vertically stretched when their height changes during reordering.

</details>