### PR TITLE
feat: 添加 wlroots 控制方式

### DIFF
--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -348,6 +348,40 @@ pub async fn maa_find_win32_windows(
     .map_err(|e| e.to_string())?
 }
 
+/// 查找 WlRoots 可用的 Wayland socket（结果会缓存到 MaaState）
+#[tauri::command]
+pub async fn maa_find_wlroots_sockets(
+    state: State<'_, Arc<MaaState>>,
+) -> Result<Vec<String>, String> {
+    info!("maa_find_wlroots_sockets called");
+
+    let state_arc = state.inner().clone();
+
+    tauri::async_runtime::spawn_blocking(move || {
+        // Linux 平台上，Toolkit::find_desktop_windows 返回项中的 window_name
+        // 即为可用的 wayland socket 名称。
+        let windows = Toolkit::find_desktop_windows().map_err(|e| e.to_string())?;
+
+        let mut result_sockets = Vec::new();
+        for w in windows {
+            let socket = w.window_name.trim();
+            if !socket.is_empty() {
+                result_sockets.push(socket.to_string());
+            }
+        }
+
+        // 缓存搜索结果
+        if let Ok(mut cached) = state_arc.cached_wlroots_sockets.lock() {
+            *cached = result_sockets.clone();
+        }
+
+        info!("Returning {} wlroots socket(s)", result_sockets.len());
+        Ok(result_sockets)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 // ============================================================================
 // 实例管理命令
 // ============================================================================
@@ -528,6 +562,9 @@ pub async fn maa_connect_controller(
                         .bits(),
                 )
                 .map_err(|e| e.to_string())?
+            }
+            ControllerConfig::WlRoots { wlr_socket_path } => {
+                Controller::new_wlroots(wlr_socket_path).map_err(|e| e.to_string())?
             }
             ControllerConfig::PlayCover { address, uuid } => {
                 let uuid_str = uuid.as_deref().unwrap_or("");

--- a/src-tauri/src/commands/state.rs
+++ b/src-tauri/src/commands/state.rs
@@ -54,6 +54,10 @@ pub fn maa_get_all_states(state: State<Arc<MaaState>>) -> Result<AllInstanceStat
         .cached_win32_windows
         .lock()
         .map_err(|e| e.to_string())?;
+    let cached_wlroots = state
+        .cached_wlroots_sockets
+        .lock()
+        .map_err(|e| e.to_string())?;
 
     let mut instance_states = HashMap::new();
 
@@ -82,6 +86,7 @@ pub fn maa_get_all_states(state: State<Arc<MaaState>>) -> Result<AllInstanceStat
         instances: instance_states,
         cached_adb_devices: cached_adb.clone(),
         cached_win32_windows: cached_win32.clone(),
+        cached_wlroots_sockets: cached_wlroots.clone(),
     })
 }
 
