### PR TITLE
revert: "refactor: use winsafe"

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2559,7 +2559,7 @@ dependencies = [
  "tauri-plugin-process",
  "tokio",
  "urlencoding",
- "winsafe",
+ "windows 0.58.0",
  "zip",
 ]
 
@@ -4590,7 +4590,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4679,7 +4679,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4895,7 +4895,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.17",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -4931,7 +4931,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4957,7 +4957,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5018,7 +5018,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
  "thiserror 2.0.17",
- "windows",
+ "windows 0.61.3",
  "windows-version",
 ]
 
@@ -5790,10 +5790,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -5814,7 +5814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.17",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5866,6 +5866,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5888,12 +5898,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -5905,8 +5928,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -5925,9 +5948,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5980,6 +6025,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -5994,6 +6048,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6301,11 +6365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winsafe"
-version = "0.0.27"
-source = "git+https://github.com/rodrigocfd/winsafe.git?rev=7e82b1c7082cc24620f5a73c17c7bd8b682d37f3#7e82b1c7082cc24620f5a73c17c7bd8b682d37f3"
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6356,7 +6415,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,12 +53,16 @@ maa-framework = { version = "1", features = ["dynamic"] }
 debug = true
 
 [target.'cfg(windows)'.dependencies]
-# FIXME: winsafe new release
-winsafe = { git = "https://github.com/rodrigocfd/winsafe.git", rev = "7e82b1c7082cc24620f5a73c17c7bd8b682d37f3", features = [
-    "advapi",
-    "kernel",
-    "shell",
-    "gui",
-    "gdi",
-    "user"
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_Security",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Registry",
+    "Win32_System_SystemInformation",
+    "Win32_System_Threading",
+    "Win32_UI_Controls",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
 ] }

