### PR TITLE
fix: 修复关闭被控端关闭时,关闭自身无法生效

### DIFF
--- a/src/components/AddTaskPanel.tsx
+++ b/src/components/AddTaskPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
 import { maaService } from '@/services/maaService';
+import { scheduleExitAfterTaskQueueSettled } from '@/services/uiTaskService';
 import { useResolvedContent } from '@/services/contentResolver';
 import { loggers, generateTaskPipelineOverride } from '@/utils';
 import { getInterfaceLangKey } from '@/i18n';
@@ -27,6 +28,7 @@ import type { TaskItem, ActionConfig, GroupItem } from '@/types/interface';
 import type { MxuSpecialTaskDefinition } from '@/types/specialTasks';
 import {
   getAllMxuSpecialTasks,
+  isMxuKillProcSelfMode,
   MXU_LAUNCH_TASK_NAME,
   MXU_KILLPROC_TASK_NAME,
 } from '@/types/specialTasks';
@@ -288,6 +290,12 @@ export function AddTaskPanel() {
 
         if (!addedTask) {
           log.warn(`无法找到刚添加的特殊任务: ${specialTask.taskName}`);
+          return;
+        }
+
+        if (isMxuKillProcSelfMode(addedTask)) {
+          log.info(`运行中追加关闭自身模式任务，将在当前队列结束后关闭自身`);
+          scheduleExitAfterTaskQueueSettled(instance.id);
           return;
         }
 

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -32,13 +32,14 @@ import { loggers, generateTaskPipelineOverride } from '@/utils';
 import type { TaskConfig } from '@/types/maa';
 import { normalizeAgentConfigs } from '@/types/interface';
 import { getInterfaceLangKey } from '@/i18n';
-import { getMxuSpecialTask, isMxuKillProcSelfMode } from '@/types/specialTasks';
+import { getMxuSpecialTask } from '@/types/specialTasks';
 import { startGlobalCallbackListener } from '@/components/connection/callbackCache';
 import { stopInstanceTasks } from '@/services/taskStopService';
 import {
   clearExitAfterTaskQueueSettled,
   exitAppDirectly,
   scheduleExitAfterTaskQueueSettled,
+  splitSelfClosingTasks,
 } from '@/services/uiTaskService';
 import { buildPiEnvVars } from '@/utils/piEnv';
 
@@ -112,9 +113,9 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
   const tasks = instance?.selectedTasks || [];
   const enabledTasks = tasks.filter((t) => t.enabled);
   const canRun = isConnected && isResourceLoaded && enabledTasks.length > 0;
-  const firstSelfManagedTaskIndex = enabledTasks.findIndex((task) => isMxuKillProcSelfMode(task));
+  const { tasksToRun, shouldExitAfterQueue } = splitSelfClosingTasks(enabledTasks);
   const canRunWithoutConnection =
-    enabledTasks.length > 0 && firstSelfManagedTaskIndex === 0;
+    enabledTasks.length > 0 && tasksToRun.length === 0 && shouldExitAfterQueue;
 
   // 获取当前控制器和资源名（用于 pipeline override 生成）
   const currentControllerName =
@@ -199,7 +200,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
     async (e: React.MouseEvent) => {
       e.stopPropagation();
 
-      if (!instance || ((!canRun && !canRunWithoutConnection) && !isRunning)) return;
+      if (!instance || (!canRun && !canRunWithoutConnection && !isRunning)) return;
 
       if (isRunning) {
         // 停止任务
@@ -224,13 +225,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
         try {
           log.info(`[${instanceName}] 开始执行任务, 数量:`, enabledTasks.length);
 
-          const tasksBeforeSelfManaged =
-            firstSelfManagedTaskIndex >= 0
-              ? enabledTasks.slice(0, firstSelfManagedTaskIndex)
-              : enabledTasks;
-          const shouldExitAfterQueue = firstSelfManagedTaskIndex >= 0;
-
-          if (shouldExitAfterQueue && tasksBeforeSelfManaged.length === 0) {
+          if (shouldExitAfterQueue && tasksToRun.length === 0) {
             log.info(`[${instanceName}] 执行前端关闭自身任务`);
             await exitAppDirectly();
             setIsStarting(false);
@@ -239,7 +234,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
 
           // 构建任务配置列表
           const taskConfigs: TaskConfig[] = [];
-          for (const selectedTask of tasksBeforeSelfManaged) {
+          for (const selectedTask of tasksToRun) {
             // 先检查是否是 MXU 特殊任务
             const specialTask = getMxuSpecialTask(selectedTask.taskName);
             const taskDef =
@@ -270,7 +265,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
 
           if (taskConfigs.length === 0) {
             if (shouldExitAfterQueue) {
-              log.info(`[${instanceName}] 没有需要连接执行的任务，直接关闭自身`);
+              log.info(`[${instanceName}] 前置任务为空，直接关闭自身`);
               await exitAppDirectly();
               setIsStarting(false);
               return;

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -32,9 +32,14 @@ import { loggers, generateTaskPipelineOverride } from '@/utils';
 import type { TaskConfig } from '@/types/maa';
 import { normalizeAgentConfigs } from '@/types/interface';
 import { getInterfaceLangKey } from '@/i18n';
-import { getMxuSpecialTask } from '@/types/specialTasks';
+import { getMxuSpecialTask, isMxuKillProcSelfMode } from '@/types/specialTasks';
 import { startGlobalCallbackListener } from '@/components/connection/callbackCache';
 import { stopInstanceTasks } from '@/services/taskStopService';
+import {
+  clearExitAfterTaskQueueSettled,
+  exitAppDirectly,
+  scheduleExitAfterTaskQueueSettled,
+} from '@/services/uiTaskService';
 import { buildPiEnvVars } from '@/utils/piEnv';
 
 const log = loggers.ui;
@@ -107,6 +112,9 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
   const tasks = instance?.selectedTasks || [];
   const enabledTasks = tasks.filter((t) => t.enabled);
   const canRun = isConnected && isResourceLoaded && enabledTasks.length > 0;
+  const firstSelfManagedTaskIndex = enabledTasks.findIndex((task) => isMxuKillProcSelfMode(task));
+  const canRunWithoutConnection =
+    enabledTasks.length > 0 && firstSelfManagedTaskIndex === 0;
 
   // 获取当前控制器和资源名（用于 pipeline override 生成）
   const currentControllerName =
@@ -191,7 +199,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
     async (e: React.MouseEvent) => {
       e.stopPropagation();
 
-      if (!instance || (!canRun && !isRunning)) return;
+      if (!instance || ((!canRun && !canRunWithoutConnection) && !isRunning)) return;
 
       if (isRunning) {
         // 停止任务
@@ -209,16 +217,29 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
         }
       } else {
         // 启动任务
-        if (!canRun) return;
+        if (!canRun && !canRunWithoutConnection) return;
 
         setIsStarting(true);
 
         try {
           log.info(`[${instanceName}] 开始执行任务, 数量:`, enabledTasks.length);
 
+          const tasksBeforeSelfManaged =
+            firstSelfManagedTaskIndex >= 0
+              ? enabledTasks.slice(0, firstSelfManagedTaskIndex)
+              : enabledTasks;
+          const shouldExitAfterQueue = firstSelfManagedTaskIndex >= 0;
+
+          if (shouldExitAfterQueue && tasksBeforeSelfManaged.length === 0) {
+            log.info(`[${instanceName}] 执行前端关闭自身任务`);
+            await exitAppDirectly();
+            setIsStarting(false);
+            return;
+          }
+
           // 构建任务配置列表
           const taskConfigs: TaskConfig[] = [];
-          for (const selectedTask of enabledTasks) {
+          for (const selectedTask of tasksBeforeSelfManaged) {
             // 先检查是否是 MXU 特殊任务
             const specialTask = getMxuSpecialTask(selectedTask.taskName);
             const taskDef =
@@ -248,9 +269,19 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
           }
 
           if (taskConfigs.length === 0) {
+            if (shouldExitAfterQueue) {
+              log.info(`[${instanceName}] 没有需要连接执行的任务，直接关闭自身`);
+              await exitAppDirectly();
+              setIsStarting(false);
+              return;
+            }
             log.warn(`[${instanceName}] 没有可执行的任务`);
             setIsStarting(false);
             return;
+          }
+
+          if (shouldExitAfterQueue) {
+            scheduleExitAfterTaskQueueSettled(instanceId);
           }
 
           // 准备 Agent 配置（支持单个或多个 Agent）
@@ -289,24 +320,25 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
 
           // 注册 task_id 与任务名的映射（用于日志显示），后端管理状态
           taskIds.forEach((maaTaskId, index) => {
-            if (enabledTasks[index]) {
+            if (tasksToRun[index]) {
               // MXU 特殊任务的 label 需要用 t() 翻译
-              const specialTask = getMxuSpecialTask(enabledTasks[index].taskName);
+              const specialTask = getMxuSpecialTask(tasksToRun[index].taskName);
               const taskDef =
                 specialTask?.taskDef ||
-                projectInterface?.task.find((t) => t.name === enabledTasks[index].taskName);
+                projectInterface?.task.find((t) => t.name === tasksToRun[index].taskName);
               const taskDisplayName =
-                enabledTasks[index].customName ||
+                tasksToRun[index].customName ||
                 (specialTask && taskDef?.label
                   ? t(taskDef.label)
                   : resolveI18nText(taskDef?.label, translations)) ||
-                enabledTasks[index].taskName;
+                tasksToRun[index].taskName;
               registerTaskIdName(maaTaskId, taskDisplayName);
             }
           });
 
           setIsStarting(false);
         } catch (err) {
+          clearExitAfterTaskQueueSettled(instanceId);
           log.error(`[${instanceName}] 任务启动异常:`, err);
           const failedAgentConfigs = normalizeAgentConfigs(projectInterface?.agent);
           if (failedAgentConfigs && failedAgentConfigs.length > 0) {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -15,7 +15,7 @@ import { isTaskCompatible } from '@/stores/helpers';
 import { maaService } from '@/services/maaService';
 import clsx from 'clsx';
 import { loggers, generateTaskPipelineOverride, computeResourcePaths } from '@/utils';
-import { getMxuSpecialTask } from '@/types/specialTasks';
+import { getMxuSpecialTask, isMxuKillProcSelfMode } from '@/types/specialTasks';
 import type { TaskConfig, ControllerConfig } from '@/types/maa';
 import { normalizeAgentConfigs } from '@/types/interface';
 import { parseWin32ScreencapMethod, parseWin32InputMethod } from '@/types/maa';
@@ -32,6 +32,12 @@ import {
 import { scheduleService } from '@/services/scheduleService';
 import { stopInstanceTasks } from '@/services/taskStopService';
 import { isTauri } from '@/utils/paths';
+import {
+  clearExitAfterTaskQueueSettled,
+  exitAppDirectly,
+  scheduleExitAfterTaskQueueSettled,
+  splitSelfClosingTasks,
+} from '@/services/uiTaskService';
 import { buildPiEnvVars } from '@/utils/piEnv';
 
 const log = loggers.task;
@@ -238,6 +244,18 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
         return false;
       }
 
+      const firstSelfManagedTaskIndex = enabledTasks.findIndex((task) => isMxuKillProcSelfMode(task));
+      const tasksBeforeSelfManaged =
+        firstSelfManagedTaskIndex >= 0
+          ? enabledTasks.slice(0, firstSelfManagedTaskIndex)
+          : enabledTasks;
+      const shouldExitAfterQueue = firstSelfManagedTaskIndex >= 0;
+
+      if (shouldExitAfterQueue && tasksBeforeSelfManaged.length === 0) {
+        log.info(`实例 ${targetInstance.name}: 执行前端关闭自身任务`);
+        return await exitAppDirectly();
+      }
+
       // 检查是否正在运行
       if (targetInstance.isRunning || preActionControlledInstanceIdRef.current === targetId) {
         log.warn(`实例 ${targetInstance.name} 正在运行中`);
@@ -249,14 +267,14 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
       const resourceName = selectedResource[targetId] || projectInterface?.resource[0]?.name;
 
       // 过滤掉不兼容当前控制器/资源的任务
-      const compatibleTasks = enabledTasks.filter((t) => {
+      const compatibleTasks = tasksBeforeSelfManaged.filter((t) => {
         const taskDef = projectInterface?.task.find((td) => td.name === t.taskName);
         return isTaskCompatible(taskDef, controllerName, resourceName);
       });
 
       // 如果有任务因不兼容被跳过，记录警告
       const compatibleTaskIds = new Set(compatibleTasks.map((t) => t.id));
-      const skippedTasks = enabledTasks.filter((t) => !compatibleTaskIds.has(t.id));
+      const skippedTasks = tasksBeforeSelfManaged.filter((t) => !compatibleTaskIds.has(t.id));
       if (skippedTasks.length > 0) {
         log.warn(
           `实例 ${targetInstance.name}: ${t('taskList.tasksSkippedDueToIncompatibility', { count: skippedTasks.length })}`,
@@ -296,6 +314,10 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
 
       // 如果所有启用的任务都被过滤掉了，则无法启动
       if (compatibleTasks.length === 0) {
+        if (shouldExitAfterQueue) {
+          log.info(`实例 ${targetInstance.name}: 前置任务为空，直接执行关闭自身`);
+          return await exitAppDirectly();
+        }
         log.warn(`实例 ${targetInstance.name}: ${t('taskList.noCompatibleTasks')}`);
         // 向用户显示明确的错误信息
         addLog(targetId, {
@@ -916,8 +938,16 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
         }
 
         if (runnableTasks.length === 0) {
+          if (shouldExitAfterQueue) {
+            log.info(`实例 ${targetInstance.name}: 没有需要连接执行的任务，直接关闭自身`);
+            return await exitAppDirectly();
+          }
           log.warn(`实例 ${targetInstance.name}: 没有可执行的任务`);
           return false;
+        }
+
+        if (shouldExitAfterQueue) {
+          scheduleExitAfterTaskQueueSettled(targetId);
         }
 
         log.info(`实例 ${targetInstance.name}: 开始执行任务, 数量:`, runnableTasks.length);
@@ -1013,6 +1043,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
 
         return true;
       } catch (err) {
+        clearExitAfterTaskQueueSettled(targetId);
         log.error(`实例 ${targetInstance.name}: 任务启动异常:`, err);
 
         const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -15,7 +15,7 @@ import { isTaskCompatible } from '@/stores/helpers';
 import { maaService } from '@/services/maaService';
 import clsx from 'clsx';
 import { loggers, generateTaskPipelineOverride, computeResourcePaths } from '@/utils';
-import { getMxuSpecialTask, isMxuKillProcSelfMode } from '@/types/specialTasks';
+import { getMxuSpecialTask } from '@/types/specialTasks';
 import type { TaskConfig, ControllerConfig } from '@/types/maa';
 import { normalizeAgentConfigs } from '@/types/interface';
 import { parseWin32ScreencapMethod, parseWin32InputMethod } from '@/types/maa';
@@ -244,14 +244,9 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
         return false;
       }
 
-      const firstSelfManagedTaskIndex = enabledTasks.findIndex((task) => isMxuKillProcSelfMode(task));
-      const tasksBeforeSelfManaged =
-        firstSelfManagedTaskIndex >= 0
-          ? enabledTasks.slice(0, firstSelfManagedTaskIndex)
-          : enabledTasks;
-      const shouldExitAfterQueue = firstSelfManagedTaskIndex >= 0;
+      const { tasksToRun, shouldExitAfterQueue } = splitSelfClosingTasks(enabledTasks);
 
-      if (shouldExitAfterQueue && tasksBeforeSelfManaged.length === 0) {
+      if (shouldExitAfterQueue && tasksToRun.length === 0) {
         log.info(`实例 ${targetInstance.name}: 执行前端关闭自身任务`);
         return await exitAppDirectly();
       }
@@ -267,14 +262,14 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
       const resourceName = selectedResource[targetId] || projectInterface?.resource[0]?.name;
 
       // 过滤掉不兼容当前控制器/资源的任务
-      const compatibleTasks = tasksBeforeSelfManaged.filter((t) => {
+      const compatibleTasks = tasksToRun.filter((t) => {
         const taskDef = projectInterface?.task.find((td) => td.name === t.taskName);
         return isTaskCompatible(taskDef, controllerName, resourceName);
       });
 
       // 如果有任务因不兼容被跳过，记录警告
       const compatibleTaskIds = new Set(compatibleTasks.map((t) => t.id));
-      const skippedTasks = tasksBeforeSelfManaged.filter((t) => !compatibleTaskIds.has(t.id));
+      const skippedTasks = tasksToRun.filter((t) => !compatibleTaskIds.has(t.id));
       if (skippedTasks.length > 0) {
         log.warn(
           `实例 ${targetInstance.name}: ${t('taskList.tasksSkippedDueToIncompatibility', { count: skippedTasks.length })}`,

--- a/src/services/taskMonitor.ts
+++ b/src/services/taskMonitor.ts
@@ -1,19 +1,146 @@
-/**
- * 任务监视器（简化版）
- *
- * 任务状态追踪已迁移到 Rust 后端（通过 MaaFramework tasker sink 回调）。
- * 本模块仅保留 cancelTaskQueueMonitor，用于停止任务时清理可能存在的历史监视器。
- */
+import {
+  TaskResultWaitAbortedError,
+  TaskResultWaitTimeoutError,
+  waitForTaskResult,
+} from '@/components/connection/callbackCache';
+import { useAppStore } from '@/stores/appStore';
+import { normalizeAgentConfigs } from '@/types/interface';
+import { loggers } from '@/utils/logger';
+
+import { maaService } from './maaService';
+import {
+  clearExitAfterTaskQueueSettled,
+  consumeExitAfterTaskQueueSettled,
+  exitAppDirectly,
+} from './uiTaskService';
+
+const log = loggers.task;
 
 const taskMonitorControllers = new Map<string, AbortController>();
 
-/** 取消指定实例的任务队列监视器（如有） */
-export function cancelTaskQueueMonitor(instanceId: string) {
+async function stopAgentIfNeeded(instanceId: string) {
+  const agentConfigs = normalizeAgentConfigs(useAppStore.getState().projectInterface?.agent);
+  if (!agentConfigs || agentConfigs.length === 0) {
+    return;
+  }
+
+  try {
+    await maaService.stopAgent(instanceId);
+  } catch (error) {
+    log.error(`[task-monitor#${instanceId}] 停止 Agent 失败:`, error);
+  }
+}
+
+async function finalizeTaskRun(instanceId: string, status: 'Succeeded' | 'Failed') {
+  const shouldExit = consumeExitAfterTaskQueueSettled(instanceId);
+
+  await stopAgentIfNeeded(instanceId);
+
+  const state = useAppStore.getState();
+  state.setInstanceTaskStatus(instanceId, status);
+  state.updateInstance(instanceId, { isRunning: false });
+  state.setInstanceCurrentTaskId(instanceId, null);
+  state.clearPendingTasks(instanceId);
+  state.clearScheduleExecution(instanceId);
+
+  if (shouldExit) {
+    log.info(`[task-monitor#${instanceId}] 任务队列结束，执行前端关闭自身`);
+    await exitAppDirectly();
+  }
+}
+
+function getPendingTaskIds(instanceId: string) {
+  return useAppStore.getState().instancePendingTaskIds[instanceId] || [];
+}
+
+async function monitorTaskQueue(instanceId: string, controller: AbortController) {
+  const initialTaskIds = getPendingTaskIds(instanceId);
+  if (initialTaskIds.length === 0) {
+    log.error(`[task-monitor#${instanceId}] 后端未返回 task_id，终止本次运行`);
+    taskMonitorControllers.delete(instanceId);
+    await finalizeTaskRun(instanceId, 'Failed');
+    return;
+  }
+
+  let hasFailed = false;
+  let index = 0;
+
+  while (true) {
+    if (controller.signal.aborted || taskMonitorControllers.get(instanceId) !== controller) {
+      return;
+    }
+
+    const taskIds = getPendingTaskIds(instanceId);
+    const taskId = taskIds[index];
+    if (taskId === undefined) {
+      break;
+    }
+
+    const state = useAppStore.getState();
+    state.setCurrentTaskIndex(instanceId, index);
+    state.setInstanceCurrentTaskId(instanceId, taskId);
+
+    const selectedTaskId = state.findSelectedTaskIdByMaaTaskId(instanceId, taskId);
+    if (selectedTaskId) {
+      state.setTaskRunStatus(instanceId, selectedTaskId, 'running');
+    }
+
+    const result = await waitForTaskResult(taskId, { signal: controller.signal });
+
+    if (controller.signal.aborted || taskMonitorControllers.get(instanceId) !== controller) {
+      return;
+    }
+
+    const latestState = useAppStore.getState();
+    const latestSelectedTaskId = latestState.findSelectedTaskIdByMaaTaskId(instanceId, taskId);
+    if (latestSelectedTaskId) {
+      latestState.setTaskRunStatus(
+        instanceId,
+        latestSelectedTaskId,
+        result === 'succeeded' ? 'succeeded' : 'failed',
+      );
+    }
+
+    if (result === 'failed') {
+      hasFailed = true;
+    }
+
+    index += 1;
+  }
+
+  if (taskMonitorControllers.get(instanceId) !== controller) {
+    return;
+  }
+
+  taskMonitorControllers.delete(instanceId);
+  await finalizeTaskRun(instanceId, hasFailed ? 'Failed' : 'Succeeded');
+}
+
+
+function cancelTaskQueueMonitorInternal(instanceId: string, clearExitSchedule: boolean) {
   const controller = taskMonitorControllers.get(instanceId);
   if (!controller) {
+    if (clearExitSchedule) {
+      clearExitAfterTaskQueueSettled(instanceId);
+    }
     return;
   }
 
   controller.abort();
   taskMonitorControllers.delete(instanceId);
+  if (clearExitSchedule) {
+    clearExitAfterTaskQueueSettled(instanceId);
+  }
+}
+
+export function cancelTaskQueueMonitor(instanceId: string) {
+  cancelTaskQueueMonitorInternal(instanceId, true);
+}
+
+export function startTaskQueueMonitor(instanceId: string) {
+  cancelTaskQueueMonitorInternal(instanceId, false);
+
+  const controller = new AbortController();
+  taskMonitorControllers.set(instanceId, controller);
+  monitorTaskQueue(instanceId, controller);
 }

--- a/src/services/uiTaskService.ts
+++ b/src/services/uiTaskService.ts
@@ -1,0 +1,37 @@
+import { loggers } from '@/utils/logger';
+import { isTauri } from '@/utils/paths';
+
+const log = loggers.task;
+
+const exitAfterQueueSettled = new Set<string>();
+
+export function scheduleExitAfterTaskQueueSettled(instanceId: string) {
+  exitAfterQueueSettled.add(instanceId);
+}
+
+export function clearExitAfterTaskQueueSettled(instanceId: string) {
+  exitAfterQueueSettled.delete(instanceId);
+}
+
+export function consumeExitAfterTaskQueueSettled(instanceId: string): boolean {
+  const scheduled = exitAfterQueueSettled.has(instanceId);
+  if (scheduled) {
+    exitAfterQueueSettled.delete(instanceId);
+  }
+  return scheduled;
+}
+
+export async function exitAppDirectly(): Promise<boolean> {
+  if (!isTauri()) {
+    return true;
+  }
+
+  try {
+    const { exit } = await import('@tauri-apps/plugin-process');
+    await exit(0);
+    return true;
+  } catch (error) {
+    log.error('前端执行关闭自身失败:', error);
+    return false;
+  }
+}

--- a/src/services/uiTaskService.ts
+++ b/src/services/uiTaskService.ts
@@ -1,5 +1,7 @@
 import { loggers } from '@/utils/logger';
 import { isTauri } from '@/utils/paths';
+import type { SelectedTask } from '@/types/interface';
+import { isMxuKillProcSelfMode } from '@/types/specialTasks';
 
 const log = loggers.task;
 
@@ -21,9 +23,39 @@ export function consumeExitAfterTaskQueueSettled(instanceId: string): boolean {
   return scheduled;
 }
 
+export interface SelfClosingTaskSplit {
+  tasksToRun: SelectedTask[];
+  shouldExitAfterQueue: boolean;
+}
+
+/**
+ * 从启用的任务列表中分离出"关闭自身"任务。
+ * 关闭自身任务及其之后的所有任务不会提交给 MaaFramework，
+ * 而是由前端在队列结束后直接执行退出。
+ */
+export function splitSelfClosingTasks(enabledTasks: SelectedTask[]): SelfClosingTaskSplit {
+  const selfIndex = enabledTasks.findIndex((task) => isMxuKillProcSelfMode(task));
+  if (selfIndex < 0) {
+    return { tasksToRun: enabledTasks, shouldExitAfterQueue: false };
+  }
+
+  const droppedCount = enabledTasks.length - selfIndex - 1;
+  if (droppedCount > 0) {
+    log.warn(
+      `"关闭自身"任务之后还有 ${droppedCount} 个任务，这些任务将不会执行`,
+    );
+  }
+
+  return {
+    tasksToRun: enabledTasks.slice(0, selfIndex),
+    shouldExitAfterQueue: true,
+  };
+}
+
 export async function exitAppDirectly(): Promise<boolean> {
   if (!isTauri()) {
-    return true;
+    log.warn('非 Tauri 环境，无法执行关闭自身');
+    return false;
   }
 
   try {

--- a/src/types/specialTasks.ts
+++ b/src/types/specialTasks.ts
@@ -8,6 +8,7 @@ import type {
   SwitchOption,
   SelectOption,
   OptionDefinition,
+  SelectedTask,
 } from './interface';
 
 /**
@@ -67,6 +68,7 @@ export const MXU_NOTIFY_ACTION = 'MXU_NOTIFY_ACTION';
 export const MXU_KILLPROC_TASK_NAME = '__MXU_KILLPROC__';
 export const MXU_KILLPROC_ENTRY = 'MXU_KILLPROC';
 export const MXU_KILLPROC_ACTION = 'MXU_KILLPROC_ACTION';
+export const MXU_KILLPROC_SELF_OPTION = '__MXU_KILLPROC_SELF_OPTION__';
 
 // MXU_POWER 特殊任务常量
 export const MXU_POWER_TASK_NAME = '__MXU_POWER__';
@@ -658,6 +660,20 @@ export function findMxuOptionByKey(optionKey: string): OptionDefinition | undefi
     if (optionDef) return optionDef;
   }
   return undefined;
+}
+
+/**
+ * 判断“关闭程序”特殊任务当前是否处于“关闭自身”模式
+ */
+export function isMxuKillProcSelfMode(
+  selectedTask: Pick<SelectedTask, 'taskName' | 'optionValues'>,
+): boolean {
+  if (selectedTask.taskName !== MXU_KILLPROC_TASK_NAME) {
+    return false;
+  }
+
+  const selfOption = selectedTask.optionValues[MXU_KILLPROC_SELF_OPTION];
+  return selfOption?.type === 'switch' ? selfOption.value : false;
 }
 
 /**


### PR DESCRIPTION
close https://github.com/MaaEnd/MaaEnd/issues/1882

## Summary by Sourcery

为自闭合的“结束进程（kill process）”任务模式提供支持，并将其集成到实例/任务执行流程中，使应用能在相关任务队列完成后自动退出。

New Features:
- 为 MXU 的 `kill-process` 特殊任务引入自闭合模式，可触发前端应用退出。
- 允许实例和工具栏任务执行在当前任务队列稳定（settle）后，根据自闭合任务模式调度应用退出。
- 支持在自闭合任务是队列中唯一或最后一个相关任务时，直接从前端退出应用。

Bug Fixes:
- 确保任务队列的收尾与取消操作能正确清除所有“队列结束后退出”的待处理状态，以避免意外退出。

Enhancements:
- 按实例跟踪“在任务队列稳定后退出应用”的标志，并在取消或启动失败时将其清除。
- 扩展任务选择逻辑，使自闭合任务在无连接时也可运行，并从正常的 Maa 任务提交中排除，但仍能影响关闭行为。
- 允许向正在运行的队列中添加自闭合任务，以在现有队列完成后安排应用退出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a self-closing "kill process" task mode and integrate it into instance/task execution flows so the app can exit automatically after relevant task queues finish.

New Features:
- Introduce a self-closing mode for the MXU kill-process special task that can trigger the frontend application to exit.
- Allow instance and toolbar task execution to schedule application exit after the current task queue settles based on the self-closing task mode.
- Support directly exiting the application from the frontend when the self-closing task is the only or final relevant task in the queue.

Bug Fixes:
- Ensure task-queue finalization and cancellation correctly clear any pending exit-after-queue state to avoid unintended exits.

Enhancements:
- Track per-instance flags to exit the app after task queues settle and clear them on cancellation or startup failures.
- Extend task selection logic so self-closing tasks can run without a connection and are excluded from normal Maa task submission while still affecting shutdown behavior.
- Enable adding a self-closing task to a running queue to schedule app exit once the existing queue completes.

</details>

## Summary by Sourcery

为 MXU kill-process 任务增加自终止变体的支持，并将其接入任务队列的生命周期，以便在相关任务队列完成后应用可以自动退出。

New Features:
- 引入“特殊任务模式”，将 MXU kill-process 任务视为一种自终止动作，使其可以在没有控制器连接的情况下运行。
- 允许用户在队列运行期间追加一个自终止任务，使应用在当前队列完成后自动退出。

Enhancements:
- 调整任务执行流程（实例卡片、工具栏和监视器），以识别并区分退出前任务和自终止任务，并在这些任务完成后调度应用退出。
- 增加一个共享的 UI 任务服务，用于调度、清除和消费按实例维度的 “exit-after-queue” 标志，并在可用时通过 Tauri 执行直接应用退出。
- 确保在任务启动失败或监视器取消时清除退出调度，以避免意外关闭应用程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a self-termination variant of the MXU kill-process task and wire it into the task queue lifecycle so the app can exit automatically after relevant task queues finish.

New Features:
- Introduce a special-task mode to treat the MXU kill-process task as a self-termination action that can run without a controller connection.
- Allow users to append a self-termination task while a queue is running so the app exits after the current queue completes.

Enhancements:
- Route task execution flows (instance cards, toolbar, and monitor) to recognize and separate pre-exit tasks from the self-termination task, scheduling an app exit once those tasks complete.
- Add a shared UI task service to schedule, clear, and consume per-instance exit-after-queue flags and to perform a direct app exit via Tauri when available.
- Ensure exit scheduling is cleared on task start failures or monitor cancellation to avoid unintended application shutdowns.

</details>