### PR TITLE
feat: 支持命令行参数-i指定启动实例名称

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -536,9 +536,12 @@ pub fn is_autostart() -> bool {
     std::env::args().any(|arg| arg == "--autostart")
 }
 
-/// 从命令行参数中获取指定选项的值（支持 `-x value` 和 `--name value` 格式）
+/// 从命令行参数中获取指定选项的值
+/// 支持 `-x value`、`--name value`、`-x=value`、`--name=value` 格式
 /// 返回第一个匹配的值；若值缺失或以 `-` 开头则视为无效并跳过
 fn get_cli_arg_value(short: &str, long: &str) -> Option<String> {
+    let short_eq = format!("{}=", short);
+    let long_eq = format!("{}=", long);
     let args: Vec<String> = std::env::args().collect();
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
@@ -550,6 +553,12 @@ fn get_cli_arg_value(short: &str, long: &str) -> Option<String> {
             }
             return None;
         }
+        if let Some(value) = arg.strip_prefix(&short_eq) {
+            return Some(value.to_string());
+        }
+        if let Some(value) = arg.strip_prefix(&long_eq) {
+            return Some(value.to_string());
+        }
     }
     None
 }
@@ -560,10 +569,10 @@ pub fn get_start_instance() -> Option<String> {
     get_cli_arg_value("-i", "--instance")
 }
 
-/// 检查命令行是否包含 -k/--kill 参数（任务完成后关闭自身）
+/// 检查命令行是否包含 -q/--quit-after-run 参数（任务完成后关闭自身）
 #[tauri::command]
-pub fn has_close_flag() -> bool {
-    std::env::args().any(|arg| arg == "-k" || arg == "--kill")
+pub fn has_quit_after_run_flag() -> bool {
+    std::env::args().any(|arg| arg == "-q" || arg == "--quit-after-run")
 }
 
 /// 自动迁移旧版注册表自启动到任务计划程序

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,7 +175,7 @@ pub fn run() {
             commands::system::is_elevated,
             commands::system::is_autostart,
             commands::system::get_start_instance,
-            commands::system::has_close_flag,
+            commands::system::has_quit_after_run_flag,
             commands::system::restart_as_admin,
             commands::system::maa_set_save_draw,
             commands::system::open_file,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -647,10 +647,10 @@ function App() {
               log.info(`${source}：激活配置并启动任务:`, targetInstance.name);
               useAppStore.getState().setActiveInstance(targetInstanceId);
 
-              // 检查 -k/--kill 参数：任务完成后关闭自身
-              const hasClose = await invoke<boolean>('has_close_flag');
-              if (hasClose) {
-                log.info('命令行 --close 参数：任务完成后将关闭自身');
+              // 检查 -q/--quit-after-run 参数：任务完成后关闭自身
+              const shouldQuit = await invoke<boolean>('has_quit_after_run_flag');
+              if (shouldQuit) {
+                log.info('命令行 --quit-after-run 参数：任务完成后将关闭自身');
                 const unsub = useAppStore.subscribe(
                   (state) => state.instances.find((i) => i.id === targetInstanceId)?.isRunning,
                   (isRunning, prevIsRunning) => {


### PR DESCRIPTION
## Summary by Sourcery

通过新增命令行参数来支持选择要自动启动的实例，并将其集成到应用的自动启动流程中。

新功能：
- 添加一个 Tauri 命令，用于读取自动启动模式下用于指定启动实例名称的 `-i/--instance` CLI 参数。
- 允许前端的自动启动逻辑在启动时优先采用 CLI 指定的实例，而不是已配置的默认自动启动实例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support selecting which instance to auto-start via a new command-line argument and integrate it into the app's autostart flow.

New Features:
- Add a Tauri command to read the -i/--instance CLI argument specifying the desired startup instance name in autostart mode.
- Allow the frontend autostart logic to prioritize the CLI-specified instance over the configured default auto-start instance when launching.

</details>