### PR TITLE
fix: 修复把ui的窗口拉的很小时显示选项预览的下拉按钮会向右偏位

### DIFF
--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -939,26 +939,26 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
           ) : (
             <>
               {/* 任务名称：单击切换选中 */}
-              <div
-                className={clsx(
-                  'flex items-center gap-1 min-w-0 flex-shrink-0',
-                  isInstanceRunning || isIncompatible ? 'cursor-not-allowed' : 'cursor-pointer',
-                )}
-                onClick={handleNameClick}
-                title={t('taskItem.clickToToggle')}
-              >
-                <span
+                <div
                   className={clsx(
-                    'text-sm font-medium truncate',
-                    task.enabled ? 'text-text-primary' : 'text-text-muted',
+                    'flex items-center gap-1 min-w-0 overflow-hidden',
+                    isInstanceRunning || isIncompatible ? 'cursor-not-allowed' : 'cursor-pointer',
                   )}
+                  onClick={handleNameClick}
+                  title={t('taskItem.clickToToggle')}
                 >
-                  {displayName}
-                </span>
-                {task.customName && (
-                  <span className="flex-shrink-0 text-xs text-text-muted">({originalLabel})</span>
-                )}
-              </div>
+                  <span
+                    className={clsx(
+                      'min-w-0 text-sm font-medium truncate',
+                      task.enabled ? 'text-text-primary' : 'text-text-muted',
+                    )}
+                  >
+                    {displayName}
+                  </span>
+                  {task.customName && (
+                    <span className="min-w-0 truncate text-xs text-text-muted">({originalLabel})</span>
+                  )}
+                </div>
 
               {/* 不带选项的任务：直接显示不兼容警告 */}
               {!canExpand && isIncompatible && (
@@ -976,7 +976,7 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
               {canExpand && (
                 <div
                   onClick={() => toggleTaskExpanded(instanceId, task.id)}
-                  className="flex-1 flex items-center self-stretch min-h-[28px] cursor-pointer"
+                  className="flex-1 min-w-0 flex items-center self-stretch min-h-[28px] cursor-pointer"
                   title={task.expanded ? t('taskItem.collapse') : t('taskItem.expand')}
                 >
                   {/* 选项预览标签 - 未展开时显示：不兼容时显示警告，否则显示选项预览 */}
@@ -1004,7 +1004,7 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
                     </div>
                   )}
                   {/* 展开/折叠箭头 */}
-                  <div className="flex items-center justify-end pl-2 ml-auto">
+                  <div className="flex shrink-0 items-center justify-end pl-2 ml-auto">
                     <ChevronRight
                       className={clsx(
                         'w-4 h-4 text-text-secondary transition-transform duration-150 ease-out',


### PR DESCRIPTION
### 预览图:
修改前:
<img width="961" height="451" alt="QQ_1775435987527" src="https://github.com/user-attachments/assets/351d0a14-cf0d-4741-a710-531872b39573" />

修改后:
<img width="1269" height="490" alt="QQ_1775436087478" src="https://github.com/user-attachments/assets/9c6f9125-2b6d-4c54-b8ba-ac94001687f0" />


## Summary by Sourcery

改进任务列表项中任务标题和展开控件的布局与截断行为，以在较窄的界面宽度下保持“选项预览”下拉菜单的正确对齐。

增强内容：
- 调整任务标题容器和文本截断逻辑，在受限宽度下更好地处理较长名称和自定义标签。
- 更新可展开区域和箭头容器的 flex 行为，防止在窗口变得较窄时展开/收起图标发生位置偏移。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve layout and truncation behavior for task title and expand control in the task list item to keep the options preview dropdown properly aligned in narrow UI widths.

Enhancements:
- Adjust task title container and text truncation to better handle long names and custom labels in constrained widths.
- Update the expandable area and arrow container flex behavior to prevent the expand/collapse icon from shifting when the window is resized small.

</details>