### PR TITLE
fix: 修复 PI_CLIENT_MAAFW_VERSION 未注入

### DIFF
--- a/src/services/maaService.ts
+++ b/src/services/maaService.ts
@@ -18,6 +18,15 @@ import { isTauri } from '@/utils/paths';
 
 const log = loggers.maa;
 
+async function syncMaaVersionToStore(version: string): Promise<void> {
+  try {
+    const { useAppStore } = await import('@/stores/appStore');
+    useAppStore.getState().setMaaInitialized(true, version);
+  } catch (err) {
+    log.debug('同步 MaaFramework 版本到 store 失败:', err);
+  }
+}
+
 /** MaaFramework 回调事件载荷 */
 export interface MaaCallbackEvent {
   /** 消息类型，如 "Resource.Loading.Succeeded", "Controller.Action.Succeeded", "Tasker.Task.Succeeded" */
@@ -51,6 +60,7 @@ export const maaService = {
   async init(libDir?: string): Promise<string> {
     log.info('初始化 MaaFramework, libDir:', libDir || '(默认)');
     const version = await invoke<string>('maa_init', { libDir: libDir || null });
+    await syncMaaVersionToStore(version);
     log.info('MaaFramework 版本:', version);
     return version;
   },
@@ -72,6 +82,7 @@ export const maaService = {
   async getVersion(): Promise<string> {
     log.debug('获取 MaaFramework 版本...');
     const version = await invoke<string>('maa_get_version');
+    await syncMaaVersionToStore(version);
     log.info('MaaFramework 版本:', version);
     return version;
   },


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在初始化和获取版本时，将 MaaFramework 版本注入到应用程序存储中，以便 `PI_CLIENT_MAAFW_VERSION` 能被正确传递。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Inject the MaaFramework version into the application store during initialization and version retrieval so PI_CLIENT_MAAFW_VERSION is correctly propagated.

</details>