### PR TITLE
fix: 放开域名白名单限制

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -28,69 +28,47 @@
     "opener:default",
     {
       "identifier": "opener:allow-open-path",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "opener:allow-reveal-item-in-dir",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-read-file",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-exists",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-read-text-file",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-write-text-file",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-write-file",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-mkdir",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-remove",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-read-dir",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     {
       "identifier": "fs:allow-rename",
-      "allow": [
-        { "path": "**/*" }
-      ]
+      "allow": [{ "path": "**/*" }]
     },
     "fs:allow-appdata-read-recursive",
     "fs:allow-appdata-write-recursive",
@@ -99,13 +77,7 @@
     "core:path:default",
     {
       "identifier": "http:default",
-      "allow": [
-        { "url": "https://mirrorchyan.com/**" },
-        { "url": "https://mirrorchyan.net/**" },
-        { "url": "https://api.github.com/**" },
-        { "url": "https://github.com/**" },
-        { "url": "https://objects.githubusercontent.com/**" }
-      ]
+      "allow": [{ "url": "https://**" }, { "url": "http://**" }]
     },
     "process:allow-restart",
     "process:allow-exit",


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 调整 Tauri 的默认权限设置，移除过于严格的域名白名单限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust Tauri default capabilities to remove overly strict domain whitelist limitations.

</details>