### PR TITLE
feat: 手机端添加运行日志按钮

### DIFF
--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -18,7 +18,7 @@ use axum::{
 };
 #[cfg(not(debug_assertions))]
 use rust_embed::RustEmbed;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{Any, CorsLayer};
 
 use crate::commands::{
     app_config::AppConfigState,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ import { ConnectionLostOverlay } from './components/app/ConnectionLostOverlay';
 import { WebUIBetaBanner } from './components/app/WebUIBetaBanner';
 import { startGlobalCallbackListener } from './components/connection/callbackCache';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { ScrollText } from 'lucide-react';
 
 const log = loggers.app;
 
@@ -1827,6 +1828,17 @@ function App() {
                 <LogsPanel />
               </div>
             </div>
+
+            {/* 浮动按钮：定位到运行日志 */}
+            <button
+              onClick={() =>
+                document.getElementById('logs-panel')?.scrollIntoView({ behavior: 'smooth' })
+              }
+              className="fixed bottom-4 right-4 z-50 p-3 rounded-full bg-accent text-white shadow-lg active:bg-accent-hover transition-colors"
+              title={t('logs.scrollToLogs')}
+            >
+              <ScrollText className="w-5 h-5" />
+            </button>
           </div>
         ) : (
           /* 桌面端横向分栏布局 */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1831,10 +1831,12 @@ function App() {
 
             {/* 浮动按钮：定位到运行日志 */}
             <button
+              type="button"
               onClick={() =>
                 document.getElementById('logs-panel')?.scrollIntoView({ behavior: 'smooth' })
               }
               className="fixed bottom-4 right-4 z-50 p-3 rounded-full bg-accent text-white shadow-lg active:bg-accent-hover transition-colors"
+              aria-label={t('logs.scrollToLogs')}
               title={t('logs.scrollToLogs')}
             >
               <ScrollText className="w-5 h-5" />

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -124,7 +124,13 @@ export function LogsPanel() {
   };
 
   return (
-    <div className="flex-1 flex flex-col bg-bg-secondary rounded-lg ring-1 ring-inset ring-border overflow-hidden min-h-50">
+    <div
+      id="logs-panel"
+      className={clsx(
+        'flex flex-col bg-bg-secondary rounded-lg ring-1 ring-inset ring-border overflow-hidden',
+        isMobile ? 'h-[calc(100dvh-2.5rem)]' : 'flex-1 min-h-50',
+      )}
+    >
       {/* 标题栏（桌面端可点击展开/折叠上方面板，移动端仅显示标题） */}
       <div
         role={isMobile ? undefined : 'button'}
@@ -204,10 +210,7 @@ export function LogsPanel() {
       {/* 日志内容 */}
       <div
         ref={logsContainerRef}
-        className={clsx(
-          'flex-1 min-h-0 overflow-y-auto p-2 font-mono text-xs bg-bg-tertiary',
-          isMobile && 'max-h-64',
-        )}
+        className="flex-1 min-h-0 overflow-y-auto p-2 font-mono text-xs bg-bg-tertiary"
         onContextMenu={handleContextMenu}
       >
         {logs.length === 0 ? (

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -128,6 +128,7 @@ export function LogsPanel() {
       id="logs-panel"
       className={clsx(
         'flex flex-col bg-bg-secondary rounded-lg ring-1 ring-inset ring-border overflow-hidden',
+        // 2.5rem = TabBar h-10；若 TabBar 高度变更需同步更新
         isMobile ? 'h-[calc(100dvh-2.5rem)]' : 'flex-1 min-h-50',
       )}
     >

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -432,6 +432,7 @@ export default {
     copyAll: 'Copy All',
     expand: 'Expand panels above',
     collapse: 'Collapse panels above',
+    scrollToLogs: 'View logs',
     // Log messages
     messages: {
       // Connection messages

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -429,6 +429,7 @@ export default {
     copyAll: 'すべてコピー',
     expand: '上部パネルを展開',
     collapse: '上部パネルを折りたたむ',
+    scrollToLogs: 'ログを表示',
     // ログメッセージ
     messages: {
       // 接続メッセージ

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -427,6 +427,7 @@ export default {
     copyAll: '모두 복사',
     expand: '상단 패널 펼치기',
     collapse: '상단 패널 접기',
+    scrollToLogs: '로그 보기',
     // 로그 메시지
     messages: {
       // 연결 메시지

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -423,6 +423,7 @@ export default {
     copyAll: '复制全部',
     expand: '展开上方面板',
     collapse: '折叠上方面板',
+    scrollToLogs: '查看日志',
     // 日志消息
     messages: {
       // 连接消息

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -419,6 +419,7 @@ export default {
     copyAll: '複製全部',
     expand: '展開上方面板',
     collapse: '摺疊上方面板',
+    scrollToLogs: '查看日誌',
     // 日誌訊息
     messages: {
       // 連接訊息


### PR DESCRIPTION
## Summary by Sourcery

添加适配移动端的浮动按钮，用于快速滚动到日志面板，并为移动端视图调整日志面板布局。

新功能：
- 在移动端引入浮动操作按钮，可直接滚动到日志面板。
- 为新的“滚动至日志”按钮在所有受支持语言中添加本地化的工具提示文本。

增强改进：
- 调整日志面板的尺寸行为，使其更好地适配移动端视口高度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a mobile-friendly floating button to quickly scroll to the logs panel and adjust the logs panel layout for mobile view.

New Features:
- Introduce a floating action button on mobile to scroll directly to the logs panel.
- Add localized tooltip text for the new scroll-to-logs button across supported languages.

Enhancements:
- Adjust logs panel sizing behavior to better fit the mobile viewport height.

</details>