### PR TITLE
fix(agent): 修复 child_exec 被错误拼接 cwd 的问题

### DIFF
--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -52,10 +52,15 @@ fn strip_ansi_escapes(s: &str) -> String {
     ANSI_RE.replace_all(s, "").into_owned()
 }
 
-/// 判断给定路径是否是“裸命令名”（仅包含单个普通组件）。
+/// 判断给定 child_exec 是否是“裸命令名”（仅包含单个普通组件且不含路径分隔符）。
 ///
 /// 例如 `python` / `node` / `git` 返回 true，`./agent.py` / `subdir/tool` 返回 false。
-fn is_bare_command(path: &Path) -> bool {
+fn is_bare_command(child_exec: &str, path: &Path) -> bool {
+    // `python/`、`python\` 这类带分隔符输入应视为路径而非裸命令。
+    if child_exec.contains('/') || child_exec.contains('\\') {
+        return false;
+    }
+
     let mut components = path.components();
     matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
 }
@@ -77,7 +82,7 @@ fn classify_child_exec(child_exec: &str) -> ChildExecKind {
     let path = Path::new(child_exec);
     let first = path.components().next();
 
-    if is_bare_command(path) {
+    if is_bare_command(child_exec, path) {
         return ChildExecKind::BareCommand;
     }
 
@@ -96,8 +101,10 @@ fn classify_child_exec(child_exec: &str) -> ChildExecKind {
 }
 
 /// 解析 agent 可执行入口路径：
-/// - 相对路径型 child_exec -> 基于 cwd 计算
-/// - 裸命令名/绝对路径 -> 保持原样
+/// - 空字符串 child_exec -> 原样返回（不拼接 cwd、不做规范化）
+/// - 裸命令名（如 `python` / `node`）-> 原样返回，由系统 PATH 解析
+/// - 相对路径型 child_exec -> 先基于 cwd 拼接，再通过 `normalize_path` 规范化
+/// - 绝对路径 / 带盘符前缀路径 -> 不拼接 cwd，但会通过 `normalize_path` 规范化
 fn resolve_child_exec_path(child_exec: &str, cwd: &str) -> PathBuf {
     match classify_child_exec(child_exec) {
         // 空字符串由上层提前校验；这里保守返回原值，避免误拼 cwd。


### PR DESCRIPTION
- child_exec 为裸命令名时（如 python）不再拼接 cwd，改为走 PATH
- 仅对路径型 child_exec 基于 cwd 解析
- 保留 normalize_path 的路径规范化处理

## Sourcery 总结

修复代理子进程的执行方式：使裸命令名称使用系统 PATH，而只有类似路径的值才会相对于当前工作目录（cwd）进行解析。

错误修复：
- 确保裸的 `child_exec` 命令名（例如 `python`、`node`）不再被错误地加上 cwd 前缀，而是依赖系统 PATH 进行解析。
- 避免将绝对路径、以根目录为基础的路径或带盘符前缀的 `child_exec` 值相对于 cwd 进行解析，同时仍然对执行路径进行规范化处理。
- 通过在创建进程之前对空值进行校验并抛出错误，防止在 `child_exec` 为空时启动代理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix agent child process execution so bare command names use the system PATH while only path-like values are resolved relative to cwd.

Bug Fixes:
- Ensure bare child_exec command names (e.g. python, node) are no longer incorrectly prefixed with cwd and instead rely on system PATH resolution.
- Avoid resolving absolute, root-based, or drive-prefixed child_exec values against cwd while still normalizing execution paths.
- Prevent spawning an agent with an empty child_exec by validating and erroring on empty values before process creation.

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修复代理子进程的执行方式：使裸命令名称使用系统 PATH，而只有类似路径的值才会相对于当前工作目录（cwd）进行解析。

错误修复：
- 确保裸的 `child_exec` 命令名（例如 `python`、`node`）不再被错误地加上 cwd 前缀，而是依赖系统 PATH 进行解析。
- 避免将绝对路径、以根目录为基础的路径或带盘符前缀的 `child_exec` 值相对于 cwd 进行解析，同时仍然对执行路径进行规范化处理。
- 通过在创建进程之前对空值进行校验并抛出错误，防止在 `child_exec` 为空时启动代理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix agent child process execution so bare command names use the system PATH while only path-like values are resolved relative to cwd.

Bug Fixes:
- Ensure bare child_exec command names (e.g. python, node) are no longer incorrectly prefixed with cwd and instead rely on system PATH resolution.
- Avoid resolving absolute, root-based, or drive-prefixed child_exec values against cwd while still normalizing execution paths.
- Prevent spawning an agent with an empty child_exec by validating and erroring on empty values before process creation.

</details>

</details>

Bug 修复：
- 确保裸的 `child_exec` 命令名（例如 `python`、`node`）通过系统 `PATH` 进行解析，而不是与 `cwd` 进行拼接。
- 仅对表示相对路径的 `child_exec` 值基于 `cwd` 进行解析，同时对所有执行路径继续保留 `normalize_path` 的处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修复代理子进程的执行方式：使裸命令名称使用系统 PATH，而只有类似路径的值才会相对于当前工作目录（cwd）进行解析。

错误修复：
- 确保裸的 `child_exec` 命令名（例如 `python`、`node`）不再被错误地加上 cwd 前缀，而是依赖系统 PATH 进行解析。
- 避免将绝对路径、以根目录为基础的路径或带盘符前缀的 `child_exec` 值相对于 cwd 进行解析，同时仍然对执行路径进行规范化处理。
- 通过在创建进程之前对空值进行校验并抛出错误，防止在 `child_exec` 为空时启动代理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix agent child process execution so bare command names use the system PATH while only path-like values are resolved relative to cwd.

Bug Fixes:
- Ensure bare child_exec command names (e.g. python, node) are no longer incorrectly prefixed with cwd and instead rely on system PATH resolution.
- Avoid resolving absolute, root-based, or drive-prefixed child_exec values against cwd while still normalizing execution paths.
- Prevent spawning an agent with an empty child_exec by validating and erroring on empty values before process creation.

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修复代理子进程的执行方式：使裸命令名称使用系统 PATH，而只有类似路径的值才会相对于当前工作目录（cwd）进行解析。

错误修复：
- 确保裸的 `child_exec` 命令名（例如 `python`、`node`）不再被错误地加上 cwd 前缀，而是依赖系统 PATH 进行解析。
- 避免将绝对路径、以根目录为基础的路径或带盘符前缀的 `child_exec` 值相对于 cwd 进行解析，同时仍然对执行路径进行规范化处理。
- 通过在创建进程之前对空值进行校验并抛出错误，防止在 `child_exec` 为空时启动代理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix agent child process execution so bare command names use the system PATH while only path-like values are resolved relative to cwd.

Bug Fixes:
- Ensure bare child_exec command names (e.g. python, node) are no longer incorrectly prefixed with cwd and instead rely on system PATH resolution.
- Avoid resolving absolute, root-based, or drive-prefixed child_exec values against cwd while still normalizing execution paths.
- Prevent spawning an agent with an empty child_exec by validating and erroring on empty values before process creation.

</details>

</details>

</details>