### PR TITLE
chore: do not off screen on Wayland

### DIFF
--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -719,7 +719,7 @@ fn execute_power_screenoff() -> bool {
         if let Ok(value) = env::var("XDG_SESSION_TYPE") {
             if value == "wayland" {
                 log::error!("[MXU_POWER] Screen off on Wayland is not available");
-                false
+                return false;
             }
         }
         match Command::new("xset").args(["dpms", "force", "off"]).spawn() {


### PR DESCRIPTION
由于 Wayland 下还没有统一的合成器协议或 API 接口用于通过 DPMS 关闭屏幕，因此暂时使 screenoff 在 Wayland 平台上直接失败。

## Summary by Sourcery

错误修复：
- 阻止在不支持基于 DPMS 的屏幕电源控制的 Wayland 会话中执行关闭屏幕操作，改为记录错误日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent screen-off action from running on Wayland sessions where DPMS-based screen power control is not available, logging an error instead.

</details>