@@ -101,6 +106,19 @@ pub fn maa_get_cached_win32_windows(
     debug!("maa_get_cached_win32_windows called");
     let cached = state
         .cached_win32_windows
+        .lock()
+        .map_err(|e| e.to_string())?;
+    Ok(cached.clone())
+}
+
+/// 获取缓存的 WlRoots socket 列表
+#[tauri::command]
+pub fn maa_get_cached_wlroots_sockets(
+    state: State<Arc<MaaState>>,
+) -> Result<Vec<String>, String> {
+    debug!("maa_get_cached_wlroots_sockets called");
+    let cached = state
+        .cached_wlroots_sockets
         .lock()
         .map_err(|e| e.to_string())?;
     Ok(cached.clone())

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -77,6 +77,9 @@ pub enum ControllerConfig {
         mouse_method: u64,
         keyboard_method: u64,
     },
+    WlRoots {
+        wlr_socket_path: String,
+    },
     Gamepad {
         handle: u64,
         #[serde(default)]
@@ -130,6 +133,7 @@ pub struct AllInstanceStates {
     pub instances: HashMap<String, InstanceState>,
     pub cached_adb_devices: Vec<AdbDevice>,
     pub cached_win32_windows: Vec<Win32Window>,
+    pub cached_wlroots_sockets: Vec<String>,
 }
 
 /// 实例运行时状态（持有 MaaFramework 对象句柄）
@@ -188,6 +192,8 @@ pub struct MaaState {
     pub cached_adb_devices: Mutex<Vec<AdbDevice>>,
     /// 缓存的 Win32 窗口列表（全局共享）
     pub cached_win32_windows: Mutex<Vec<Win32Window>>,
+    /// 缓存的 WlRoots socket 列表（全局共享）
+    pub cached_wlroots_sockets: Mutex<Vec<String>>,
 }
 
 impl MaaState {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
             commands::maa_core::maa_check_version,
             commands::maa_core::maa_find_adb_devices,
             commands::maa_core::maa_find_win32_windows,
+            commands::maa_core::maa_find_wlroots_sockets,
             commands::maa_core::maa_create_instance,
             commands::maa_core::maa_destroy_instance,
             commands::maa_core::maa_connect_controller,
@@ -160,6 +161,7 @@ pub fn run() {
             commands::state::maa_get_all_states,
             commands::state::maa_get_cached_adb_devices,
             commands::state::maa_get_cached_win32_windows,
+            commands::state::maa_get_cached_wlroots_sockets,
             commands::state::log_to_stdout,
             // 更新安装命令
             commands::update::extract_zip,

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -468,7 +468,7 @@ export function ConnectionPanel() {
           if (instanceId) {
             addLog(instanceId, {
               type: 'info',
-              message: t('taskList.autoConnect.autoSelectedWlrootsSocket', {
+              message: t('taskList.autoConnect.autoSelectedDevice', {
                 name: autoSelected,
               }),
             });
@@ -981,7 +981,7 @@ export function ConnectionPanel() {
             return;
           }
           // 没找到匹配的，显示错误提示
-          setDeviceError(t('controller.savedWlrootsSocketNotFound'));
+          setDeviceError(t('controller.savedDeviceNotFound'));
         }
 
         // 显示搜索结果供用户选择

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -43,8 +43,10 @@ export function ConnectionPanel() {
     instances,
     cachedAdbDevices,
     cachedWin32Windows,
+    cachedWlrootsSockets,
     setCachedAdbDevices,
     setCachedWin32Windows,
+    setCachedWlrootsSockets,
     selectedController,
     selectedResource,
     setSelectedController,
@@ -78,6 +80,7 @@ export function ConnectionPanel() {
   const [deviceError, setDeviceError] = useState<string | null>(null);
   const [selectedAdbDevice, setSelectedAdbDevice] = useState<AdbDevice | null>(null);
   const [selectedWindow, setSelectedWindow] = useState<Win32Window | null>(null);
+  const [selectedWlrootsSocket, setSelectedWlrootsSocket] = useState<string | null>(null);
   const [showDeviceDropdown, setShowDeviceDropdown] = useState(false);
   // PlayCover 地址从保存的配置初始化
   const [playcoverAddress, setPlaycoverAddress] = useState(
@@ -253,6 +256,14 @@ export function ConnectionPanel() {
       setSelectedWindow(null);
     }
 
+    if (savedDevice?.wlrSocketPath && cachedWlrootsSockets.length > 0) {
+      // 从缓存中找到匹配的 WlRoots socket
+      const matchedSocket = cachedWlrootsSockets.find((s) => s === savedDevice.wlrSocketPath);
+      setSelectedWlrootsSocket(matchedSocket || null);
+    } else {
+      setSelectedWlrootsSocket(null);
+    }
+
     // 恢复 PlayCover 地址
     if (savedDevice?.playcoverAddress) {
       setPlaycoverAddress(savedDevice.playcoverAddress);
@@ -298,7 +309,7 @@ export function ConnectionPanel() {
 
   // 判断是否需要搜索设备（PlayCover 不需要搜索）
   const needsDeviceSearch =
-    controllerType === 'Adb' || controllerType === 'Win32' || controllerType === 'Gamepad';
+    controllerType === 'Adb' || controllerType === 'Win32'  || controllerType === 'Gamepad' || controllerType === 'WlRoots';
 
   // 记录上一次的控制器名称，用于检测切换
   const prevControllerNameRef = useRef<string | undefined>(currentControllerName);
@@ -329,6 +340,7 @@ export function ConnectionPanel() {
       savedDevice &&
       ((controllerType === 'Adb' && savedDevice.adbDeviceName) ||
         ((controllerType === 'Win32' || controllerType === 'Gamepad') && savedDevice.windowName) ||
+        (controllerType === 'WlRoots' && savedDevice.wlrSocketPath) ||
         (controllerType === 'PlayCover' && savedDevice.playcoverAddress));
 
     if (hasHistoricalDevice && needsDeviceSearch) {
@@ -439,6 +451,36 @@ export function ConnectionPanel() {
           // 有保存窗口但匹配失败，显示下拉框让用户选择
           setShowDeviceDropdown(true);
         }
+      } else if (controllerType === 'WlRoots') {
+        const sockets = await maaService.findWlrootsSockets();
+        setCachedWlrootsSockets(sockets);
+
+        let autoSelected: string | null = null;
+        if (savedDevice?.wlrSocketPath) {
+          const matched = sockets.filter((s) => s === savedDevice.wlrSocketPath);
+          if (matched.length === 1) {
+            autoSelected = matched[0];
+          }
+        } else if (sockets.length > 0) {
+          // 没有保存连接时自动选择第一个
+          autoSelected = sockets[0];
+          // 给出首次自动匹配提示
+          if (instanceId) {
+            addLog(instanceId, {
+              type: 'info',
+              message: t('taskList.autoConnect.autoSelectedWlrootsSocket', {
+                name: autoSelected,
+              }),
+            });
+          }
+        }
+
+        if (autoSelected) {
+          handleSelectWlrootsSocket(autoSelected);
+        } else if (sockets.length > 0) {
+          // 有保存连接但匹配失败，显示下拉框让用户选择
+          setShowDeviceDropdown(true);
+        }
       }
     } catch (err) {
       setDeviceError(err instanceof Error ? err.message : t('controller.connectionFailed'));
@@ -524,6 +566,13 @@ export function ConnectionPanel() {
         };
         deviceName = selectedWindow.window_name || selectedWindow.class_name;
         targetType = 'window';
+      } else if (controllerType === 'WlRoots' && selectedWlrootsSocket) {
+        config = {
+          type: 'WlRoots',
+          wlr_socket_path: selectedWlrootsSocket,
+        };
+        deviceName = selectedWlrootsSocket;
+        targetType = 'device';
       } else if (controllerType === 'PlayCover') {
         // 保存 PlayCover 地址到实例配置
         setInstanceSavedDevice(instanceId, { playcoverAddress });
@@ -670,6 +719,7 @@ export function ConnectionPanel() {
       case 'Adb':
         return <Smartphone className="w-4 h-4" />;
       case 'Win32':
+      case 'WlRoots':
         return <Monitor className="w-4 h-4" />;
       case 'PlayCover':
         return <Apple className="w-4 h-4" />;
@@ -703,6 +753,16 @@ export function ConnectionPanel() {
         return savedDevice.windowName;
       }
       return t('controller.selectWindow');
+    }
+    if (controllerType === 'WlRoots') {
+      if (selectedWlrootsSocket) {
+        return selectedWlrootsSocket;
+      }
+      // 缓存为空但有历史窗口名称
+      if (savedDevice?.wlrSocketPath) {
+        return savedDevice.wlrSocketPath;
+      }
+      return t('controller.selectDevice');
     }
     return t('controller.selectDevice');
   };
@@ -804,6 +864,47 @@ export function ConnectionPanel() {
     }
   };
 
+  // 选择 WlRoots socket 并自动连接（如已连接会先断开旧连接）
+  const handleSelectWlrootsSocket = async (socketPath: string) => {
+    setSelectedWlrootsSocket(socketPath);
+    setShowDeviceDropdown(false);
+
+    // 保存 socket path 到实例配置
+    setInstanceSavedDevice(instanceId, { wlrSocketPath: socketPath });
+
+    // 自动连接
+    setIsConnecting(true);
+    setDeviceError(null);
+
+    try {
+      // 先断开旧连接
+      if (isConnected) {
+        await maaService.destroyInstance(instanceId).catch(() => {});
+        setIsConnected(false);
+        setInstanceResourceLoaded(instanceId, false);
+      }
+
+      const initialized = await ensureMaaInitialized();
+      if (!initialized) {
+        throw new Error(t('maa.initFailed'));
+      }
+
+      await maaService.createInstance(instanceId).catch(() => {});
+
+      const config: ControllerConfig = {
+        type: 'WlRoots',
+        wlr_socket_path: socketPath,
+      };
+
+      await connectControllerInternal(config, socketPath, 'device');
+    } catch (err) {
+      setDeviceError(err instanceof Error ? err.message : t('controller.connectionFailed'));
+      setIsConnected(false);
+      setInstanceConnectionStatus(instanceId, 'Disconnected');
+      setIsConnecting(false);
+    }
+  };
+
   // 点击历史设备条目时，触发搜索并自动匹配连接
   const handleSearchAndConnectHistorical = async () => {
     if (!currentController) return;
@@ -864,6 +965,27 @@ export function ConnectionPanel() {
 
         // 显示搜索结果供用户选择
         if (windows.length > 0) {
+          setShowDeviceDropdown(true);
+        }
+      } else if (controllerType === 'WlRoots') {
+        const sockets = await maaService.findWlrootsSockets();
+        setCachedWlrootsSockets(sockets);
+
+        // 尝试匹配保存的窗口名称
+        if (savedDevice?.wlrSocketPath) {
+          const matched = sockets.find((s) => s === savedDevice.wlrSocketPath);
+          if (matched) {
+            // 找到匹配的，自动连接
+            setIsSearching(false);
+            handleSelectWlrootsSocket(matched);
+            return;
+          }
+          // 没找到匹配的，显示错误提示
+          setDeviceError(t('controller.savedWlrootsSocketNotFound'));
+        }
+
+        // 显示搜索结果供用户选择
+        if (sockets.length > 0) {
           setShowDeviceDropdown(true);
         }
       }
@@ -936,6 +1058,35 @@ export function ConnectionPanel() {
 
       return [];
     }
+    if (controllerType === 'WlRoots') {
+      // 如果缓存中有窗口，使用缓存列表
+      if (cachedWlrootsSockets.length > 0) {
+        return cachedWlrootsSockets.map((socket) => ({
+          id: `wlr:${socket}`,
+          name: socket,
+          description: socket,
+          selected: selectedWlrootsSocket === socket,
+          onClick: () => handleSelectWlrootsSocket(socket),
+          isHistorical: false,
+        }));
+      }
+
+      // 缓存为空但有历史窗口名称，显示历史窗口条目
+      if (savedDevice?.wlrSocketPath) {
+        return [
+          {
+            id: 'historical-wlroots-socket',
+            name: savedDevice.wlrSocketPath,
+            description: t('controller.lastSelected'),
+            selected: true,
+            onClick: handleSearchAndConnectHistorical,
+            isHistorical: true,
+          },
+        ];
+      }
+
+      return [];
+    }
     return [];
   };
 
@@ -943,6 +1094,7 @@ export function ConnectionPanel() {
   const canConnect = () => {
     if (controllerType === 'Adb') return !!selectedAdbDevice;
     if (controllerType === 'Win32' || controllerType === 'Gamepad') return !!selectedWindow;
+    if (controllerType === 'WlRoots') return !!selectedWlrootsSocket;
     if (controllerType === 'PlayCover') return playcoverAddress.trim().length > 0;
     return false;
   };
@@ -976,6 +1128,9 @@ export function ConnectionPanel() {
       if (savedDevice?.windowName) {
         return truncateText(savedDevice.windowName, 6);
       }
+      if (savedDevice?.wlrSocketPath) {
+        return truncateText(savedDevice.wlrSocketPath, 6);
+      }
       if (savedDevice?.playcoverAddress) {
         return truncateText(savedDevice.playcoverAddress, 6);
       }
@@ -991,6 +1146,7 @@ export function ConnectionPanel() {
       activeInstance?.savedDevice &&
       (activeInstance.savedDevice.adbDeviceName ||
         activeInstance.savedDevice.windowName ||
+        activeInstance.savedDevice.wlrSocketPath ||
         activeInstance.savedDevice.playcoverAddress);
 
     return (
@@ -1107,6 +1263,7 @@ export function ConnectionPanel() {
                           setInstanceConnectionStatus(instanceId, 'Disconnected');
                           setSelectedAdbDevice(null);
                           setSelectedWindow(null);
+                          setSelectedWlrootsSocket(null);
 
                           // 检查当前资源是否支持新控制器，如果不支持则切换到第一个可用资源
                           const newControllerResources = allResources.filter((r) => {
@@ -1192,7 +1349,7 @@ export function ConnectionPanel() {
               </div>
             )}
 
-            {/* 设备选择（Adb/Win32/Gamepad）- 下拉框和刷新按钮同一行 */}
+            {/* 设备选择（Adb/Win32/Gamepad/Wlroots）- 下拉框和刷新按钮同一行 */}
             {needsDeviceSearch && (
               <div className="flex gap-2">
                 <div className="relative flex-1 min-w-0">
@@ -1216,7 +1373,11 @@ export function ConnectionPanel() {
                     <span
                       className={clsx(
                         'truncate',
-                        (controllerType === 'Adb' ? selectedAdbDevice : selectedWindow)
+                        (controllerType === 'Adb'
+                          ? selectedAdbDevice
+                          : controllerType === 'WlRoots'
+                            ? selectedWlrootsSocket
+                            : selectedWindow)
                           ? 'text-text-primary'
                           : 'text-text-muted',
                       )}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -134,6 +134,8 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
       deviceName = savedDevice.adbDeviceName;
     } else if (savedDevice?.windowName) {
       deviceName = savedDevice.windowName;
+    } else if (savedDevice?.wlrSocketPath) {
+      deviceName = savedDevice.wlrSocketPath;
     } else if (savedDevice?.playcoverAddress) {
       deviceName = savedDevice.playcoverAddress;
     }

--- a/src/components/DeviceSelector.tsx
+++ b/src/components/DeviceSelector.tsx
@@ -46,14 +46,17 @@ export function DeviceSelector({
   const {
     cachedAdbDevices,
     cachedWin32Windows,
+    cachedWlrootsSockets,
     setCachedAdbDevices,
     setCachedWin32Windows,
+    setCachedWlrootsSockets,
     registerCtrlIdName,
   } = useAppStore();
 
   // 选中的设备（本地状态）
   const [selectedAdbDevice, setSelectedAdbDevice] = useState<AdbDevice | null>(null);
   const [selectedWindow, setSelectedWindow] = useState<Win32Window | null>(null);
+  const [selectedWlrootsSocket, setSelectedWlrootsSocket] = useState<string | null>(null);
 
   const [showDropdown, setShowDropdown] = useState(false);
 
@@ -137,7 +140,7 @@ export function DeviceSelector({
 
   // 判断是否需要搜索设备（PlayCover 不需要搜索）
   const needsDeviceSearch =
-    controllerType === 'Adb' || controllerType === 'Win32' || controllerType === 'Gamepad';
+    controllerType === 'Adb' || controllerType === 'Win32' || controllerType === 'WlRoots' || controllerType === 'Gamepad';
 
   // 初始化 MaaFramework（如果还没初始化）
   const ensureMaaInitialized = async () => {
@@ -186,6 +189,15 @@ export function DeviceSelector({
         if (windows.length > 0) {
           setShowDropdown(true);
         }
+      } else if (controllerType === 'WlRoots') {
+        const sockets = await maaService.findWlrootsSockets();
+        setCachedWlrootsSockets(sockets);
+        if (sockets.length === 1) {
+          setSelectedWlrootsSocket(sockets[0]);
+        }
+        if (sockets.length > 0) {
+          setShowDropdown(true);
+        }
       }
     } catch (err) {
       log.error('搜索设备失败:', err);
@@ -229,6 +241,11 @@ export function DeviceSelector({
           mouse_method: parseWin32InputMethod(controllerDef.win32?.mouse || ''),
           keyboard_method: parseWin32InputMethod(controllerDef.win32?.keyboard || ''),
         };
+      } else if (controllerType === 'WlRoots' && selectedWlrootsSocket) {
+        config = {
+          type: 'WlRoots',
+          wlr_socket_path: selectedWlrootsSocket,
+        };
       } else if (controllerType === 'PlayCover') {
         config = {
           type: 'PlayCover',
@@ -254,6 +271,9 @@ export function DeviceSelector({
       } else if ((controllerType === 'Win32' || controllerType === 'Gamepad') && selectedWindow) {
         deviceName = selectedWindow.window_name || selectedWindow.class_name;
         targetType = 'window';
+      } else if (controllerType === 'WlRoots' && selectedWlrootsSocket) {
+        deviceName = selectedWlrootsSocket;
+        targetType = 'device';
       } else if (controllerType === 'PlayCover') {
         deviceName = playcoverAddress;
         targetType = 'device';
@@ -291,6 +311,9 @@ export function DeviceSelector({
     }
     if ((controllerType === 'Win32' || controllerType === 'Gamepad') && selectedWindow) {
       return selectedWindow.window_name || selectedWindow.class_name;
+    }
+    if (controllerType === 'WlRoots' && selectedWlrootsSocket) {
+      return selectedWlrootsSocket;
     }
     return t('controller.selectController');
   };
@@ -386,6 +409,44 @@ export function DeviceSelector({
     }
   };
 
+  // 选择 WlRoots socket 并自动连接
+  const handleSelectWlrootsSocket = async (socketPath: string) => {
+    setSelectedWlrootsSocket(socketPath);
+    setShowDropdown(false);
+
+    // 自动连接
+    setIsConnecting(true);
+    setError(null);
+
+    try {
+      const initialized = await ensureMaaInitialized();
+      if (!initialized) {
+        throw new Error('无法初始化 MaaFramework，请确保 MaaFramework 动态库在正确的位置');
+      }
+
+      await maaService.createInstance(instanceId).catch(() => {});
+
+      const config: ControllerConfig = {
+        type: 'WlRoots',
+        wlr_socket_path: socketPath,
+      };
+
+      const ctrlId = await maaService.connectController(instanceId, config);
+
+      // 注册 ctrl_id 与窗口名/类型的映射
+      registerCtrlIdName(ctrlId, socketPath, 'device');
+
+      // 记录等待中的 ctrl_id，后续由回调处理完成状态
+      setPendingCtrlId(ctrlId);
+    } catch (err) {
+      log.error('自动连接失败:', err);
+      setError(err instanceof Error ? err.message : '连接失败');
+      setIsConnected(false);
+      onConnectionChange?.(false);
+      setIsConnecting(false);
+    }
+  };
+
   // 获取设备列表
   const getDeviceList = () => {
     if (controllerType === 'Adb') {
@@ -406,6 +467,15 @@ export function DeviceSelector({
         onClick: () => handleSelectWindow(window),
       }));
     }
+    if (controllerType === 'WlRoots') {
+      return cachedWlrootsSockets.map((socket) => ({
+        id: `wlr:${socket}`,
+        name: socket,
+        description: socket,
+        selected: selectedWlrootsSocket === socket,
+        onClick: () => handleSelectWlrootsSocket(socket),
+      }));
+    }
     return [];
   };
 
@@ -413,6 +483,7 @@ export function DeviceSelector({
   const canConnect = () => {
     if (controllerType === 'Adb') return !!selectedAdbDevice;
     if (controllerType === 'Win32' || controllerType === 'Gamepad') return !!selectedWindow;
+    if (controllerType === 'WlRoots') return !!selectedWlrootsSocket;
     if (controllerType === 'PlayCover') return playcoverAddress.trim().length > 0;
     return false;
   };
@@ -425,6 +496,7 @@ export function DeviceSelector({
       case 'Adb':
         return <Smartphone className="w-4 h-4" />;
       case 'Win32':
+      case 'WlRoots':
         return <Monitor className="w-4 h-4" />;
       case 'PlayCover':
         return <Apple className="w-4 h-4" />;
@@ -442,6 +514,8 @@ export function DeviceSelector({
         return t('controller.adb');
       case 'Win32':
         return t('controller.win32');
+      case 'WlRoots':
+        return t('controller.wlroots');
       case 'PlayCover':
         return t('controller.playcover');
       case 'Gamepad':
@@ -513,7 +587,11 @@ export function DeviceSelector({
               <span
                 className={clsx(
                   'truncate',
-                  (controllerType === 'Adb' ? selectedAdbDevice : selectedWindow)
+                  (controllerType === 'Adb'
+                    ? selectedAdbDevice
+                    : controllerType === 'WlRoots'
+                      ? selectedWlrootsSocket
+                      : selectedWindow)
                     ? 'text-text-primary'
                     : 'text-text-muted',
                 )}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -386,7 +386,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
                         addLog(targetId, {
                           type: 'info',
                           message: t('taskList.autoConnect.autoSelectedDevice', {
-                            path: sockets[0],
+                            name: sockets[0],
                           }),
                         });
                       }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -199,7 +199,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
       // 检查是否有保存的设备配置
       const hasSavedDevice = Boolean(
         savedDevice &&
-        (savedDevice.adbDeviceName || savedDevice.windowName || savedDevice.playcoverAddress),
+        (savedDevice.adbDeviceName || savedDevice.windowName || savedDevice.wlrSocketPath || savedDevice.playcoverAddress),
       );
 
       let isTargetConnected = instanceConnectionStatus[targetId] === 'Connected';
@@ -315,6 +315,15 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
                       // 没有保存的窗口，等待任意匹配窗口出现
                       deviceFound = windows.length > 0;
                     }
+                  } else if (controllerType === 'WlRoots') {
+                    const sockets = await maaService.findWlrootsSockets();
+                    if (savedDevice?.wlrSocketPath) {
+                      // 有保存的套接字路径，精确匹配
+                      deviceFound = sockets.includes(savedDevice.wlrSocketPath);
+                    } else {
+                      // 没有保存的套接字路径，等待任意匹配的套接字出现
+                      deviceFound = sockets.length > 0;
+                    }
                   } else {
                     // 无法确定控制器类型，跳过等待
                     deviceFound = true;
@@ -342,6 +351,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
                 if (
                   !savedDevice?.windowName &&
                   !savedDevice?.adbDeviceName &&
+                  !savedDevice?.wlrSocketPath &&
                   !savedDevice?.playcoverAddress
                 ) {
                   // 尝试找出实际匹配到的名称用于提示
@@ -367,6 +377,16 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
                           type: 'info',
                           message: t('taskList.autoConnect.autoSelectedWindow', {
                             name: windows[0].window_name || windows[0].class_name,
+                          }),
+                        });
+                      }
+                    } else if (controllerType === 'WlRoots') {
+                      const sockets = await maaService.findWlrootsSockets();
+                      if (sockets.length > 0) {
+                        addLog(targetId, {
+                          type: 'info',
+                          message: t('taskList.autoConnect.autoSelectedDevice', {
+                            path: sockets[0],
                           }),
                         });
                       }
@@ -491,6 +511,20 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
               }
               deviceName = matchedWindow.window_name || matchedWindow.class_name;
               targetType = 'window';
+            } else if (controllerType === 'WlRoots' && savedDevice.wlrSocketPath) {
+              const sockets = await maaService.findWlrootsSockets();
+              if (!sockets.includes(savedDevice.wlrSocketPath)) {
+                log.warn(
+                  `实例 ${targetInstance.name}: 未找到 WlRoots socket ${savedDevice.wlrSocketPath}`,
+                );
+                return false;
+              }
+              config = {
+                type: 'WlRoots',
+                wlr_socket_path: savedDevice.wlrSocketPath,
+              };
+              deviceName = savedDevice.wlrSocketPath;
+              targetType = 'device';
             } else if (controllerType === 'PlayCover' && savedDevice.playcoverAddress) {
               config = {
                 type: 'PlayCover',
@@ -571,6 +605,30 @@ export function Toolbar({ showAddPanel, onToggleAddPanel }: ToolbarProps) {
               }
               deviceName = firstWindow.window_name || firstWindow.class_name;
               targetType = 'window';
+            } else if (controllerType === 'WlRoots') {
+              const sockets = await maaService.findWlrootsSockets();
+              if (sockets.length === 0) {
+                log.warn(`实例 ${targetInstance.name}: 未搜索到任何 WlRoots socket`);
+                addLog(targetId, {
+                  type: 'error',
+                  message: t('taskList.autoConnect.noDeviceFound'),
+                });
+                return false;
+              }
+              const firstSocket = sockets[0];
+              log.info(`实例 ${targetInstance.name}: 自动选择 WlRoots socket: ${firstSocket}`);
+              addLog(targetId, {
+                type: 'info',
+                message: t('taskList.autoConnect.autoSelectedDevice', {
+                  name: firstSocket,
+                }),
+              });
+              config = {
+                type: 'WlRoots',
+                wlr_socket_path: firstSocket,
+              };
+              deviceName = firstSocket;
+              targetType = 'device';
             } else if (controllerType === 'PlayCover') {
               // PlayCover 没有搜索功能，无法自动连接
               log.warn(`实例 ${targetInstance.name}: PlayCover 控制器需要手动配置地址`);

--- a/src/components/connection/useDeviceConnection.ts
+++ b/src/components/connection/useDeviceConnection.ts
@@ -22,8 +22,10 @@ export function useDeviceConnection({
   const {
     cachedAdbDevices,
     cachedWin32Windows,
+    cachedWlrootsSockets,
     setCachedAdbDevices,
     setCachedWin32Windows,
+    setCachedWlrootsSockets,
     setInstanceConnectionStatus,
     setInstanceResourceLoaded,
     setInstanceSavedDevice,
@@ -39,6 +41,7 @@ export function useDeviceConnection({
   const [deviceError, setDeviceError] = useState<string | null>(null);
   const [selectedAdbDevice, setSelectedAdbDevice] = useState<AdbDevice | null>(null);
   const [selectedWindow, setSelectedWindow] = useState<Win32Window | null>(null);
+  const [selectedWlrootsSocket, setSelectedWlrootsSocket] = useState<string | null>(null);
   const [showDeviceDropdown, setShowDeviceDropdown] = useState(false);
   const [playcoverAddress, setPlaycoverAddress] = useState(
     activeInstance?.savedDevice?.playcoverAddress || '127.0.0.1:1717',
@@ -141,6 +144,25 @@ export function useDeviceConnection({
         } else if (windows.length > 0) {
           setShowDeviceDropdown(true);
         }
+      } else if (controllerType === 'WlRoots') {
+        const sockets = await maaService.findWlrootsSockets();
+        setCachedWlrootsSockets(sockets);
+
+        let autoSelected: string | null = null;
+        if (savedDevice?.wlrSocketPath) {
+          const matched = sockets.filter((s) => s === savedDevice.wlrSocketPath);
+          if (matched.length === 1) {
+            autoSelected = matched[0];
+          }
+        } else if (sockets.length > 0) {
+          autoSelected = sockets[0];
+        }
+
+        if (autoSelected) {
+          handleSelectWlrootsSocket(autoSelected);
+        } else if (sockets.length > 0) {
+          setShowDeviceDropdown(true);
+        }
       }
     } catch (err) {
       setDeviceError(err instanceof Error ? err.message : t('controller.connectionFailed'));
@@ -153,6 +175,7 @@ export function useDeviceConnection({
     activeInstance?.savedDevice,
     setCachedAdbDevices,
     setCachedWin32Windows,
+    setCachedWlrootsSockets,
     t,
   ]);
 
@@ -271,6 +294,55 @@ export function useDeviceConnection({
     ],
   );
 
+  // 选择 WlRoots socket 并自动连接
+  const handleSelectWlrootsSocket = useCallback(
+    async (socketPath: string) => {
+      setSelectedWlrootsSocket(socketPath);
+      setShowDeviceDropdown(false);
+
+      setInstanceSavedDevice(instanceId, { wlrSocketPath: socketPath });
+
+      setIsConnecting(true);
+      setDeviceError(null);
+
+      try {
+        if (isConnected) {
+          await maaService.destroyInstance(instanceId).catch(() => {});
+          setIsConnected(false);
+          setInstanceResourceLoaded(instanceId, false);
+        }
+
+        const initialized = await ensureMaaInitialized();
+        if (!initialized) {
+          throw new Error(t('maa.initFailed'));
+        }
+
+        await maaService.createInstance(instanceId).catch(() => {});
+
+        const config: ControllerConfig = {
+          type: 'WlRoots',
+          wlr_socket_path: socketPath,
+        };
+
+        await connectControllerInternal(config, socketPath, 'device');
+      } catch (err) {
+        setDeviceError(err instanceof Error ? err.message : t('controller.connectionFailed'));
+        setIsConnected(false);
+        setInstanceConnectionStatus(instanceId, 'Disconnected');
+        setIsConnecting(false);
+      }
+    },
+    [
+      instanceId,
+      isConnected,
+      setInstanceSavedDevice,
+      setInstanceConnectionStatus,
+      setInstanceResourceLoaded,
+      connectControllerInternal,
+      t,
+    ],
+  );
+
   // PlayCover 连接
   const handleConnectPlayCover = useCallback(async () => {
     setIsConnecting(true);
@@ -331,16 +403,26 @@ export function useDeviceConnection({
       }
       return t('controller.selectWindow');
     }
+    if (controllerType === 'WlRoots') {
+      if (selectedWlrootsSocket) {
+        return selectedWlrootsSocket;
+      }
+      if (savedDevice?.wlrSocketPath) {
+        return savedDevice.wlrSocketPath;
+      }
+      return t('controller.selectSocketPath');
+    }
     return t('controller.selectDevice');
-  }, [controllerType, selectedAdbDevice, selectedWindow, activeInstance?.savedDevice, t]);
+  }, [controllerType, selectedAdbDevice, selectedWindow, selectedWlrootsSocket, activeInstance?.savedDevice, t]);
 
   // 判断是否可以连接
   const canConnect = useCallback(() => {
     if (controllerType === 'Adb') return !!selectedAdbDevice;
     if (controllerType === 'Win32' || controllerType === 'Gamepad') return !!selectedWindow;
+    if (controllerType === 'WlRoots') return !!selectedWlrootsSocket;
     if (controllerType === 'PlayCover') return playcoverAddress.trim().length > 0;
     return false;
-  }, [controllerType, selectedAdbDevice, selectedWindow, playcoverAddress]);
+  }, [controllerType, selectedAdbDevice, selectedWindow, selectedWlrootsSocket, playcoverAddress]);
 
   return {
     // 状态
@@ -354,6 +436,7 @@ export function useDeviceConnection({
     playcoverAddress,
     cachedAdbDevices,
     cachedWin32Windows,
+    cachedWlrootsSockets,
     // Refs
     deviceDropdownRef,
     deviceMenuRef,

--- a/src/components/connection/useDeviceConnection.ts
+++ b/src/components/connection/useDeviceConnection.ts
@@ -410,7 +410,7 @@ export function useDeviceConnection({
       if (savedDevice?.wlrSocketPath) {
         return savedDevice.wlrSocketPath;
       }
-      return t('controller.selectSocketPath');
+      return t('controller.selectDevice');
     }
     return t('controller.selectDevice');
   }, [controllerType, selectedAdbDevice, selectedWindow, selectedWlrootsSocket, activeInstance?.savedDevice, t]);

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -349,6 +349,7 @@ export default {
     selectController: 'Select Controller',
     adb: 'Android Device',
     win32: 'Windows Window',
+    wlroots: 'WlRoots (Linux)',
     playcover: 'PlayCover (macOS)',
     gamepad: 'Gamepad',
     connecting: 'Connecting...',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -348,6 +348,7 @@ export default {
     selectController: 'コントローラーを選択',
     adb: 'Android デバイス',
     win32: 'Windows ウィンドウ',
+    wlroots: 'WlRoots (Linux)',
     playcover: 'PlayCover (macOS)',
     gamepad: 'ゲームパッド',
     connecting: '接続中...',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -347,6 +347,7 @@ export default {
     selectController: '컨트롤러 선택',
     adb: 'Android 기기',
     win32: 'Windows 창',
+    wlroots: 'WlRoots (Linux)',
     playcover: 'PlayCover (macOS)',
     gamepad: '게임패드',
     connecting: '연결 중...',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -340,6 +340,7 @@ export default {
     selectController: '选择控制器',
     adb: 'Android 设备',
     win32: 'Windows 窗口',
+    wlroots: 'WlRoots (Linux)',
     playcover: 'PlayCover (macOS)',
     gamepad: '游戏手柄',
     connecting: '连接中...',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -340,6 +340,7 @@ export default {
     selectController: '選擇控制器',
     adb: 'Android 裝置',
     win32: 'Windows 視窗',
+    wlroots: 'WlRoots (Linux)',
     playcover: 'PlayCover (macOS)',
     gamepad: '遊戲控制器',
     connecting: '連接中...',

--- a/src/services/interfaceLoader.ts
+++ b/src/services/interfaceLoader.ts
@@ -298,6 +298,7 @@ async function processImports(
 // 检测当前操作系统
 const isWindows = navigator.platform.toLowerCase().includes('win');
 const isMacOS = navigator.platform.toLowerCase().includes('mac');
+const isLinux = navigator.platform.toLowerCase().includes('linux');
 
 /**
  * 获取当前平台不支持的控制器类型集合
@@ -312,6 +313,10 @@ function getUnsupportedControllerTypes(): Set<ControllerType> {
   // 非 macOS 系统不支持 PlayCover
   if (!isMacOS) {
     unsupported.add('PlayCover');
+  }
+  // 非 Linux 系统不支持 WlRoots
+  if (!isLinux) {
+    unsupported.add('WlRoots');
   }
   return unsupported;
 }

--- a/src/services/maaService.ts
+++ b/src/services/maaService.ts
@@ -140,6 +140,19 @@ export const maaService = {
   },
 
   /**
+   * 查找 WlRoots 可用的 Wayland socket
+   */
+  async findWlrootsSockets(): Promise<string[]> {
+    log.info('搜索 WlRoots socket...');
+    const sockets = await invoke<string[]>('maa_find_wlroots_sockets');
+    log.info('找到 WlRoots socket:', sockets.length, '个');
+    sockets.forEach((socket, i) => {
+      log.debug(`  socket[${i}]: ${socket}`);
+    });
+    return sockets;
+  },
+
+  /**
    * 创建实例
    * @param instanceId 实例 ID
    */
@@ -545,6 +558,7 @@ export const maaService = {
     >;
     cachedAdbDevices: AdbDevice[];
     cachedWin32Windows: Win32Window[];
+    cachedWlrootsSockets: string[];
   } | null> {
     if (!isTauri()) return null;
     try {
@@ -561,6 +575,7 @@ export const maaService = {
         >;
         cached_adb_devices: AdbDevice[];
         cached_win32_windows: Win32Window[];
+        cached_wlroots_sockets: string[];
       }>('maa_get_all_states');
 
       // 转换字段名
@@ -589,6 +604,7 @@ export const maaService = {
         instances,
         cachedAdbDevices: states.cached_adb_devices,
         cachedWin32Windows: states.cached_win32_windows,
+        cachedWlrootsSockets: states.cached_wlroots_sockets,
       };
     } catch (err) {
       log.error('获取所有状态失败:', err);
@@ -615,6 +631,18 @@ export const maaService = {
     if (!isTauri()) return [];
     try {
       return await invoke<Win32Window[]>('maa_get_cached_win32_windows');
+    } catch {
+      return [];
+    }
+  },
+
+  /**
+   * 获取缓存的 WlRoots socket 列表
+   */
+  async getCachedWlrootsSockets(): Promise<string[]> {
+    if (!isTauri()) return [];
+    try {
+      return await invoke<string[]>('maa_get_cached_wlroots_sockets');
     } catch {
       return [];
     }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1275,8 +1275,10 @@ export const useAppStore = create<AppState>()(
     // 设备列表缓存
     cachedAdbDevices: [],
     cachedWin32Windows: [],
+    cachedWlrootsSockets: [],
     setCachedAdbDevices: (devices) => set({ cachedAdbDevices: devices }),
     setCachedWin32Windows: (windows) => set({ cachedWin32Windows: windows }),
+    setCachedWlrootsSockets: (sockets) => set({ cachedWlrootsSockets: sockets }),
 
     // 从后端恢复 MAA 运行时状态
     restoreBackendStates: (states) =>

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1319,6 +1319,7 @@ export const useAppStore = create<AppState>()(
           instanceTaskStatus: taskStatus,
           cachedAdbDevices: states.cachedAdbDevices,
           cachedWin32Windows: states.cachedWin32Windows,
+          cachedWlrootsSockets: states.cachedWlrootsSockets,
         };
       }),
 

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -249,8 +249,10 @@ export interface AppState {
   // 设备列表缓存
   cachedAdbDevices: AdbDevice[];
   cachedWin32Windows: Win32Window[];
+  cachedWlrootsSockets: string[];
   setCachedAdbDevices: (devices: AdbDevice[]) => void;
   setCachedWin32Windows: (windows: Win32Window[]) => void;
+  setCachedWlrootsSockets: (sockets: string[]) => void;
 
   // 从后端恢复 MAA 运行时状态
   restoreBackendStates: (states: {
@@ -266,6 +268,7 @@ export interface AppState {
     >;
     cachedAdbDevices: AdbDevice[];
     cachedWin32Windows: Win32Window[];
+    cachedWlrootsSockets: string[];
   }) => void;
 
   // 截图流状态

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -27,6 +27,8 @@ export interface SavedDeviceInfo {
   adbDeviceName?: string;
   // Win32/Gamepad：保存窗口名称
   windowName?: string;
+  // WlRoots：保存 Wayland socket 路径
+  wlrSocketPath?: string;
   // PlayCover：保存地址
   playcoverAddress?: string;
 }

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -58,7 +58,7 @@ export function normalizeAgentConfigs(
   return Array.isArray(agent) ? agent : [agent];
 }
 
-export type ControllerType = 'Adb' | 'Win32' | 'PlayCover' | 'Gamepad';
+export type ControllerType = 'Adb' | 'Win32' | 'WlRoots' | 'PlayCover' | 'Gamepad';
 
 export interface ControllerItem {
   name: string;
@@ -76,6 +76,7 @@ export interface ControllerItem {
   option?: string[];
   adb?: Record<string, unknown>;
   win32?: Win32Config;
+  wlroots?: WlRootsConfig;
   playcover?: PlayCoverConfig;
   gamepad?: GamepadConfig;
 }
@@ -86,6 +87,10 @@ export interface Win32Config {
   mouse?: string;
   keyboard?: string;
   screencap?: string | string[];
+}
+
+export interface WlRootsConfig {
+  wlr_socket_path?: string;
 }
 
 export interface PlayCoverConfig {
@@ -232,6 +237,7 @@ export type OptionValue =
 export interface SavedDeviceInfo {
   adbDeviceName?: string;
   windowName?: string;
+  wlrSocketPath?: string;
   playcoverAddress?: string;
 }
 

--- a/src/types/maa.ts
+++ b/src/types/maa.ts
@@ -36,6 +36,12 @@ export interface Win32ControllerConfig {
   keyboard_method: number;
 }
 
+/** WlRoots 控制器配置 (Linux) */
+export interface WlRootsControllerConfig {
+  type: 'WlRoots';
+  wlr_socket_path: string;
+}
+
 /** PlayCover 控制器配置 (macOS) */
 export interface PlayCoverControllerConfig {
   type: 'PlayCover';
@@ -53,6 +59,7 @@ export interface GamepadControllerConfig {
 export type ControllerConfig =
   | AdbControllerConfig
   | Win32ControllerConfig
+  | WlRootsControllerConfig
   | PlayCoverControllerConfig
   | GamepadControllerConfig;
 

--- a/src/utils/useMaaCallbackLogger.ts
+++ b/src/utils/useMaaCallbackLogger.ts
@@ -160,6 +160,8 @@ function inferCtrlInfoFromInstance(instanceId: string): {
     return { type: 'window', name: savedDevice?.windowName };
   } else if (controller.type === 'Adb') {
     return { type: 'device', name: savedDevice?.adbDeviceName };
+  } else if (controller.type === 'WlRoots') {
+    return { type: 'device', name: savedDevice?.wlrSocketPath };
   } else if (controller.type === 'PlayCover') {
     return { type: 'device', name: savedDevice?.playcoverAddress };
   }


### PR DESCRIPTION
## Summary by Sourcery

在前端和后端中将 WlRoots（Linux Wayland）新增为一等公民级别的控制器类型，包括发现、连接、缓存以及 UI 集成。

新功能：
- 引入 WlRoots 作为新的控制器类型，与 Adb、Win32、PlayCover 和 Gamepad 并列。
- 支持发现可用的 WlRoots Wayland 套接字，并在连接面板、设备选择器和工具栏自动连接中提供自动选择和连接流程。
- 在保存的设备配置和实例状态中持久化并恢复 WlRoots 套接字路径。
- 暴露后端 Tauri 命令和 Maa 控制器配置，用于创建和连接 WlRoots 控制器，包括缓存套接字的管理。

改进：
- 扩展平台能力检测，在非 Linux 平台隐藏 WlRoots 控制项。
- 更新全局应用状态和 Maa 状态缓存结构，将 WlRoots 套接字与现有的 ADB 和 Win32 缓存一并纳入。
- 为所有支持的语言本地化 WlRoots 控制器标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add WlRoots (Linux Wayland) as a first-class controller type across frontend and backend, including discovery, connection, caching, and UI integration.

New Features:
- Introduce WlRoots as a new controller type alongside Adb, Win32, PlayCover, and Gamepad.
- Support discovery of available WlRoots Wayland sockets, with automatic selection and connection flows in the connection panel, device selector, and toolbar auto-connect.
- Persist and restore WlRoots socket paths as part of saved device configuration and instance state.
- Expose backend Tauri commands and Maa controller configuration for creating and connecting WlRoots controllers, including cached socket management.

Enhancements:
- Extend platform capability detection to hide WlRoots controls on non-Linux platforms.
- Update global app state and Maa state caching structures to include WlRoots sockets alongside existing ADB and Win32 caches.
- Localize the WlRoots controller label across all supported languages.

</details>