### PR TITLE
feat: 更多的tauri log

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ pub mod ws_broadcast;
 use commands::{AppConfigState, MaaState};
 use std::sync::Arc;
 use tauri::Manager;
-use tauri_plugin_log::{Target, TargetKind, TimezoneStrategy};
+use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
 use ws_broadcast::WsBroadcast;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -37,6 +37,9 @@ pub fn run() {
         ))
         .plugin(
             tauri_plugin_log::Builder::new()
+                // 默认约 40KB + KeepOne 会整文件删除，不便排查；改为单文件更大且保留多份轮转档
+                .max_file_size(1 * 1024 * 1024)
+                .rotation_strategy(RotationStrategy::KeepSome(8))
                 .targets({
                     #[allow(unused_mut)]
                     let mut targets = vec![Target::new(TargetKind::Folder {


### PR DESCRIPTION
8kb不够用
上8MB。

## Summary by Sourcery

增强内容：
- 将 Tauri 日志文件的最大大小提升至 1 MB，并将日志轮换策略改为保留多个日志文件备份，而不是仅保留一个较小的日志文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Raise maximum Tauri log file size to 1 MB and switch to a rotation strategy that keeps several log file backups instead of a single small one.

</details>