--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -94,16 +94,28 @@ pub fn maa_init(state: State<Arc<MaaState>>, lib_dir: Option<String>) -> Result<
     // Windows: 将 lib_dir 添加到 DLL 搜索路径，确保依赖 DLL 能被找到
     #[cfg(windows)]
     {
+        use std::os::windows::ffi::OsStrExt;
+        #[link(name = "kernel32")]
+        extern "system" {
+            fn SetDllDirectoryW(path: *const u16) -> i32;
+        }
+
         let dll_dir = if lib_path.is_file() {
             lib_path.parent().unwrap_or(&lib_path)
         } else {
             &lib_path
         };
 
-        debug!("SetDllDirectoryW set to {:?}", dll_dir);
-        let result = winsafe::SetDllDirectory(Some(&dll_dir.to_string_lossy()));
-        if result.is_err() {
+        let wide_path: Vec<u16> = dll_dir
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let result = unsafe { SetDllDirectoryW(wide_path.as_ptr()) };
+        if result == 0 {
             warn!("SetDllDirectoryW failed");
+        } else {
+            debug!("SetDllDirectoryW set to {:?}", dll_dir);
         }
     }
 

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -2,11 +2,12 @@
 //!
 //! 提供权限检查、系统信息查询、全局选项设置等功能
 
+use log::{info, warn};
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use super::types::SystemInfo;
 use super::types::WebView2DirInfo;
 use super::utils::get_maafw_dir;
-use log::{info, warn};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
@@ -24,18 +25,38 @@ pub fn set_vcredist_missing(missing: bool) {
 pub fn is_elevated() -> bool {
     #[cfg(windows)]
     {
-        use winsafe::co::{TOKEN, TOKEN_INFORMATION_CLASS};
-        use winsafe::{TokenInfo, HPROCESS};
+        use std::ptr;
+        use windows::Win32::Foundation::{CloseHandle, HANDLE};
+        use windows::Win32::Security::{
+            GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+        };
+        use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
-        if let Ok(token_handle) = HPROCESS::GetCurrentProcess().OpenProcessToken(TOKEN::QUERY) {
-            let result = token_handle.GetTokenInformation(TOKEN_INFORMATION_CLASS::Elevation);
-            if let Ok(TokenInfo::Elevation(elevation)) = result {
-                elevation.TokenIsElevated()
+        unsafe {
+            let mut token_handle: HANDLE = HANDLE::default();
+            if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token_handle).is_err() {
+                return false;
+            }
+
+            let mut elevation = TOKEN_ELEVATION::default();
+            let mut return_length: u32 = 0;
+            let size = std::mem::size_of::<TOKEN_ELEVATION>() as u32;
+
+            let result = GetTokenInformation(
+                token_handle,
+                TokenElevation,
+                Some(ptr::addr_of_mut!(elevation) as *mut _),
+                size,
+                &mut return_length,
+            );
+
+            let _ = CloseHandle(token_handle);
+
+            if result.is_ok() {
+                elevation.TokenIsElevated != 0
             } else {
                 false
             }
-        } else {
-            false
         }
     }
 
@@ -51,30 +72,49 @@ pub fn is_elevated() -> bool {
 pub fn restart_as_admin(app_handle: tauri::AppHandle) -> Result<(), String> {
     #[cfg(windows)]
     {
-        use winsafe::co::SW;
-        use winsafe::{ShellExecuteEx, SHELLEXECUTEINFO};
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+        use windows::core::PCWSTR;
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::UI::Shell::ShellExecuteW;
+        use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
         let exe_path = std::env::current_exe().map_err(|e| format!("获取程序路径失败: {}", e))?;
 
         let exe_path_str = exe_path.to_string_lossy().to_string();
 
+        // 将字符串转换为 Windows 宽字符
+        fn to_wide(s: &str) -> Vec<u16> {
+            OsStr::new(s).encode_wide().chain(Some(0)).collect()
+        }
+
+        let operation = to_wide("runas");
+        let file = to_wide(&exe_path_str);
+
         info!("restart_as_admin: restarting with admin privileges");
 
-        let result = ShellExecuteEx(&SHELLEXECUTEINFO {
-            file: &exe_path_str,
-            verb: Option::from("runas"),
-            show: SW::SHOWNORMAL,
-            ..Default::default()
-        });
+        unsafe {
+            let result = ShellExecuteW(
+                HWND::default(),
+                PCWSTR::from_raw(operation.as_ptr()),
+                PCWSTR::from_raw(file.as_ptr()),
+                PCWSTR::null(), // 无参数
+                PCWSTR::null(), // 使用当前目录
+                SW_SHOWNORMAL,
+            );
 
-        // ShellExecuteEx 返回 Result：Ok 表示成功，Err 表示失败
-        if let Err(e) = result {
-            Err(format!("以管理员身份启动失败: 错误码 {}", e.raw()))
-        } else {
-            info!("restart_as_admin: new process started, exiting current");
-            // 退出当前进程
-            app_handle.exit(0);
-            Ok(())
+            // ShellExecuteW 返回值 > 32 表示成功
+            if result.0 as usize > 32 {
+                info!("restart_as_admin: new process started, exiting current");
+                // 退出当前进程
+                app_handle.exit(0);
+                Ok(())
+            } else {
+                Err(format!(
+                    "以管理员身份启动失败: 错误码 {}",
+                    result.0 as usize
+                ))
+            }
         }
     }
 
@@ -186,55 +226,112 @@ pub fn check_process_running(program: &str) -> bool {
 
     #[cfg(windows)]
     {
-        use winsafe::co::{PROCESS, PROCESS_NAME, TH32CS};
-        use winsafe::{HPROCESS, HPROCESSLIST};
+        use windows::Win32::Foundation::CloseHandle;
+        use windows::Win32::System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+            TH32CS_SNAPPROCESS,
+        };
+        use windows::Win32::System::Threading::{
+            OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
+            PROCESS_QUERY_LIMITED_INFORMATION,
+        };
 
         let file_name_lower = file_name.to_lowercase();
-        let target_lower = canonical_target.to_string_lossy().to_lowercase();
 
-        let mut snapshot = match HPROCESSLIST::CreateToolhelp32Snapshot(TH32CS::SNAPPROCESS, None) {
-            Ok(h) => h,
-            Err(e) => {
-                log::error!(
-                    "check_process_running: CreateToolhelp32Snapshot failed: {}",
-                    e
+        /// 动态扩容获取进程完整路径，处理长路径（>MAX_PATH）场景
+        unsafe fn query_process_image_path(
+            process: windows::Win32::Foundation::HANDLE,
+        ) -> Option<String> {
+            let mut capacity: u32 = 512;
+            loop {
+                let mut buf = vec![0u16; capacity as usize];
+                let mut size = capacity;
+                let result = QueryFullProcessImageNameW(
+                    process,
+                    PROCESS_NAME_FORMAT(0),
+                    windows::core::PWSTR(buf.as_mut_ptr()),
+                    &mut size,
                 );
-                return false;
-            }
-        };
-        for process_result in snapshot.iter_processes() {
-            if let Ok(entry) = process_result {
-                if entry.szExeFile().to_lowercase() == file_name_lower {
-                    if let Ok(process) = HPROCESS::OpenProcess(
-                        PROCESS::QUERY_LIMITED_INFORMATION,
-                        false,
-                        entry.th32ProcessID,
-                    ) {
-                        if let Ok(running_path) =
-                            process.QueryFullProcessImageName(PROCESS_NAME::WIN32)
-                        {
-                            let running_canonical = PathBuf::from(&running_path)
-                                .canonicalize()
-                                .map(|p| p.to_string_lossy().to_lowercase())
-                                .unwrap_or_else(|_| running_path.to_lowercase());
-
-                            if running_canonical == target_lower {
-                                info!(
-                                    "check_process_running: '{}' -> true (matched: {})",
-                                    program, running_path
-                                );
-                                return true;
-                            }
-                        }
-                    }
+                if result.is_ok() {
+                    return Some(String::from_utf16_lossy(&buf[..size as usize]));
                 }
-            } else {
-                break;
+                // ERROR_INSUFFICIENT_BUFFER 对应 HRESULT 0x8007007A，仅此错误时扩容重试
+                let err = windows::core::Error::from_win32();
+                if err.code().0 as u32 != 0x8007007A || capacity >= 32768 {
+                    // 非缓冲区不足错误或已达上限，放弃
+                    return None;
+                }
+                capacity *= 2;
             }
         }
 
-        info!("check_process_running: '{}' -> false", program);
-        false
+        unsafe {
+            let snapshot = match CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) {
+                Ok(h) => h,
+                Err(e) => {
+                    log::error!(
+                        "check_process_running: CreateToolhelp32Snapshot failed: {}",
+                        e
+                    );
+                    return false;
+                }
+            };
+
+            let mut entry = PROCESSENTRY32W {
+                dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+                ..Default::default()
+            };
+
+            let target_lower = canonical_target.to_string_lossy().to_lowercase();
+
+            if Process32FirstW(snapshot, &mut entry).is_ok() {
+                loop {
+                    // 从 szExeFile (UTF-16) 提取进程名
+                    let len = entry
+                        .szExeFile
+                        .iter()
+                        .position(|&c| c == 0)
+                        .unwrap_or(entry.szExeFile.len());
+                    let exe_name = String::from_utf16_lossy(&entry.szExeFile[..len]).to_lowercase();
+
+                    // 先按文件名筛选
+                    if exe_name == file_name_lower {
+                        // 尝试获取完整路径
+                        if let Ok(process) = OpenProcess(
+                            PROCESS_QUERY_LIMITED_INFORMATION,
+                            false,
+                            entry.th32ProcessID,
+                        ) {
+                            if let Some(running_path) = query_process_image_path(process) {
+                                let running_canonical = PathBuf::from(&running_path)
+                                    .canonicalize()
+                                    .map(|p| p.to_string_lossy().to_lowercase())
+                                    .unwrap_or_else(|_| running_path.to_lowercase());
+
+                                if running_canonical == target_lower {
+                                    let _ = CloseHandle(process);
+                                    let _ = CloseHandle(snapshot);
+                                    info!(
+                                        "check_process_running: '{}' -> true (matched: {})",
+                                        program, running_path
+                                    );
+                                    return true;
+                                }
+                            }
+                            let _ = CloseHandle(process);
+                        }
+                    }
+
+                    if Process32NextW(snapshot, &mut entry).is_err() {
+                        break;
+                    }
+                }
+            }
+
+            let _ = CloseHandle(snapshot);
+            info!("check_process_running: '{}' -> false", program);
+            false
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -497,6 +594,13 @@ pub fn migrate_legacy_autostart() {
 }
 
 #[cfg(windows)]
+fn to_wide(s: &str) -> Vec<u16> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    OsStr::new(s).encode_wide().chain(Some(0)).collect()
+}
+
+#[cfg(windows)]
 fn create_schtask_autostart() -> Result<(), String> {
     use std::os::windows::process::CommandExt;
     let exe_path = std::env::current_exe().map_err(|e| format!("获取程序路径失败: {}", e))?;
@@ -571,18 +675,26 @@ fn schtask_autostart_needs_refresh() -> bool {
 /// 清理旧版注册表自启动条目（tauri-plugin-autostart 遗留）
 #[cfg(windows)]
 fn remove_legacy_registry_autostart() {
-    use winsafe::co::{KEY, REG_OPTION};
-    use winsafe::HKEY;
+    use windows::core::PCWSTR;
+    use windows::Win32::System::Registry::*;
 
-    let key_result = HKEY::CURRENT_USER.RegOpenKeyEx(
-        Some(r"Software\Microsoft\Windows\CurrentVersion\Run"),
-        REG_OPTION::NoValue,
-        KEY::SET_VALUE | KEY::QUERY_VALUE,
-    );
-
-    if let Ok(key) = key_result {
-        for name in &["mxu", "MXU"] {
-            let _ = key.RegDeleteValue(Some(name));
+    unsafe {
+        let subkey = to_wide(r"Software\Microsoft\Windows\CurrentVersion\Run");
+        let mut hkey = HKEY::default();
+        if RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            PCWSTR(subkey.as_ptr()),
+            0,
+            KEY_SET_VALUE | KEY_QUERY_VALUE,
+            &mut hkey,
+        )
+        .is_ok()
+        {
+            for name in &["mxu", "MXU"] {
+                let wname = to_wide(name);
+                let _ = RegDeleteValueW(hkey, PCWSTR(wname.as_ptr()));
+            }
+            let _ = RegCloseKey(hkey);
         }
     }
 }
@@ -590,20 +702,29 @@ fn remove_legacy_registry_autostart() {
 /// 检查旧版注册表中是否存在自启动条目
 #[cfg(windows)]
 fn has_legacy_registry_autostart() -> bool {
-    use winsafe::co::{KEY, REG_OPTION};
-    use winsafe::HKEY;
+    use windows::core::PCWSTR;
+    use windows::Win32::System::Registry::*;
 
-    let key_result = HKEY::CURRENT_USER.RegOpenKeyEx(
-        Some(r"Software\Microsoft\Windows\CurrentVersion\Run"),
-        REG_OPTION::NoValue,
-        KEY::QUERY_VALUE,
-    );
-    if let Ok(key) = key_result {
-        ["mxu", "MXU"]
-            .iter()
-            .any(|name| key.RegQueryValueEx(Some(name)).is_ok())
-    } else {
-        false
+    unsafe {
+        let subkey = to_wide(r"Software\Microsoft\Windows\CurrentVersion\Run");
+        let mut hkey = HKEY::default();
+        if RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            PCWSTR(subkey.as_ptr()),
+            0,
+            KEY_QUERY_VALUE,
+            &mut hkey,
+        )
+        .is_err()
+        {
+            return false;
+        }
+        let found = ["mxu", "MXU"].iter().any(|name| {
+            let wname = to_wide(name);
+            RegQueryValueExW(hkey, PCWSTR(wname.as_ptr()), None, None, None, None).is_ok()
+        });
+        let _ = RegCloseKey(hkey);
+        found
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -39,9 +39,16 @@ fn main() {
         }
 
         // 启动时自动请求管理员权限：如果当前不是管理员，则自提权重启并退出当前进程
-        // 说明：用户在 UAC 对话框中取消时，ShellExecuteEx 会返回 Err，此时继续以普通权限启动。
+        // 说明：用户取消 UAC 时 ShellExecuteW 会失败，此时继续以普通权限启动。
         // 调试模式下不请求管理员权限，方便开发调试
         if !cfg!(debug_assertions) && !mxu_lib::commands::system::is_elevated() {
+            use std::ffi::OsStr;
+            use std::os::windows::ffi::OsStrExt;
+            use windows::core::PCWSTR;
+            use windows::Win32::Foundation::HWND;
+            use windows::Win32::UI::Shell::ShellExecuteW;
+            use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
             let exe_path = match std::env::current_exe() {
                 Ok(p) => p,
                 Err(_) => {
@@ -51,19 +58,27 @@ fn main() {
                 }
             };
 
-            use winsafe::co::SW;
-            use winsafe::{ShellExecuteEx, SHELLEXECUTEINFO};
+            fn to_wide(s: &str) -> Vec<u16> {
+                OsStr::new(s).encode_wide().chain(Some(0)).collect()
+            }
 
-            let result = ShellExecuteEx(&SHELLEXECUTEINFO {
-                file: &exe_path.to_string_lossy(),
-                verb: Option::from("runas"),
-                show: SW::SHOWNORMAL,
-                ..Default::default()
-            });
+            let operation = to_wide("runas");
+            let file = to_wide(&exe_path.to_string_lossy());
 
-            if result.is_ok() {
-                // 新的管理员进程已启动，退出当前普通权限进程
-                std::process::exit(0);
+            unsafe {
+                let result = ShellExecuteW(
+                    HWND::default(),
+                    PCWSTR::from_raw(operation.as_ptr()),
+                    PCWSTR::from_raw(file.as_ptr()),
+                    PCWSTR::null(),
+                    PCWSTR::null(),
+                    SW_SHOWNORMAL,
+                );
+
+                if result.0 as usize > 32 {
+                    // 新的管理员进程已启动，退出当前普通权限进程
+                    std::process::exit(0);
+                }
             }
         }
     }

--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -691,16 +691,20 @@ fn execute_power_restart() -> bool {
 fn execute_power_screenoff() -> bool {
     #[cfg(windows)]
     {
-        use winsafe::co::SC;
-        use winsafe::msg::wm;
-        use winsafe::{HWND, POINT};
-        unsafe {
-            // NOTE: POINT::from(2) is equal to LPARAM(2)
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::UI::WindowsAndMessaging::SendMessageW;
 
-            HWND::BROADCAST.SendMessage(wm::SysCommand {
-                request: SC::MONITORPOWER,
-                position: POINT::from(2),
-            });
+        // WM_SYSCOMMAND = 0x0112, SC_MONITORPOWER = 0xF170, LPARAM(2) = turn off
+        const WM_SYSCOMMAND: u32 = 0x0112;
+        const SC_MONITORPOWER: usize = 0xF170;
+
+        unsafe {
+            SendMessageW(
+                HWND(0xFFFF as *mut std::ffi::c_void), // HWND_BROADCAST
+                WM_SYSCOMMAND,
+                windows::Win32::Foundation::WPARAM(SC_MONITORPOWER),
+                windows::Win32::Foundation::LPARAM(2), // 2 = turn off monitor
+            );
         }
         info!("[MXU_POWER] Screen off command issued (Windows)");
         true

--- a/src-tauri/src/webview2/detection.rs
+++ b/src-tauri/src/webview2/detection.rs
@@ -2,17 +2,38 @@
 
 use std::path::PathBuf;
 
-use winsafe::co::{KEY, REG_OPTION, RRF};
-use winsafe::{GetSystemDirectory, GetSystemWow64Directory, RegistryValue, HKEY};
+use super::to_wide;
+use windows::core::PCWSTR;
+use windows::Win32::System::Registry::{
+    RegCloseKey, RegGetValueW, RegOpenKeyExW, HKEY, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE,
+    KEY_READ, RRF_RT_REG_DWORD, RRF_RT_REG_SZ,
+};
+use windows::Win32::System::SystemInformation::{GetSystemDirectoryW, GetSystemWow64DirectoryW};
 
 /// 使用 Win32 API 获取系统目录路径
 fn get_system_directory() -> Option<PathBuf> {
-    GetSystemDirectory().map(PathBuf::from).ok()
+    let mut buffer = [0u16; 260];
+    let len = unsafe { GetSystemDirectoryW(Some(&mut buffer)) };
+    if len > 0 && (len as usize) < buffer.len() {
+        Some(PathBuf::from(String::from_utf16_lossy(
+            &buffer[..len as usize],
+        )))
+    } else {
+        None
+    }
 }
 
 /// 使用 Win32 API 获取 SysWOW64 目录路径
 fn get_system_wow64_directory() -> Option<PathBuf> {
-    GetSystemWow64Directory().map(PathBuf::from).ok()
+    let mut buffer = [0u16; 260];
+    let len = unsafe { GetSystemWow64DirectoryW(Some(&mut buffer)) };
+    if len > 0 && (len as usize) < buffer.len() {
+        Some(PathBuf::from(String::from_utf16_lossy(
+            &buffer[..len as usize],
+        )))
+    } else {
+        None
+    }
 }
 
 /// 检测 WebView2 是否已安装（注册表 + DLL 双重检测）
@@ -23,31 +44,64 @@ fn get_system_wow64_directory() -> Option<PathBuf> {
 /// - pv 值必须存在且不为空、不为 "0.0.0.0"
 ///
 /// 参考: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-suitable-webview2-runtime-is-already-installed
+#[allow(unreachable_code)]
 pub fn is_webview2_installed() -> bool {
     // // 测试：强制视为未安装，以调试下载/安装流程。调试完请删除或注释下面这行。
     // return false;
 
     let registry_locations: &[(HKEY, &str)] = &[
         (
-            HKEY::LOCAL_MACHINE,
+            HKEY_LOCAL_MACHINE,
             r"SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
         ),
         (
-            HKEY::LOCAL_MACHINE,
+            HKEY_LOCAL_MACHINE,
             r"SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
         ),
         (
-            HKEY::CURRENT_USER,
+            HKEY_CURRENT_USER,
             r"Software\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
         ),
     ];
 
     let mut registry_found = false;
     for (root, path) in registry_locations {
-        let result = root.RegOpenKeyEx(Some(path), REG_OPTION::NoValue, KEY::READ);
-        if let Ok(hkey) = result {
-            let value_result = hkey.RegGetValue(None, Some("pv"), RRF::RT_REG_SZ);
-            if let Ok(RegistryValue::Sz(version)) = value_result {
+        let path_wide = to_wide(path);
+        let mut hkey: HKEY = HKEY::default();
+        let result = unsafe {
+            RegOpenKeyExW(
+                *root,
+                PCWSTR::from_raw(path_wide.as_ptr()),
+                0,
+                KEY_READ,
+                &mut hkey,
+            )
+        };
+        if result.is_ok() {
+            // 读取 pv (REG_SZ) 值，验证版本号有效
+            let pv_name = to_wide("pv");
+            let mut buffer = [0u16; 260];
+            let mut size = (buffer.len() * 2) as u32;
+
+            let value_result = unsafe {
+                RegGetValueW(
+                    hkey,
+                    PCWSTR::null(),
+                    PCWSTR::from_raw(pv_name.as_ptr()),
+                    RRF_RT_REG_SZ,
+                    None,
+                    Some(buffer.as_mut_ptr() as *mut _),
+                    Some(&mut size),
+                )
+            };
+
+            unsafe {
+                let _ = RegCloseKey(hkey);
+            }
+
+            if value_result.is_ok() {
+                let len = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+                let version = String::from_utf16_lossy(&buffer[..len]);
                 if !version.is_empty() && version != "0.0.0.0" {
                     registry_found = true;
                     break;
@@ -85,48 +139,90 @@ pub fn is_webview2_installed() -> bool {
 ///
 /// 返回 Some(reason) 如果被禁用，None 如果未被禁用
 pub fn is_webview2_disabled() -> Option<String> {
-    // // 测试：强制视为已禁用，以调试下载/安装流程。调试完请删除或注释下面这行。
-    // return Some("Test Disable".to_string());
-
     // 检查组策略禁用（通过 BrowserExecutableFolder 设置为特定值或空）
     // 参考: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-suitable-webview2-runtime-is-already-installed
 
     // 检查 HKCU 和 HKLM 下的策略设置
     let policy_paths = [
         (
-            HKEY::CURRENT_USER,
+            HKEY_CURRENT_USER,
             r"Software\Policies\Microsoft\Edge\WebView2",
         ),
         (
-            HKEY::LOCAL_MACHINE,
+            HKEY_LOCAL_MACHINE,
             r"Software\Policies\Microsoft\Edge\WebView2",
         ),
     ];
 
     for (root, path) in &policy_paths {
-        let result = root.RegOpenKeyEx(Some(path), REG_OPTION::NoValue, KEY::READ);
+        let path_wide = to_wide(path);
+        let mut hkey: HKEY = HKEY::default();
+        let result = unsafe {
+            RegOpenKeyExW(
+                *root,
+                PCWSTR::from_raw(path_wide.as_ptr()),
+                0,
+                KEY_READ,
+                &mut hkey,
+            )
+        };
 
-        if let Ok(hkey) = result {
+        if result.is_ok() {
             // 检查 BrowserExecutableFolder 值 - 如果设置为空字符串，表示禁用
-            let value_result =
-                hkey.RegGetValue(None, Some("BrowserExecutableFolder"), RRF::RT_REG_SZ);
+            let value_name = to_wide("BrowserExecutableFolder");
+            let mut buffer = [0u16; 260];
+            let mut size = (buffer.len() * 2) as u32;
 
-            if let Ok(RegistryValue::Sz(value)) = value_result {
+            let value_result = unsafe {
+                RegGetValueW(
+                    hkey,
+                    PCWSTR::null(),
+                    PCWSTR::from_raw(value_name.as_ptr()),
+                    RRF_RT_REG_SZ,
+                    None,
+                    Some(buffer.as_mut_ptr() as *mut _),
+                    Some(&mut size),
+                )
+            };
+
+            if value_result.is_ok() {
+                // 找到 null 终止符的位置
+                let len = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+                let value = String::from_utf16_lossy(&buffer[..len]);
+
                 // 如果值为空字符串，表示通过策略禁用了 WebView2
                 if value.is_empty() {
+                    unsafe {
+                        let _ = RegCloseKey(hkey);
+                    }
                     return Some("通过组策略禁用 (BrowserExecutableFolder 为空)".to_string());
                 }
             }
 
             // 检查 ReleaseChannelPreference 或其他禁用标志
-            let dword_result =
-                hkey.RegGetValue(None, Some("ReleaseChannelPreference"), RRF::RT_REG_DWORD);
+            let release_channel = to_wide("ReleaseChannelPreference");
+            let mut dword_value: u32 = 0;
+            let mut dword_size = std::mem::size_of::<u32>() as u32;
+
+            let dword_result = unsafe {
+                RegGetValueW(
+                    hkey,
+                    PCWSTR::null(),
+                    PCWSTR::from_raw(release_channel.as_ptr()),
+                    RRF_RT_REG_DWORD,
+                    None,
+                    Some(&mut dword_value as *mut u32 as *mut _),
+                    Some(&mut dword_size),
+                )
+            };
 
             // 值为 0 可能表示禁用了 Evergreen WebView2
-            if let Ok(RegistryValue::Dword(dword_value)) = dword_result {
-                if dword_value == 0 {
-                    // 这不一定表示完全禁用，只是偏好设置，继续检查其他项
-                }
+            if dword_result.is_ok() && dword_value == 0 {
+                // 这不一定表示完全禁用，只是偏好设置，继续检查其他项
+            }
+
+            unsafe {
+                let _ = RegCloseKey(hkey);
             }
         }
     }
@@ -134,21 +230,47 @@ pub fn is_webview2_disabled() -> Option<String> {
     // 检查 Windows 功能中 WebView2 是否被禁用
     // 通过检查 Windows 可选功能状态
     let feature_paths = [(
-        HKEY::LOCAL_MACHINE,
+        HKEY_LOCAL_MACHINE,
         r"SOFTWARE\Policies\Microsoft\EdgeWebView",
     )];
 
     for (root, path) in &feature_paths {
-        let result = root.RegOpenKeyEx(Some(path), REG_OPTION::NoValue, KEY::READ);
+        let path_wide = to_wide(path);
+        let mut hkey: HKEY = HKEY::default();
+        let result = unsafe {
+            RegOpenKeyExW(
+                *root,
+                PCWSTR::from_raw(path_wide.as_ptr()),
+                0,
+                KEY_READ,
+                &mut hkey,
+            )
+        };
 
-        if let Ok(hkey) = result {
+        if result.is_ok() {
             // 检查 Enabled 值
-            let value_result = hkey.RegGetValue(None, Some("Enabled"), RRF::RT_REG_DWORD);
+            let enabled_name = to_wide("Enabled");
+            let mut dword_value: u32 = 1;
+            let mut dword_size = std::mem::size_of::<u32>() as u32;
 
-            if let Ok(RegistryValue::Dword(dword_value)) = value_result {
-                if dword_value == 0 {
-                    return Some("WebView2 已被组策略禁用".to_string());
-                }
+            let value_result = unsafe {
+                RegGetValueW(
+                    hkey,
+                    PCWSTR::null(),
+                    PCWSTR::from_raw(enabled_name.as_ptr()),
+                    RRF_RT_REG_DWORD,
+                    None,
+                    Some(&mut dword_value as *mut u32 as *mut _),
+                    Some(&mut dword_size),
+                )
+            };
+
+            unsafe {
+                let _ = RegCloseKey(hkey);
+            }
+
+            if value_result.is_ok() && dword_value == 0 {
+                return Some("WebView2 已被组策略禁用".to_string());
             }
         }
     }
@@ -164,17 +286,47 @@ pub fn is_webview2_disabled() -> Option<String> {
             r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\{}",
             exe_name
         );
-        let result =
-            HKEY::LOCAL_MACHINE.RegOpenKeyEx(Some(&ifeo_path), REG_OPTION::NoValue, KEY::READ);
+        let path_wide = to_wide(&ifeo_path);
+        let mut hkey: HKEY = HKEY::default();
+        let result = unsafe {
+            RegOpenKeyExW(
+                HKEY_LOCAL_MACHINE,
+                PCWSTR::from_raw(path_wide.as_ptr()),
+                0,
+                KEY_READ,
+                &mut hkey,
+            )
+        };
 
-        if let Ok(hkey) = result {
+        if result.is_ok() {
             // 检查是否存在 Debugger 值（用于阻止进程启动）
-            let value_result = hkey.RegGetValue(None, Some("Debugger"), RRF::RT_REG_SZ);
+            let debugger_name = to_wide("Debugger");
+            let mut buffer = [0u16; 260];
+            let mut size = (buffer.len() * 2) as u32;
 
-            if let Ok(RegistryValue::Sz(debugger_value)) = value_result {
+            let value_result = unsafe {
+                RegGetValueW(
+                    hkey,
+                    PCWSTR::null(),
+                    PCWSTR::from_raw(debugger_name.as_ptr()),
+                    RRF_RT_REG_SZ,
+                    None,
+                    Some(buffer.as_mut_ptr() as *mut _),
+                    Some(&mut size),
+                )
+            };
+
+            unsafe {
+                let _ = RegCloseKey(hkey);
+            }
+
+            if value_result.is_ok() {
                 // 存在 Debugger 值，表示进程被 IFEO 拦截
+                let len = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+                let debugger_value = String::from_utf16_lossy(&buffer[..len]);
+
+                // 如果 Debugger 值不为空，说明被拦截了
                 if !debugger_value.is_empty() {
-                    // 如果 Debugger 值不为空，说明被拦截了
                     return Some(format!(
                         "{} 已被 IFEO 禁用\r\n(可能使用了 Edge Blocker 等工具)",
                         display_name

--- a/src-tauri/src/webview2/dialog.rs
+++ b/src-tauri/src/webview2/dialog.rs
@@ -1,18 +1,34 @@
 //! 原生 Win32 对话框（进度、成功、错误）
 
 use std::cell::RefCell;
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
-use winsafe::co::{BS, CS, ES, SS, WS, WS_EX};
-use winsafe::gui::{
-    Button, ButtonOpts, Edit, EditOpts, Label, LabelOpts, ProgressBar, ProgressBarOpts, WindowMain,
-    WindowMainOpts,
+use super::to_wide;
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::Graphics::Gdi::{
+    CreateFontIndirectW, DeleteObject, GetStockObject, GetSysColorBrush, UpdateWindow,
+    CLEARTYPE_QUALITY, COLOR_BTNFACE, DEFAULT_CHARSET, DEFAULT_GUI_FONT, HGDIOBJ, LOGFONTW,
 };
-use winsafe::prelude::GuiEventsWindow;
-use winsafe::prelude::GuiParent;
-use winsafe::prelude::{GuiEventsButton, GuiWindow};
-use winsafe::{AdjustWindowRectEx, PostQuitMessage, RECT};
+use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows::Win32::UI::Controls::{
+    InitCommonControlsEx, ICC_PROGRESS_CLASS, INITCOMMONCONTROLSEX, PBM_SETPOS, PBM_SETRANGE32,
+    PBS_SMOOTH, PROGRESS_CLASSW,
+};
+use windows::Win32::UI::WindowsAndMessaging::*;
+
+const SS_CENTER: u32 = 0x0001;
+const ES_MULTILINE: u32 = 0x0004;
+const ES_READONLY: u32 = 0x0800;
+const ES_AUTOVSCROLL: u32 = 0x0040;
+const ID_OK_BUTTON: u16 = 1001;
+
+const WM_UPDATE_PROGRESS: u32 = WM_USER + 1;
+const WM_UPDATE_STATUS: u32 = WM_USER + 2;
+const WM_DIALOG_CLOSE: u32 = WM_USER + 3;
 
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum DialogType {
@@ -24,10 +40,10 @@ pub(crate) enum DialogType {
 
 #[derive(Default)]
 struct DialogState {
-    progress_hwnd: Option<ProgressBar>,
-    status_hwnd: Option<Label>,
-    edit_hwnd: Option<Edit>,
-    button_hwnd: Option<Button>,
+    progress_hwnd: Option<HWND>,
+    status_hwnd: Option<HWND>,
+    button_hwnd: Option<HWND>,
+    hfont: Option<HGDIOBJ>,
     dialog_type: Option<DialogType>,
 }
 
@@ -37,7 +53,6 @@ impl DialogState {
         self.status_hwnd = None;
         self.button_hwnd = None;
         self.dialog_type = None;
-        self.edit_hwnd = None;
     }
 }
 
@@ -45,8 +60,112 @@ thread_local! {
     static DIALOG_STATE: RefCell<DialogState> = RefCell::new(DialogState::default());
 }
 
+unsafe extern "system" fn dialog_wnd_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    match msg {
+        WM_CREATE => LRESULT(0),
+        WM_UPDATE_PROGRESS => {
+            DIALOG_STATE.with(|s| {
+                if let Some(pb) = s.borrow().progress_hwnd {
+                    let _ = SendMessageW(pb, PBM_SETPOS, wparam, LPARAM(0));
+                }
+            });
+            LRESULT(0)
+        }
+        WM_UPDATE_STATUS => {
+            DIALOG_STATE.with(|s| {
+                if let Some(status) = s.borrow().status_hwnd {
+                    let text_ptr = lparam.0 as *const u16;
+                    let _ = SetWindowTextW(status, PCWSTR::from_raw(text_ptr));
+                }
+            });
+            LRESULT(0)
+        }
+        WM_COMMAND => {
+            let control_id = (wparam.0 & 0xFFFF) as u16;
+            if control_id == ID_OK_BUTTON {
+                PostQuitMessage(0);
+            }
+            LRESULT(0)
+        }
+        WM_CLOSE => {
+            // 用户点击 X 关闭窗口：进度对话框直接退出进程（此时 Tauri 尚未启动）
+            DIALOG_STATE.with(|s| {
+                if s.borrow().dialog_type == Some(DialogType::Progress) {
+                    std::process::exit(0);
+                }
+            });
+            PostQuitMessage(0);
+            LRESULT(0)
+        }
+        WM_DIALOG_CLOSE => {
+            PostQuitMessage(0);
+            LRESULT(0)
+        }
+        WM_DESTROY => {
+            DIALOG_STATE.with(|s| {
+                let mut g = s.borrow_mut();
+                if let Some(h) = g.hfont.take() {
+                    let _ = DeleteObject(h);
+                }
+                g.clear();
+            });
+            LRESULT(0)
+        }
+        _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+    }
+}
+
+fn center_window(hwnd: HWND, width: i32, height: i32) {
+    unsafe {
+        let screen_w = GetSystemMetrics(SM_CXSCREEN);
+        let screen_h = GetSystemMetrics(SM_CYSCREEN);
+        let _ = SetWindowPos(
+            hwnd,
+            None,
+            (screen_w - width) / 2,
+            (screen_h - height) / 2,
+            0,
+            0,
+            SWP_NOSIZE | SWP_NOZORDER,
+        );
+    }
+}
+
+fn set_font(hwnd: HWND, font: Option<HGDIOBJ>) {
+    unsafe {
+        let ptr = font
+            .map(|f| f.0 as usize)
+            .unwrap_or_else(|| GetStockObject(DEFAULT_GUI_FONT).0 as usize);
+        let _ = SendMessageW(hwnd, WM_SETFONT, WPARAM(ptr), LPARAM(1));
+    }
+}
+
+fn create_ui_font() -> Option<HGDIOBJ> {
+    unsafe {
+        let mut lf = LOGFONTW::default();
+        lf.lfHeight = -12;
+        lf.lfCharSet = DEFAULT_CHARSET;
+        lf.lfQuality = CLEARTYPE_QUALITY;
+        let segoe = super::to_wide("Segoe UI");
+        let len = (segoe.len() - 1).min(31);
+        lf.lfFaceName[..len].copy_from_slice(&segoe[..len]);
+
+        let hf = CreateFontIndirectW(&lf);
+        if hf.0.is_null() {
+            return None;
+        }
+        Some(HGDIOBJ(hf.0))
+    }
+}
+
 pub(crate) struct CustomDialog {
-    hwnd: WindowMain,
+    hwnd: HWND,
+    progress: std::sync::Arc<AtomicU32>,
     handle: Option<std::thread::JoinHandle<()>>,
 }
 
@@ -63,7 +182,7 @@ impl CustomDialog {
     }
 
     pub(crate) fn show_error(title: &str, message: &str) {
-        if let Some(dialog) = Self::create(DialogType::Error, title, message, 560, 500) {
+        if let Some(dialog) = Self::create(DialogType::Error, title, message, 560, 450) {
             dialog.wait();
         }
     }
@@ -75,35 +194,72 @@ impl CustomDialog {
         width: i32,
         height: i32,
     ) -> Option<Self> {
+        let progress = std::sync::Arc::new(AtomicU32::new(0));
+        let progress_clone = progress.clone();
+
         let title_owned = title.to_string();
         let message_owned = message.to_string();
 
         let (tx_hwnd, rx_hwnd) = mpsc::channel();
 
-        let handle = std::thread::spawn(move || {
-            let wnd_style = WS::OVERLAPPED | WS::CAPTION | WS::SYSMENU;
+        let handle = std::thread::spawn(move || unsafe {
+            let icc = INITCOMMONCONTROLSEX {
+                dwSize: std::mem::size_of::<INITCOMMONCONTROLSEX>() as u32,
+                dwICC: ICC_PROGRESS_CLASS,
+            };
+            let _ = InitCommonControlsEx(&icc);
+
+            let hinstance = GetModuleHandleW(None).unwrap_or_default();
+
+            let font_for_controls = create_ui_font();
+            if let Some(h) = font_for_controls {
+                DIALOG_STATE.with(|s| s.borrow_mut().hfont = Some(h));
+            }
+
+            let class_name = to_wide("WebView2CustomDialog");
+            let wc = WNDCLASSW {
+                style: CS_HREDRAW | CS_VREDRAW,
+                lpfnWndProc: Some(dialog_wnd_proc),
+                hInstance: hinstance.into(),
+                lpszClassName: PCWSTR::from_raw(class_name.as_ptr()),
+                hbrBackground: GetSysColorBrush(COLOR_BTNFACE),
+                ..Default::default()
+            };
+            RegisterClassW(&wc);
+
+            let title_wide = to_wide(&title_owned);
+            let wnd_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU;
             // width/height represent desired client area; compute actual window size
-            let rc = RECT {
+            let mut rc = windows::Win32::Foundation::RECT {
                 left: 0,
                 top: 0,
                 right: width,
                 bottom: height,
             };
-            let (wnd_w, wnd_h) =
-                if let Ok(rc_new) = AdjustWindowRectEx(rc, wnd_style, false, WS_EX::default()) {
-                    (rc_new.right - rc_new.left, rc_new.bottom - rc_new.top)
-                } else {
-                    (width, height)
-                };
+            let success = AdjustWindowRect(&mut rc, wnd_style, false).is_ok();
+            let (wnd_w, wnd_h) = if success {
+                (rc.right - rc.left, rc.bottom - rc.top)
+            } else {
+                (width, height)
+            };
 
-            let hwnd = WindowMain::new(WindowMainOpts {
-                title: &title_owned,
-                class_name: "WebView2CustomDialog",
-                style: wnd_style,
-                class_style: CS::HREDRAW | CS::VREDRAW,
-                size: (wnd_w, wnd_h),
-                ..Default::default()
-            });
+            let hwnd = CreateWindowExW(
+                WINDOW_EX_STYLE::default(),
+                PCWSTR::from_raw(class_name.as_ptr()),
+                PCWSTR::from_raw(title_wide.as_ptr()),
+                wnd_style,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                wnd_w,
+                wnd_h,
+                None,
+                None,
+                hinstance,
+                None,
+            )
+            .unwrap_or_default();
+
+            center_window(hwnd, wnd_w, wnd_h);
 
             const MARGIN: i32 = 24;
             const BTN_W: i32 = 96;
@@ -111,25 +267,40 @@ impl CustomDialog {
 
             match dialog_type {
                 DialogType::Progress => {
-                    let status_hwnd = Label::new(
-                        &hwnd,
-                        LabelOpts {
-                            text: &message_owned,
-                            control_style: SS::CENTER,
-                            position: (MARGIN, MARGIN),
-                            size: (width - 2 * MARGIN, 24),
-                            ..Default::default()
-                        },
-                    );
+                    let status_text = to_wide(&message_owned);
+                    let status_hwnd = CreateWindowExW(
+                        WINDOW_EX_STYLE::default(),
+                        PCWSTR::from_raw(to_wide("STATIC").as_ptr()),
+                        PCWSTR::from_raw(status_text.as_ptr()),
+                        WS_CHILD | WS_VISIBLE | WINDOW_STYLE(SS_CENTER),
+                        MARGIN,
+                        MARGIN,
+                        width - 2 * MARGIN,
+                        24,
+                        hwnd,
+                        None,
+                        hinstance,
+                        None,
+                    )
+                    .unwrap_or_default();
+                    set_font(status_hwnd, font_for_controls);
 
-                    let progressbar_hwnd = ProgressBar::new(
-                        &hwnd,
-                        ProgressBarOpts {
-                            position: (MARGIN, MARGIN + 24 + 8),
-                            size: (width - 2 * MARGIN, 22),
-                            ..Default::default()
-                        },
-                    );
+                    let progressbar_hwnd = CreateWindowExW(
+                        WINDOW_EX_STYLE::default(),
+                        PROGRESS_CLASSW,
+                        PCWSTR::null(),
+                        WS_CHILD | WS_VISIBLE | WINDOW_STYLE(PBS_SMOOTH as u32),
+                        MARGIN,
+                        MARGIN + 24 + 8,
+                        width - 2 * MARGIN,
+                        22,
+                        hwnd,
+                        None,
+                        hinstance,
+                        None,
+                    )
+                    .unwrap_or_default();
+                    let _ = SendMessageW(progressbar_hwnd, PBM_SETRANGE32, WPARAM(0), LPARAM(100));
 
                     DIALOG_STATE.with(|s| {
                         let mut g = s.borrow_mut();
@@ -140,106 +311,121 @@ impl CustomDialog {
                 }
                 DialogType::Success | DialogType::Error => {
                     let text_height = height - (MARGIN + 12 + BTN_H + 12);
-                    let status_hwnd = Edit::new(
-                        &hwnd,
-                        EditOpts {
-                            text: &message_owned,
-                            control_style: ES::MULTILINE | ES::READONLY | ES::AUTOVSCROLL,
-                            position: (MARGIN, MARGIN),
-                            width: width - 2 * MARGIN,
-                            height: text_height,
-                            ..Default::default()
-                        },
-                    );
+                    let msg_text = to_wide(&message_owned);
+                    let status_hwnd = CreateWindowExW(
+                        WINDOW_EX_STYLE::default(),
+                        PCWSTR::from_raw(to_wide("EDIT").as_ptr()),
+                        PCWSTR::from_raw(msg_text.as_ptr()),
+                        WS_CHILD
+                            | WS_VISIBLE
+                            | WINDOW_STYLE(ES_MULTILINE | ES_READONLY | ES_AUTOVSCROLL),
+                        MARGIN,
+                        MARGIN,
+                        width - 2 * MARGIN,
+                        text_height,
+                        hwnd,
+                        None,
+                        hinstance,
+                        None,
+                    )
+                    .unwrap_or_default();
+                    set_font(status_hwnd, font_for_controls);
 
-                    let btn_hwnd = Button::new(
-                        &hwnd,
-                        ButtonOpts {
-                            text: "确定",
-                            position: ((width - BTN_W) / 2, height - 12 - BTN_H),
-                            width: BTN_W,
-                            height: BTN_H,
-                            control_style: BS::DEFPUSHBUTTON,
-                            ..Default::default()
-                        },
-                    );
-
-                    let evt_hwnd = hwnd.clone();
-
-                    btn_hwnd.on().bn_clicked(move || {
-                        evt_hwnd.close();
-                        Ok(())
-                    });
+                    let btn_text = to_wide("确定");
+                    let btn_hwnd = CreateWindowExW(
+                        WINDOW_EX_STYLE::default(),
+                        PCWSTR::from_raw(to_wide("BUTTON").as_ptr()),
+                        PCWSTR::from_raw(btn_text.as_ptr()),
+                        WS_CHILD | WS_VISIBLE | WINDOW_STYLE(BS_DEFPUSHBUTTON as u32),
+                        (width - BTN_W) / 2,
+                        height - 12 - BTN_H,
+                        BTN_W,
+                        BTN_H,
+                        hwnd,
+                        HMENU(ID_OK_BUTTON as *mut _),
+                        hinstance,
+                        None,
+                    )
+                    .unwrap_or_default();
+                    set_font(btn_hwnd, font_for_controls);
 
                     DIALOG_STATE.with(|s| {
                         let mut g = s.borrow_mut();
-                        g.edit_hwnd = Some(status_hwnd);
+                        g.status_hwnd = Some(status_hwnd);
                         g.button_hwnd = Some(btn_hwnd);
                     });
                 }
             }
 
-            let _ = tx_hwnd.send(hwnd.clone());
+            let _ = tx_hwnd.send(hwnd.0 as usize);
 
-            hwnd.on().wm_close(move || {
-                DIALOG_STATE.with(|s| {
-                    if s.borrow().dialog_type == Some(DialogType::Progress) {
-                        std::process::exit(0);
+            let _ = ShowWindow(hwnd, SW_SHOW);
+            let _ = UpdateWindow(hwnd);
+
+            let mut msg = MSG::default();
+            let mut last_progress = 0u32;
+
+            loop {
+                if dialog_type == DialogType::Progress {
+                    let current = progress_clone.load(Ordering::Relaxed);
+                    if current != last_progress {
+                        last_progress = current;
+                        let _ = SendMessageW(
+                            hwnd,
+                            WM_UPDATE_PROGRESS,
+                            WPARAM(current as usize),
+                            LPARAM(0),
+                        );
                     }
-                });
-                PostQuitMessage(0);
-                Ok(())
-            });
+                }
 
-            hwnd.on().wm_destroy(move || {
-                DIALOG_STATE.with(|s| {
-                    let mut g = s.borrow_mut();
-                    g.clear();
-                });
-                Ok(())
-            });
+                if PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
+                    if msg.message == WM_QUIT {
+                        break;
+                    }
+                    let _ = TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
+                } else {
+                    std::thread::sleep(Duration::from_millis(30));
+                }
+            }
 
-            let _ = hwnd.run_main(None);
+            let _ = DestroyWindow(hwnd);
         });
 
-        let hwnd = rx_hwnd.recv_timeout(Duration::from_millis(500)).ok()?;
+        let addr = rx_hwnd.recv_timeout(Duration::from_millis(500)).ok()?;
+        let hwnd = HWND(addr as *mut c_void);
 
         Some(CustomDialog {
             hwnd,
+            progress,
             handle: Some(handle),
         })
     }
 
     pub(crate) fn set_progress(&self, percent: u32) {
-        self.hwnd.run_ui_thread(move || {
-            DIALOG_STATE.with(|s| {
-                if let Some(progress) = &s.borrow().progress_hwnd {
-                    progress.set_position(percent.min(100));
-                };
-            });
-            Ok(())
-        });
+        self.progress.store(percent.min(100), Ordering::Relaxed);
     }
 
-    pub(crate) fn set_status(&self, text: String) {
-        self.hwnd.run_ui_thread(move || {
-            DIALOG_STATE.with(|s| {
-                if let Some(status) = &s.borrow().status_hwnd {
-                    let _ = status.hwnd().SetWindowText(&text);
-                }
-            });
-            Ok(())
-        });
+    pub(crate) fn set_status(&self, text: &str) {
+        // 安全说明：wide_text 分配在栈上，其指针通过 LPARAM 传递给 UI 线程。
+        // 这里必须使用 SendMessageW（同步）而非 PostMessageW（异步），
+        // 因为 SendMessageW 会阻塞直到消息处理完成，确保 wide_text 在被使用期间有效。
+        let wide_text = to_wide(text);
+        unsafe {
+            let _ = SendMessageW(
+                self.hwnd,
+                WM_UPDATE_STATUS,
+                WPARAM(0),
+                LPARAM(wide_text.as_ptr() as isize),
+            );
+        }
     }
 
     pub(crate) fn close(mut self) {
-        // 绕过 WM_CLOSE，直接退出消息循环。
-        // WM_CLOSE 的处理器会在 Progress 对话框时调用 process::exit(0)，
-        // 那是为用户点 X 取消启动设计的；程序主动关闭时不应走那条路径。
-        self.hwnd.run_ui_thread(move || {
-            PostQuitMessage(0);
-            Ok(())
-        });
+        unsafe {
+            let _ = PostMessageW(self.hwnd, WM_DIALOG_CLOSE, WPARAM(0), LPARAM(0));
+        }
         if let Some(h) = self.handle.take() {
             let _ = h.join();
         }

--- a/src-tauri/src/webview2/install.rs
+++ b/src-tauri/src/webview2/install.rs
@@ -4,13 +4,13 @@
 //! 解压到程序目录下的 `cache/webview2_runtime/` 目录，通过环境变量
 //! `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` 指定运行时路径，不影响系统。
 
-use super::detection::{is_webview2_disabled, is_webview2_installed};
-use super::dialog::CustomDialog;
 use log::{info, warn};
 use std::io::Read;
 use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
-use winsafe::GetSystemDirectory;
+
+use super::detection::{is_webview2_disabled, is_webview2_installed};
+use super::dialog::CustomDialog;
 
 /// WebView2 Fixed Version Runtime 版本号及对应的下载 GUID。
 /// **三者必须保持一致**——更新版本时需同时更新 `WEBVIEW2_VERSION`、`GUID_X64` 和 `GUID_ARM64`。
@@ -135,19 +135,22 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()
 
 /// 获取 expand.exe 的完整路径（通过 Windows API 获取系统目录，避免依赖可被篡改的环境变量）
 fn get_expand_exe_path() -> Result<std::path::PathBuf, String> {
-    let res = GetSystemDirectory();
-    if let Ok(path) = res {
-        let expand_path = std::path::PathBuf::from(path).join("expand.exe");
-        if expand_path.exists() {
-            Ok(expand_path)
-        } else {
-            Err(format!(
-                "未找到 expand.exe，请确认系统完整性。\n预期路径: {}",
-                expand_path.display()
-            ))
-        }
+    use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
+
+    let mut buf = [0u16; 260];
+    let len = unsafe { GetSystemDirectoryW(Some(&mut buf)) } as usize;
+    if len == 0 || len > buf.len() {
+        return Err("GetSystemDirectoryW 调用失败，无法获取系统目录".to_string());
+    }
+    let system_dir = String::from_utf16_lossy(&buf[..len]);
+    let expand_path = std::path::PathBuf::from(&system_dir).join("expand.exe");
+    if expand_path.exists() {
+        Ok(expand_path)
     } else {
-        Err("GetSystemDirectory 调用失败，无法获取系统目录".to_string())
+        Err(format!(
+            "未找到 expand.exe，请确认系统完整性。\n预期路径: {}",
+            expand_path.display()
+        ))
     }
 }
 
@@ -444,20 +447,20 @@ pub fn download_and_extract() -> Result<(), String> {
                 .map_err(|e| format!("写入文件失败: {}", e))?;
             downloaded += bytes_read as u64;
 
-            // 节流 UI 更新，避免 run_ui_thread 跨线程同步调用阻塞下载
+            // 节流 UI 更新，避免 SendMessageW 跨线程同步调用阻塞下载
             if last_ui_update.elapsed() >= std::time::Duration::from_millis(200) {
                 last_ui_update = std::time::Instant::now();
                 if let Some(ref pw) = progress_dialog {
                     if total_size > 0 {
                         let percent = ((downloaded as f64 / total_size as f64) * 100.0) as u32;
                         pw.set_progress(percent);
-                        pw.set_status(format!(
+                        pw.set_status(&format!(
                             "正在下载独立 WebView2... {:.1} MB / {:.1} MB",
                             downloaded as f64 / 1024.0 / 1024.0,
                             total_size as f64 / 1024.0 / 1024.0
                         ));
                     } else {
-                        pw.set_status(format!(
+                        pw.set_status(&format!(
                             "正在下载独立 WebView2... {:.1} MB",
                             downloaded as f64 / 1024.0 / 1024.0
                         ));
@@ -483,7 +486,7 @@ pub fn download_and_extract() -> Result<(), String> {
     // 更新进度：解压中
     if let Some(ref pw) = progress_dialog {
         pw.set_progress(100);
-        pw.set_status("正在解压...".to_string());
+        pw.set_status("正在解压...");
     }
 
     // 解压 cab 文件

--- a/src-tauri/src/webview2/mod.rs
+++ b/src-tauri/src/webview2/mod.rs
@@ -6,3 +6,13 @@ mod install;
 
 pub use install::ensure_webview2;
 pub use install::get_webview2_runtime_dir;
+
+use std::os::windows::ffi::OsStrExt;
+
+/// 将 Rust 字符串转换为 Windows 宽字符串 (null-terminated)
+pub(crate) fn to_wide(s: &str) -> Vec<u16> {
+    std::ffi::OsStr::new(s)
+        .encode_wide()
+        .chain(Some(0))
+        .collect()
+}


### PR DESCRIPTION
Reverts MistEO/MXU#134

没法启动了，先 revert 了，明天再查

## Summary by Sourcery

将之前基于 winsafe 的 Windows 集成替换为通过 `windows` crate 直接绑定 Win32 API，覆盖对话框、权限提升、进程检查、WebView2 检测/安装、注册表处理、DLL 搜索路径配置以及电源操作等功能。

Enhancements:
- 使用原生 `windows` crate API 重新实现自定义 Win32 对话框窗口和进度 UI，替代 winsafe 的 GUI 封装，并添加手动消息处理和字体管理。
- 将 Windows 权限提升、进程枚举、系统目录访问和熄屏行为从 winsafe 辅助方法切换为 `windows` crate 调用，并改进错误处理和路径处理。
- 重写 WebView2 运行时的检测和禁用检查逻辑，改为通过 `windows` crate 显式调用注册表和系统目录相关 API。
- 在 Maa 初始化中调整 DLL 搜索路径配置，直接通过 FFI 调用 `SetDllDirectoryW`，并通过日志确认调用是否成功。
- 在 Windows 上对 `ShellExecute`、注册表和 WebView2 工具相关的 UTF-16 转换辅助函数进行简化与集中管理。
- 更新 Cargo 依赖，移除 winsafe，改为依赖带有必要 Win32 feature 标志的 `windows` crate。

Build:
- 在 Windows 目标平台上，用 `windows` crate 替换 winsafe Git 依赖，用于 Win32 绑定。

Tests:
- 在适配新的对话框实现的同时，保留并更新 WebView2 下载和解压过程中的进度对话框状态更新以及节流的 UI 刷新逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the previous winsafe-based Windows integration with direct Win32 API bindings via the windows crate across dialogs, privilege elevation, process checks, WebView2 detection/installation, registry handling, DLL search path configuration, and power actions.

Enhancements:
- Reimplement the custom Win32 dialog window and progress UI using raw windows crate APIs instead of the winsafe GUI wrapper, adding manual message handling and font management.
- Switch Windows privilege elevation, process enumeration, system directory access, and screen-off behavior from winsafe helpers to windows crate calls with improved error handling and path handling.
- Rewrite WebView2 runtime detection and disablement checks to use explicit registry and system-directory calls via the windows crate.
- Adjust DLL search path configuration in Maa initialization to call SetDllDirectoryW directly via FFI and confirm success via logging.
- Simplify and centralize UTF-16 conversion helpers on Windows for ShellExecute, registry, and WebView2 utilities.
- Update Cargo dependencies to drop winsafe and depend on the windows crate with the necessary Win32 feature flags.

Build:
- Replace the winsafe Git dependency with the windows crate for Win32 bindings on Windows targets.

Tests:
- Preserve and update progress dialog status updates and throttled UI refresh during WebView2 download and extraction while adapting to the new dialog implementation.

</details>