### PR TITLE
feat: 支持多个前置任务，并丰富相关功能

### DIFF
--- a/src/components/ActionItem.tsx
+++ b/src/components/ActionItem.tsx
@@ -1,26 +1,12 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  ChevronRight,
-  ChevronUp,
-  ChevronDown,
-  ChevronsUp,
-  ChevronsDown,
-  X,
-  Check,
-  Play,
-  GripVertical,
-  Copy,
-  Edit3,
-  Trash2,
-  ToggleLeft,
-  ToggleRight,
-} from 'lucide-react';
+import { ChevronRight, X, Play, GripVertical } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useAppStore } from '@/stores/appStore';
-import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
+import { ContextMenu, useContextMenu } from './ContextMenu';
 import { ConfirmDialog } from './ConfirmDialog';
+import { buildListItemMenuItems, InlineNameEditor } from './listItemShared';
 import type { ActionConfig } from '@/types/interface';
 import clsx from 'clsx';
 import { FileField, TextField, SwitchField } from './FormControls';
@@ -30,9 +16,7 @@ interface ActionItemProps {
   action: ActionConfig;
   disabled?: boolean;
   canReorder?: boolean;
-  /** 在前置程序列表中的索引 */
   index: number;
-  /** 前置程序总数 */
   total: number;
 }
 
@@ -129,7 +113,6 @@ export function ActionItem({
     updateAction({ enabled: !currentAction.enabled });
   };
 
-  // 重命名
   const handleSaveEdit = () => {
     renamePreAction(instanceId, action.id, editName.trim());
     setIsEditing(false);
@@ -140,93 +123,44 @@ export function ActionItem({
     setEditName('');
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') handleSaveEdit();
-    else if (e.key === 'Escape') handleCancelEdit();
-  };
-
   // 右键菜单
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
 
-      const isFirst = index === 0;
-      const isLast = index === total - 1;
-      const canMove = !disabled && total > 1;
-
-      const menuItems: MenuItem[] = [
-        {
-          id: 'duplicate',
-          label: t('contextMenu.duplicateAction'),
-          icon: Copy,
-          disabled: !!disabled,
-          onClick: () => duplicatePreAction(instanceId, action.id),
+      const menuItems = buildListItemMenuItems({
+        labels: {
+          duplicate: t('contextMenu.duplicateAction'),
+          rename: t('contextMenu.renameAction'),
+          enable: t('contextMenu.enableAction'),
+          disable: t('contextMenu.disableAction'),
+          expand: t('contextMenu.expandAction'),
+          collapse: t('contextMenu.collapseAction'),
+          moveUp: t('contextMenu.moveUp'),
+          moveDown: t('contextMenu.moveDown'),
+          moveToTop: t('contextMenu.moveToTop'),
+          moveToBottom: t('contextMenu.moveToBottom'),
+          delete: t('contextMenu.deleteAction'),
         },
-        {
-          id: 'rename',
-          label: t('contextMenu.renameAction'),
-          icon: Edit3,
-          onClick: () => {
-            setEditName(currentAction.customName || '');
-            setIsEditing(true);
-          },
+        isEnabled: currentAction.enabled,
+        isExpanded: expanded,
+        isFirst: index === 0,
+        isLast: index === total - 1,
+        isLocked: !!disabled,
+        onDuplicate: () => duplicatePreAction(instanceId, action.id),
+        onRename: () => {
+          setEditName(currentAction.customName || '');
+          setIsEditing(true);
         },
-        { id: 'divider-1', label: '', divider: true },
-        {
-          id: 'toggle',
-          label: currentAction.enabled
-            ? t('contextMenu.disableAction')
-            : t('contextMenu.enableAction'),
-          icon: currentAction.enabled ? ToggleLeft : ToggleRight,
-          disabled: !!disabled,
-          onClick: () => updateAction({ enabled: !currentAction.enabled }),
-        },
-        {
-          id: 'expand',
-          label: expanded ? t('contextMenu.collapseAction') : t('contextMenu.expandAction'),
-          icon: expanded ? ChevronUp : ChevronDown,
-          onClick: () => setExpanded(!expanded),
-        },
-        { id: 'divider-2', label: '', divider: true },
-        {
-          id: 'move-up',
-          label: t('contextMenu.moveUp'),
-          icon: ChevronUp,
-          disabled: isFirst || !canMove,
-          onClick: () => reorderPreActions(instanceId, index, index - 1),
-        },
-        {
-          id: 'move-down',
-          label: t('contextMenu.moveDown'),
-          icon: ChevronDown,
-          disabled: isLast || !canMove,
-          onClick: () => reorderPreActions(instanceId, index, index + 1),
-        },
-        {
-          id: 'move-top',
-          label: t('contextMenu.moveToTop'),
-          icon: ChevronsUp,
-          disabled: isFirst || !canMove,
-          onClick: () => reorderPreActions(instanceId, index, 0),
-        },
-        {
-          id: 'move-bottom',
-          label: t('contextMenu.moveToBottom'),
-          icon: ChevronsDown,
-          disabled: isLast || !canMove,
-          onClick: () => reorderPreActions(instanceId, index, total - 1),
-        },
-        { id: 'divider-3', label: '', divider: true },
-        {
-          id: 'delete',
-          label: t('contextMenu.deleteAction'),
-          icon: Trash2,
-          danger: true,
-          disabled: !!disabled,
-          onClick: handleRemove,
-        },
-      ];
+        onToggle: () => updateAction({ enabled: !currentAction.enabled }),
+        onExpand: () => setExpanded(!expanded),
+        onMoveUp: () => reorderPreActions(instanceId, index, index - 1),
+        onMoveDown: () => reorderPreActions(instanceId, index, index + 1),
+        onMoveToTop: () => reorderPreActions(instanceId, index, 0),
+        onMoveToBottom: () => reorderPreActions(instanceId, index, total - 1),
+        onDelete: handleRemove,
+      });
 
       showMenu(e, menuItems);
     },
@@ -298,42 +232,13 @@ export function ActionItem({
         {/* 名称 + 展开区域 */}
         <div className="flex-1 flex items-center min-w-0">
           {isEditing ? (
-            <div className="flex-1 flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-              <input
-                type="text"
-                value={editName}
-                onChange={(e) => setEditName(e.target.value)}
-                onKeyDown={handleKeyDown}
-                onBlur={handleSaveEdit}
-                placeholder={defaultTitle}
-                autoFocus
-                className={clsx(
-                  'flex-1 px-2 py-1 text-sm rounded border border-accent',
-                  'bg-bg-primary text-text-primary',
-                  'focus:outline-none focus:ring-1 focus:ring-accent/20',
-                )}
-              />
-              <button
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleSaveEdit();
-                }}
-                className="p-1 rounded hover:bg-success/10 text-success"
-              >
-                <Check className="w-4 h-4" />
-              </button>
-              <button
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleCancelEdit();
-                }}
-                className="p-1 rounded hover:bg-error/10 text-error"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
+            <InlineNameEditor
+              value={editName}
+              onChange={setEditName}
+              onSave={handleSaveEdit}
+              onCancel={handleCancelEdit}
+              placeholder={defaultTitle}
+            />
           ) : (
             <>
               {/* 名称：点击切换启用 */}
@@ -344,7 +249,7 @@ export function ActionItem({
                 )}
                 onClick={handleToggleEnabled}
               >
-                <Play className={clsx('w-4 h-4 mr-0.5 flex-shrink-0 text-success')} />
+                <Play className="w-4 h-4 mr-0.5 flex-shrink-0 text-success" />
                 <span
                   className={clsx(
                     'min-w-0 text-sm font-medium truncate',
@@ -365,7 +270,6 @@ export function ActionItem({
                 onClick={() => setExpanded(!expanded)}
                 className="flex-1 min-w-0 flex items-center self-stretch min-h-[28px] cursor-pointer"
               >
-                {/* 参数预览标签 - 未展开时显示 */}
                 {!expanded && (
                   <div className="flex-1 flex items-center gap-1.5 mx-2 overflow-hidden">
                     {hasConfig ? (
@@ -385,8 +289,6 @@ export function ActionItem({
                     ) : null}
                   </div>
                 )}
-
-                {/* 展开/折叠箭头 */}
                 <div className="flex shrink-0 items-center justify-end pl-2 ml-auto">
                   <ChevronRight
                     className={clsx(

--- a/src/components/ActionItem.tsx
+++ b/src/components/ActionItem.tsx
@@ -1,18 +1,42 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronRight, X, Play, GripVertical } from 'lucide-react';
+import {
+  ChevronRight,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUp,
+  ChevronsDown,
+  X,
+  Check,
+  Play,
+  GripVertical,
+  Copy,
+  Edit3,
+  Trash2,
+  ToggleLeft,
+  ToggleRight,
+} from 'lucide-react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useAppStore } from '@/stores/appStore';
+import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
+import { ConfirmDialog } from './ConfirmDialog';
 import type { ActionConfig } from '@/types/interface';
 import clsx from 'clsx';
 import { FileField, TextField, SwitchField } from './FormControls';
 
 interface ActionItemProps {
   instanceId: string;
-  action: ActionConfig | undefined;
+  action: ActionConfig;
   disabled?: boolean;
+  canReorder?: boolean;
+  /** 在前置程序列表中的索引 */
+  index: number;
+  /** 前置程序总数 */
+  total: number;
 }
 
-const defaultAction: ActionConfig = {
+const defaultValues: Omit<ActionConfig, 'id'> = {
   enabled: false,
   program: '',
   args: '',
@@ -21,64 +45,236 @@ const defaultAction: ActionConfig = {
   useCmd: false,
 };
 
-export function ActionItem({ instanceId, action, disabled }: ActionItemProps) {
+/** 参数预览标签 */
+function ActionPreviewTag({ label, on }: { label: string; on: boolean }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs rounded text-text-tertiary max-w-[140px]"
+      title={`${label}: ${on ? 'ON' : 'OFF'}`}
+    >
+      <span className="truncate">{label}</span>
+      <span
+        className={clsx(
+          'w-1.5 h-1.5 rounded-full flex-shrink-0',
+          on ? 'bg-success/70' : 'bg-text-muted/50',
+        )}
+      />
+    </span>
+  );
+}
+
+export function ActionItem({
+  instanceId,
+  action,
+  disabled,
+  canReorder,
+  index,
+  total,
+}: ActionItemProps) {
   const { t } = useTranslation();
-  const { setInstancePreAction } = useAppStore();
+  const {
+    updatePreAction,
+    removePreAction,
+    renamePreAction,
+    duplicatePreAction,
+    reorderPreActions,
+    confirmBeforeDelete,
+  } = useAppStore();
+
   const [expanded, setExpanded] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const { state: menuState, show: showMenu, hide: hideMenu } = useContextMenu();
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: action.id,
+    disabled: !canReorder,
+  });
+
+  const constrainedTransform = transform
+    ? { ...transform, x: 0, scaleX: 1, scaleY: 1 }
+    : null;
+
+  const style = {
+    transform: CSS.Transform.toString(constrainedTransform),
+    transition,
+  };
 
   const currentAction = useMemo<ActionConfig>(
-    () => ({
-      ...defaultAction,
-      ...action,
-    }),
+    () => ({ ...defaultValues, ...action }),
     [action],
   );
 
-  const setAction = setInstancePreAction;
+  const defaultTitle = t('action.preAction');
+  const displayName = currentAction.customName || defaultTitle;
+  const hasConfig = currentAction.program.trim().length > 0;
 
-  const title = t('action.preAction');
-  const Icon = Play;
-  const iconColor = 'text-success';
-
-  // 删除动作
-  const handleRemove = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleRemove = () => {
     if (disabled) return;
-    setAction(instanceId, undefined);
+    if (confirmBeforeDelete) {
+      setShowDeleteConfirm(true);
+    } else {
+      removePreAction(instanceId, action.id);
+    }
   };
 
-  // 更新动作配置
   const updateAction = (updates: Partial<ActionConfig>) => {
-    setAction(instanceId, {
-      ...currentAction,
-      ...updates,
-    });
+    updatePreAction(instanceId, action.id, updates);
   };
 
-  // 切换启用状态
   const handleToggleEnabled = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (disabled) return;
     updateAction({ enabled: !currentAction.enabled });
   };
 
-  // 判断是否有有效配置（有程序路径）
-  const hasConfig = currentAction.program.trim().length > 0;
+  // 重命名
+  const handleSaveEdit = () => {
+    renamePreAction(instanceId, action.id, editName.trim());
+    setIsEditing(false);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setEditName('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleSaveEdit();
+    else if (e.key === 'Escape') handleCancelEdit();
+  };
+
+  // 右键菜单
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const isFirst = index === 0;
+      const isLast = index === total - 1;
+      const canMove = !disabled && total > 1;
+
+      const menuItems: MenuItem[] = [
+        {
+          id: 'duplicate',
+          label: t('contextMenu.duplicateAction'),
+          icon: Copy,
+          disabled: !!disabled,
+          onClick: () => duplicatePreAction(instanceId, action.id),
+        },
+        {
+          id: 'rename',
+          label: t('contextMenu.renameAction'),
+          icon: Edit3,
+          onClick: () => {
+            setEditName(currentAction.customName || '');
+            setIsEditing(true);
+          },
+        },
+        { id: 'divider-1', label: '', divider: true },
+        {
+          id: 'toggle',
+          label: currentAction.enabled
+            ? t('contextMenu.disableAction')
+            : t('contextMenu.enableAction'),
+          icon: currentAction.enabled ? ToggleLeft : ToggleRight,
+          disabled: !!disabled,
+          onClick: () => updateAction({ enabled: !currentAction.enabled }),
+        },
+        {
+          id: 'expand',
+          label: expanded ? t('contextMenu.collapseAction') : t('contextMenu.expandAction'),
+          icon: expanded ? ChevronUp : ChevronDown,
+          onClick: () => setExpanded(!expanded),
+        },
+        { id: 'divider-2', label: '', divider: true },
+        {
+          id: 'move-up',
+          label: t('contextMenu.moveUp'),
+          icon: ChevronUp,
+          disabled: isFirst || !canMove,
+          onClick: () => reorderPreActions(instanceId, index, index - 1),
+        },
+        {
+          id: 'move-down',
+          label: t('contextMenu.moveDown'),
+          icon: ChevronDown,
+          disabled: isLast || !canMove,
+          onClick: () => reorderPreActions(instanceId, index, index + 1),
+        },
+        {
+          id: 'move-top',
+          label: t('contextMenu.moveToTop'),
+          icon: ChevronsUp,
+          disabled: isFirst || !canMove,
+          onClick: () => reorderPreActions(instanceId, index, 0),
+        },
+        {
+          id: 'move-bottom',
+          label: t('contextMenu.moveToBottom'),
+          icon: ChevronsDown,
+          disabled: isLast || !canMove,
+          onClick: () => reorderPreActions(instanceId, index, total - 1),
+        },
+        { id: 'divider-3', label: '', divider: true },
+        {
+          id: 'delete',
+          label: t('contextMenu.deleteAction'),
+          icon: Trash2,
+          danger: true,
+          disabled: !!disabled,
+          onClick: handleRemove,
+        },
+      ];
+
+      showMenu(e, menuItems);
+    },
+    [
+      t,
+      action.id,
+      instanceId,
+      index,
+      total,
+      disabled,
+      expanded,
+      currentAction.enabled,
+      currentAction.customName,
+      duplicatePreAction,
+      reorderPreActions,
+      updateAction,
+      showMenu,
+      handleRemove,
+    ],
+  );
 
   return (
     <div
+      ref={setNodeRef}
+      style={style}
+      onContextMenu={handleContextMenu}
       className={clsx(
         'group rounded-lg border overflow-hidden transition-shadow flex-shrink-0',
         currentAction.enabled
           ? 'bg-bg-secondary border-border'
           : 'bg-bg-secondary/50 border-border/50',
         disabled && 'opacity-50',
+        isDragging && 'opacity-50 shadow-lg z-10',
       )}
     >
       {/* 头部 */}
       <div className="flex items-center gap-2 p-3">
-        {/* 拖拽手柄占位（不可拖拽，仅用于对齐） */}
-        <div className="p-1 rounded opacity-30 cursor-not-allowed">
+        {/* 拖拽手柄 */}
+        <div
+          {...attributes}
+          {...listeners}
+          className={clsx(
+            'p-1 rounded',
+            canReorder
+              ? 'cursor-grab active:cursor-grabbing hover:bg-bg-hover'
+              : 'opacity-30 cursor-not-allowed',
+          )}
+        >
           <GripVertical className="w-4 h-4 text-text-muted" />
         </div>
 
@@ -99,45 +295,118 @@ export function ActionItem({ instanceId, action, disabled }: ActionItemProps) {
           />
         </label>
 
-        {/* 动作名称 + 展开区域 */}
-        <div
-          className="flex-1 flex items-center min-w-0 cursor-pointer"
-          onClick={() => setExpanded(!expanded)}
-        >
-          {/* 图标 */}
-          <Icon className={clsx('w-4 h-4 mr-1.5 flex-shrink-0', iconColor)} />
+        {/* 名称 + 展开区域 */}
+        <div className="flex-1 flex items-center min-w-0">
+          {isEditing ? (
+            <div className="flex-1 flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+              <input
+                type="text"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleSaveEdit}
+                placeholder={defaultTitle}
+                autoFocus
+                className={clsx(
+                  'flex-1 px-2 py-1 text-sm rounded border border-accent',
+                  'bg-bg-primary text-text-primary',
+                  'focus:outline-none focus:ring-1 focus:ring-accent/20',
+                )}
+              />
+              <button
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleSaveEdit();
+                }}
+                className="p-1 rounded hover:bg-success/10 text-success"
+              >
+                <Check className="w-4 h-4" />
+              </button>
+              <button
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleCancelEdit();
+                }}
+                className="p-1 rounded hover:bg-error/10 text-error"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* 名称：点击切换启用 */}
+              <div
+                className={clsx(
+                  'flex items-center gap-1 min-w-0 overflow-hidden',
+                  disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                )}
+                onClick={handleToggleEnabled}
+              >
+                <Play className={clsx('w-4 h-4 mr-0.5 flex-shrink-0 text-success')} />
+                <span
+                  className={clsx(
+                    'min-w-0 text-sm font-medium truncate',
+                    currentAction.enabled ? 'text-text-primary' : 'text-text-muted',
+                  )}
+                >
+                  {displayName}
+                </span>
+                {currentAction.customName && (
+                  <span className="min-w-0 truncate text-xs text-text-muted">
+                    ({defaultTitle})
+                  </span>
+                )}
+              </div>
 
-          <span
-            className={clsx(
-              'text-sm font-medium truncate',
-              currentAction.enabled ? 'text-text-primary' : 'text-text-muted',
-            )}
-          >
-            {title}
-          </span>
+              {/* 展开/折叠点击区域（含参数预览） */}
+              <div
+                onClick={() => setExpanded(!expanded)}
+                className="flex-1 min-w-0 flex items-center self-stretch min-h-[28px] cursor-pointer"
+              >
+                {/* 参数预览标签 - 未展开时显示 */}
+                {!expanded && (
+                  <div className="flex-1 flex items-center gap-1.5 mx-2 overflow-hidden">
+                    {hasConfig ? (
+                      <>
+                        <span className="inline-flex items-center px-1.5 py-0.5 text-xs rounded text-text-tertiary max-w-[180px] truncate">
+                          {currentAction.program.split(/[/\\]/).pop()}
+                        </span>
+                        <ActionPreviewTag
+                          label={t('action.waitForExit')}
+                          on={currentAction.waitForExit}
+                        />
+                        <ActionPreviewTag
+                          label={t('action.skipIfRunning')}
+                          on={currentAction.skipIfRunning}
+                        />
+                      </>
+                    ) : null}
+                  </div>
+                )}
 
-          {/* 预览：未展开时显示程序名称 */}
-          {!expanded && hasConfig && (
-            <span className="ml-2 text-xs text-text-tertiary truncate max-w-[200px]">
-              {currentAction.program.split(/[/\\]/).pop()}
-            </span>
+                {/* 展开/折叠箭头 */}
+                <div className="flex shrink-0 items-center justify-end pl-2 ml-auto">
+                  <ChevronRight
+                    className={clsx(
+                      'w-4 h-4 text-text-secondary transition-transform duration-150 ease-out',
+                      expanded && 'rotate-90',
+                    )}
+                  />
+                </div>
+              </div>
+            </>
           )}
-
-          {/* 展开/折叠箭头 */}
-          <div className="flex items-center justify-end pl-2 ml-auto">
-            <ChevronRight
-              className={clsx(
-                'w-4 h-4 text-text-secondary transition-transform duration-150 ease-out',
-                expanded && 'rotate-90',
-              )}
-            />
-          </div>
         </div>
 
         {/* 删除按钮 */}
-        {!disabled && (
+        {!disabled && !isEditing && (
           <button
-            onClick={handleRemove}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleRemove();
+            }}
             className={clsx(
               'p-1 rounded opacity-0 group-hover:opacity-100 transition-all',
               'text-text-muted hover:bg-error/10 hover:text-error',
@@ -154,9 +423,8 @@ export function ActionItem({ instanceId, action, disabled }: ActionItemProps) {
         className="grid transition-[grid-template-rows] duration-150 ease-out"
         style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
       >
-        <div className="overflow-hidden min-h-0">
+        <div className={clsx('min-h-0', expanded ? 'overflow-visible' : 'overflow-hidden')}>
           <div className="border-t border-border bg-bg-tertiary p-3 space-y-3">
-            {/* 程序路径 */}
             <FileField
               label={t('action.program')}
               value={currentAction.program}
@@ -164,8 +432,6 @@ export function ActionItem({ instanceId, action, disabled }: ActionItemProps) {
               placeholder={t('action.programPlaceholder')}
               disabled={disabled}
             />
-
-            {/* 附加参数 */}
             <TextField
               label={t('action.args')}
               value={currentAction.args}
@@ -173,8 +439,6 @@ export function ActionItem({ instanceId, action, disabled }: ActionItemProps) {
               placeholder={t('action.argsPlaceholder')}
               disabled={disabled}
             />
-
-            {/* 等待进程退出开关 */}
             <SwitchField
               label={t('action.waitForExit')}
               hint={t('action.waitForExitHintPre')}
@@ -182,8 +446,6 @@ export function ActionItem({ instanceId, action, disabled }: ActionItemProps) {
               onChange={(v) => updateAction({ waitForExit: v })}
               disabled={disabled}
             />
-
-            {/* 已运行时跳过执行开关 */}
             <SwitchField
               label={t('action.skipIfRunning')}
               hint={t('action.skipIfRunningHint')}
@@ -191,8 +453,6 @@ export function ActionItem({ instanceId, action, disabled }: ActionItemProps) {
               onChange={(v) => updateAction({ skipIfRunning: v })}
               disabled={disabled}
             />
-
-            {/* 通过 cmd /c 启动开关（仅 Windows） */}
             {navigator.userAgent.toLowerCase().includes('win') && (
               <SwitchField
                 label={t('action.useCmd')}
@@ -205,6 +465,26 @@ export function ActionItem({ instanceId, action, disabled }: ActionItemProps) {
           </div>
         </div>
       </div>
+
+      {/* 右键菜单 */}
+      {menuState.isOpen && (
+        <ContextMenu items={menuState.items} position={menuState.position} onClose={hideMenu} />
+      )}
+
+      {/* 删除确认弹窗 */}
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        title={t('taskItem.removeConfirmTitle')}
+        message={t('taskItem.removeConfirmMessage')}
+        cancelText={t('common.cancel')}
+        confirmText={t('common.delete')}
+        destructive
+        onCancel={() => setShowDeleteConfirm(false)}
+        onConfirm={() => {
+          setShowDeleteConfirm(false);
+          removePreAction(instanceId, action.id);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/AddTaskPanel.tsx
+++ b/src/components/AddTaskPanel.tsx
@@ -27,6 +27,7 @@ import { Tooltip } from './ui/Tooltip';
 import type { TaskItem, ActionConfig, GroupItem } from '@/types/interface';
 import type { MxuSpecialTaskDefinition } from '@/types/specialTasks';
 import { getAllMxuSpecialTasks } from '@/types/specialTasks';
+import { generateId } from '@/stores/helpers';
 import clsx from 'clsx';
 
 const log = loggers.task;
@@ -142,15 +143,18 @@ function TaskButton({
   );
 }
 
-// 默认动作配置
-const defaultAction: ActionConfig = {
-  enabled: true,
-  program: '',
-  args: '',
-  waitForExit: false,
-  skipIfRunning: true,
-  useCmd: false,
-};
+// 生成带新 id 的默认动作配置
+function createDefaultAction(): ActionConfig {
+  return {
+    id: generateId(),
+    enabled: true,
+    program: '',
+    args: '',
+    waitForExit: false,
+    skipIfRunning: true,
+    useCmd: false,
+  };
+}
 
 export function AddTaskPanel() {
   const { t } = useTranslation();
@@ -167,7 +171,7 @@ export function AddTaskPanel() {
     // 新增任务标记
     newTaskNames,
     removeNewTaskName,
-    setInstancePreAction,
+    addPreAction,
     // 添加任务面板
     setShowAddTaskPanel,
     addTaskPanelHeight,
@@ -716,24 +720,22 @@ export function AddTaskPanel() {
                 )}
                 {specialExpanded && (
                   <div id={specialContentId} className="mt-1 flex gap-2 flex-wrap">
-                    {/* 前置任务按钮：仅在未添加时显示 */}
-                    {!instance.preAction && (
-                      <button
-                        onClick={() => {
-                          setInstancePreAction(instance.id, defaultAction);
-                          setShowAddTaskPanel(false);
-                        }}
-                        disabled={instance.isRunning}
-                        className={clsx(
-                          'flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs transition-colors',
-                          'bg-bg-secondary/70 hover:bg-bg-hover text-text-secondary border border-border/70 hover:border-accent',
-                          instance.isRunning && 'opacity-50 cursor-not-allowed',
-                        )}
-                      >
-                        <Play className="w-3.5 h-3.5 text-success/80" />
-                        <span>{t('action.preAction')}</span>
-                      </button>
-                    )}
+                    {/* 前置任务按钮：可添加多个 */}
+                    <button
+                      onClick={() => {
+                        addPreAction(instance.id, createDefaultAction());
+                        setShowAddTaskPanel(false);
+                      }}
+                      disabled={instance.isRunning}
+                      className={clsx(
+                        'flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs transition-colors',
+                        'bg-bg-secondary/70 hover:bg-bg-hover text-text-secondary border border-border/70 hover:border-accent',
+                        instance.isRunning && 'opacity-50 cursor-not-allowed',
+                      )}
+                    >
+                      <Play className="w-3.5 h-3.5 text-success/80" />
+                      <span>{t('action.preAction')}</span>
+                    </button>
                     {/* 动态渲染所有注册的特殊任务按钮 */}
                     {specialTasks.map((specialTask) => {
                       return (

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -2,33 +2,16 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import {
-  GripVertical,
-  ChevronDown,
-  ChevronRight,
-  ChevronUp,
-  ChevronsUp,
-  ChevronsDown,
-  Check,
-  X,
-  Copy,
-  Edit3,
-  Trash2,
-  ToggleLeft,
-  ToggleRight,
-  Loader2,
-  FileText,
-  Link,
-  AlertCircle,
-} from 'lucide-react';
+import { GripVertical, ChevronRight, X, Loader2, FileText, Link, AlertCircle } from 'lucide-react';
 import { useAppStore, type TaskRunStatus } from '@/stores/appStore';
 import { maaService } from '@/services/maaService';
 import { useResolvedContent } from '@/services/contentResolver';
 import { generateTaskPipelineOverride } from '@/utils';
 import { OptionEditor, SwitchGrid, switchHasNestedOptions } from './OptionEditor';
-import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
+import { ContextMenu, useContextMenu } from './ContextMenu';
 import { Tooltip } from './ui/Tooltip';
 import { ConfirmDialog } from './ConfirmDialog';
+import { buildListItemMenuItems, InlineNameEditor } from './listItemShared';
 import type { SelectedTask } from '@/types/interface';
 import { isMxuSpecialTask, getMxuSpecialTask, findMxuOptionByKey } from '@/types/specialTasks';
 import { getInterfaceLangKey } from '@/i18n';
@@ -654,14 +637,6 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
     setEditName('');
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      handleSaveEdit();
-    } else if (e.key === 'Escape') {
-      handleCancelEdit();
-    }
-  };
-
   // 右键菜单处理
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
@@ -673,91 +648,46 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
 
       const tasks = instance.selectedTasks;
       const taskIndex = tasks.findIndex((t) => t.id === task.id);
-      const isFirst = taskIndex === 0;
-      const isLast = taskIndex === tasks.length - 1;
 
-      const menuItems: MenuItem[] = [
-        {
-          id: 'duplicate',
-          label: t('contextMenu.duplicateTask'),
-          icon: Copy,
-          disabled: isInstanceRunning,
-          onClick: () => duplicateTask(instanceId, task.id),
+      const menuItems = buildListItemMenuItems({
+        labels: {
+          duplicate: t('contextMenu.duplicateTask'),
+          rename: t('contextMenu.renameTask'),
+          enable: t('contextMenu.enableTask'),
+          disable: t('contextMenu.disableTask'),
+          expand: t('contextMenu.expandOptions'),
+          collapse: t('contextMenu.collapseOptions'),
+          moveUp: t('contextMenu.moveUp'),
+          moveDown: t('contextMenu.moveDown'),
+          moveToTop: t('contextMenu.moveToTop'),
+          moveToBottom: t('contextMenu.moveToBottom'),
+          delete: t('contextMenu.deleteTask'),
         },
-        {
-          id: 'rename',
-          label: t('contextMenu.renameTask'),
-          icon: Edit3,
-          onClick: () => {
-            setEditName(task.customName || '');
-            setIsEditing(true);
-          },
+        isEnabled: task.enabled,
+        isExpanded: !!task.expanded,
+        canExpand,
+        isFirst: taskIndex === 0,
+        isLast: taskIndex === tasks.length - 1,
+        isLocked: isInstanceRunning,
+        onDuplicate: () => duplicateTask(instanceId, task.id),
+        onRename: () => {
+          setEditName(task.customName || '');
+          setIsEditing(true);
         },
-        { id: 'divider-1', label: '', divider: true },
-        {
-          id: 'toggle',
-          label: task.enabled ? t('contextMenu.disableTask') : t('contextMenu.enableTask'),
-          icon: task.enabled ? ToggleLeft : ToggleRight,
-          disabled: isInstanceRunning,
-          onClick: () => toggleTaskEnabled(instanceId, task.id),
+        onToggle: () => toggleTaskEnabled(instanceId, task.id),
+        onExpand: () => toggleTaskExpanded(instanceId, task.id),
+        onMoveUp: () => moveTaskUp(instanceId, task.id),
+        onMoveDown: () => moveTaskDown(instanceId, task.id),
+        onMoveToTop: () => moveTaskToTop(instanceId, task.id),
+        onMoveToBottom: () => moveTaskToBottom(instanceId, task.id),
+        onDelete: () => {
+          if (!confirmBeforeDelete) {
+            removeTaskFromInstance(instanceId, task.id);
+            return;
+          }
+          setShowDeleteConfirm(true);
         },
-        ...(canExpand
-          ? [
-              {
-                id: 'expand',
-                label: task.expanded
-                  ? t('contextMenu.collapseOptions')
-                  : t('contextMenu.expandOptions'),
-                icon: task.expanded ? ChevronUp : ChevronDown,
-                onClick: () => toggleTaskExpanded(instanceId, task.id),
-              },
-            ]
-          : []),
-        { id: 'divider-2', label: '', divider: true },
-        {
-          id: 'move-up',
-          label: t('contextMenu.moveUp'),
-          icon: ChevronUp,
-          disabled: isFirst || !canReorder,
-          onClick: () => moveTaskUp(instanceId, task.id),
-        },
-        {
-          id: 'move-down',
-          label: t('contextMenu.moveDown'),
-          icon: ChevronDown,
-          disabled: isLast || !canReorder,
-          onClick: () => moveTaskDown(instanceId, task.id),
-        },
-        {
-          id: 'move-top',
-          label: t('contextMenu.moveToTop'),
-          icon: ChevronsUp,
-          disabled: isFirst || !canReorder,
-          onClick: () => moveTaskToTop(instanceId, task.id),
-        },
-        {
-          id: 'move-bottom',
-          label: t('contextMenu.moveToBottom'),
-          icon: ChevronsDown,
-          disabled: isLast || !canReorder,
-          onClick: () => moveTaskToBottom(instanceId, task.id),
-        },
-        { id: 'divider-3', label: '', divider: true },
-        {
-          id: 'delete',
-          label: t('contextMenu.deleteTask'),
-          icon: Trash2,
-          danger: true,
-          disabled: !canDelete,
-          onClick: () => {
-            if (!confirmBeforeDelete) {
-              removeTaskFromInstance(instanceId, task.id);
-              return;
-            }
-            setShowDeleteConfirm(true);
-          },
-        },
-      ];
+      });
 
       showMenu(e, menuItems);
     },
@@ -775,10 +705,9 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
       moveTaskToTop,
       moveTaskToBottom,
       removeTaskFromInstance,
+      confirmBeforeDelete,
       showMenu,
       isInstanceRunning,
-      canReorder,
-      canDelete,
     ],
   );
 
@@ -900,42 +829,13 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
         {/* 任务名称 + 展开区域容器 */}
         <div className="flex-1 flex items-center min-w-0">
           {isEditing ? (
-            <div className="flex-1 flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-              <input
-                type="text"
-                value={editName}
-                onChange={(e) => setEditName(e.target.value)}
-                onKeyDown={handleKeyDown}
-                onBlur={handleSaveEdit}
-                placeholder={originalLabel}
-                autoFocus
-                className={clsx(
-                  'flex-1 px-2 py-1 text-sm rounded border border-accent',
-                  'bg-bg-primary text-text-primary',
-                  'focus:outline-none focus:ring-1 focus:ring-accent/20',
-                )}
-              />
-              <button
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleSaveEdit();
-                }}
-                className="p-1 rounded hover:bg-success/10 text-success"
-              >
-                <Check className="w-4 h-4" />
-              </button>
-              <button
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleCancelEdit();
-                }}
-                className="p-1 rounded hover:bg-error/10 text-error"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
+            <InlineNameEditor
+              value={editName}
+              onChange={setEditName}
+              onSave={handleSaveEdit}
+              onCancel={handleCancelEdit}
+              placeholder={originalLabel}
+            />
           ) : (
             <>
               {/* 任务名称：单击切换选中 */}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -132,6 +132,7 @@ export function TaskList() {
     getActiveInstance,
     updateInstance,
     reorderTasks,
+    reorderPreActions,
     selectAllTasks,
     collapseAllTasks,
     setShowAddTaskPanel,
@@ -336,15 +337,22 @@ export function TaskList() {
   });
 
   const handleDragEnd = (event: DragEndEvent) => {
-    // 运行时禁止重新排序
     if (isInstanceRunning) return;
-
     const { active, over } = event;
-
     if (over && active.id !== over.id && instance) {
       const oldIndex = instance.selectedTasks.findIndex((t) => t.id === active.id);
       const newIndex = instance.selectedTasks.findIndex((t) => t.id === over.id);
       reorderTasks(instance.id, oldIndex, newIndex);
+    }
+  };
+
+  const handlePreActionDragEnd = (event: DragEndEvent) => {
+    if (isInstanceRunning) return;
+    const { active, over } = event;
+    if (over && active.id !== over.id && instance?.preActions) {
+      const oldIndex = instance.preActions.findIndex((a) => a.id === active.id);
+      const newIndex = instance.preActions.findIndex((a) => a.id === over.id);
+      reorderPreActions(instance.id, oldIndex, newIndex);
     }
   };
 
@@ -429,11 +437,13 @@ export function TaskList() {
 
   const tasks = instance.selectedTasks;
 
-  const showPreAction = !!instance.preAction;
+  const preActions = instance.preActions ?? [];
+  const showPreActions = preActions.length > 0;
+  const canReorderPreActions = !isInstanceRunning && preActions.length > 1;
   const hasPresets =
     (projectInterface?.preset?.length ?? 0) > 0 && !skippedPresetInstanceIds.has(instance.id);
 
-  if (tasks.length === 0 && !showPreAction) {
+  if (tasks.length === 0 && !showPreActions) {
     return (
       <>
         <div className="flex-1 overflow-y-auto" onContextMenu={handleListContextMenu}>
@@ -461,12 +471,32 @@ export function TaskList() {
           className="flex-1 flex flex-col overflow-y-auto p-3 gap-2"
           onContextMenu={handleListContextMenu}
         >
-          {showPreAction && (
-            <ActionItem
-              instanceId={instance.id}
-              action={instance.preAction}
-              disabled={isInstanceRunning}
-            />
+          {showPreActions && (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handlePreActionDragEnd}
+              modifiers={[restrictHorizontalMovement]}
+            >
+              <SortableContext
+                items={preActions.map((a) => a.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-2">
+                  {preActions.map((action, idx) => (
+                    <ActionItem
+                      key={action.id}
+                      instanceId={instance.id}
+                      action={action}
+                      disabled={isInstanceRunning}
+                      canReorder={canReorderPreActions}
+                      index={idx}
+                      total={preActions.length}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
           )}
 
           {hasPresets ? (
@@ -495,13 +525,31 @@ export function TaskList() {
         onContextMenu={handleListContextMenu}
       >
         <div className="space-y-2">
-          {/* 前置动作（只在已配置时显示） */}
-          {showPreAction && (
-            <ActionItem
-              instanceId={instance.id}
-              action={instance.preAction}
-              disabled={isInstanceRunning}
-            />
+          {/* 前置动作列表（支持拖拽排序） */}
+          {showPreActions && (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handlePreActionDragEnd}
+              modifiers={[restrictHorizontalMovement]}
+            >
+              <SortableContext
+                items={preActions.map((a) => a.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                {preActions.map((action, idx) => (
+                  <ActionItem
+                    key={action.id}
+                    instanceId={instance.id}
+                    action={action}
+                    disabled={isInstanceRunning}
+                    canReorder={canReorderPreActions}
+                    index={idx}
+                    total={preActions.length}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
           )}
 
           {/* 任务列表 */}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -332,67 +332,76 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
       }
 
       try {
-        // 前置程序重启应用后需要强制重连（旧窗口句柄已失效）
         let needsReconnect = false;
 
-        // 先执行前置动作（在连接设备之前）
-        // 检查是否应跳过已运行的前置程序
-        const preAction = targetInstance.preAction;
-        let shouldRunPreAction = Boolean(preAction?.enabled && preAction.program.trim());
-
-        if (shouldRunPreAction && preAction?.skipIfRunning) {
-          const programPath = preAction.program.trim();
-          const processName = programPath.split(/[/\\]/).pop() || programPath;
-          if (await maaService.isProcessRunning(programPath)) {
-            log.info(`实例 ${targetInstance.name}: 前置程序已在运行，跳过执行:`, processName);
-            addLog(targetId, {
-              type: 'info',
-              message: t('action.preActionSkipped', { name: processName }),
-            });
-            shouldRunPreAction = false;
-          }
-        }
-
+        // 收集所有启用且有程序路径的前置程序，按列表顺序执行
+        const allPreActions = (targetInstance.preActions ?? []).filter(
+          (a) => a.enabled && a.program.trim(),
+        );
+        let hasNonWaitForExit = false;
         let preActionControlStarted = false;
-        if (shouldRunPreAction && preAction) {
+
+        if (allPreActions.length > 0) {
           preActionControlStarted = true;
           await beginPreActionControl(targetId);
-          log.info(`实例 ${targetInstance.name}: 执行前置动作:`, preAction.program);
-          addLog(targetId, {
-            type: 'info',
-            message: t('action.preActionStarting'),
-          });
+
           try {
-            throwIfPreActionStopped(targetId);
-            const exitCode = await maaService.runAction(
-              targetId,
-              preAction.program,
-              preAction.args,
-              basePath,
-              preAction.waitForExit ?? true,
-              preAction.useCmd ?? false,
-            );
-            throwIfPreActionStopped(targetId);
-            if (exitCode !== 0) {
-              log.warn(`实例 ${targetInstance.name}: 前置动作退出码非零:`, exitCode);
+            for (const preAction of allPreActions) {
+              const programPath = preAction.program.trim();
+              const processName = programPath.split(/[/\\]/).pop() || programPath;
+
+              // 检查是否应跳过已运行的前置程序
+              if (preAction.skipIfRunning) {
+                if (await maaService.isProcessRunning(programPath)) {
+                  log.info(`实例 ${targetInstance.name}: 前置程序已在运行，跳过执行:`, processName);
+                  addLog(targetId, {
+                    type: 'info',
+                    message: t('action.preActionSkipped', { name: processName }),
+                  });
+                  continue;
+                }
+              }
+
+              log.info(`实例 ${targetInstance.name}: 执行前置动作:`, programPath);
               addLog(targetId, {
-                type: 'warning',
-                message: t('action.preActionExitCode', { code: exitCode }),
+                type: 'info',
+                message: t('action.preActionStartingNamed', { name: processName }),
               });
-            } else {
-              addLog(targetId, {
-                type: 'success',
-                message: t('action.preActionCompleted'),
-              });
+
+              throwIfPreActionStopped(targetId);
+              const exitCode = await maaService.runAction(
+                targetId,
+                programPath,
+                preAction.args,
+                basePath,
+                preAction.waitForExit ?? true,
+                preAction.useCmd ?? false,
+              );
+              throwIfPreActionStopped(targetId);
+
+              if (exitCode !== 0) {
+                log.warn(`实例 ${targetInstance.name}: 前置动作退出码非零:`, exitCode);
+                addLog(targetId, {
+                  type: 'warning',
+                  message: t('action.preActionExitCode', { code: exitCode }),
+                });
+              } else {
+                addLog(targetId, {
+                  type: 'success',
+                  message: t('action.preActionCompletedNamed', { name: processName }),
+                });
+              }
+
+              if (!(preAction.waitForExit ?? true)) {
+                hasNonWaitForExit = true;
+              }
             }
 
-            // 如果没勾选等待进程退出，则循环查找设备直到找到
-            // 注意：即使没有保存的设备配置，也需要等待（等待任意匹配的设备/窗口出现）
-            if (!(preAction.waitForExit ?? true) && controller) {
+            // 所有前置程序执行完毕后，如果有任何非等待退出的动作，则等待设备/窗口就绪
+            if (hasNonWaitForExit && controller) {
               const controllerType = controller.type;
               const isWindowType = controllerType === 'Win32' || controllerType === 'Gamepad';
               log.info(`实例 ${targetInstance.name}: 等待${isWindowType ? '窗口' : '设备'}就绪...`);
-              // 根据是否有保存的设备名，输出不同的等待提示
               if (isWindowType) {
                 addLog(targetId, {
                   type: 'info',
@@ -410,7 +419,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
               }
               let deviceFound = false;
               let attempts = 0;
-              const maxAttempts = 300; // 最多等待 5 分钟
+              const maxAttempts = 300;
 
               while (!deviceFound && attempts < maxAttempts) {
                 throwIfPreActionStopped(targetId);
@@ -418,10 +427,8 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                   if (controllerType === 'Adb') {
                     const devices = await maaService.findAdbDevices();
                     if (savedDevice?.adbDeviceName) {
-                      // 有保存的设备名，精确匹配
                       deviceFound = devices.some((d) => d.name === savedDevice.adbDeviceName);
                     } else {
-                      // 没有保存的设备，等待任意设备出现
                       deviceFound = devices.length > 0;
                     }
                   } else if (controllerType === 'Win32' || controllerType === 'Gamepad') {
@@ -431,23 +438,18 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                       controller.win32?.window_regex || controller.gamepad?.window_regex;
                     const windows = await maaService.findWin32Windows(classRegex, windowRegex);
                     if (savedDevice?.windowName) {
-                      // 有保存的窗口名，精确匹配
                       deviceFound = windows.some((w) => w.window_name === savedDevice.windowName);
                     } else {
-                      // 没有保存的窗口，等待任意匹配窗口出现
                       deviceFound = windows.length > 0;
                     }
                   } else if (controllerType === 'WlRoots') {
                     const sockets = await maaService.findWlrootsSockets();
                     if (savedDevice?.wlrSocketPath) {
-                      // 有保存的套接字路径，精确匹配
                       deviceFound = sockets.includes(savedDevice.wlrSocketPath);
                     } else {
-                      // 没有保存的套接字路径，等待任意匹配的套接字出现
                       deviceFound = sockets.length > 0;
                     }
                   } else {
-                    // 无法确定控制器类型，跳过等待
                     deviceFound = true;
                   }
                 } catch (searchErr) {
@@ -469,14 +471,12 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                   type: 'success',
                   message: isWindowType ? t('action.windowReady') : t('action.deviceReady'),
                 });
-                // 如果没有 savedDevice，说明是自动匹配的，需要给用户提示
                 if (
                   !savedDevice?.windowName &&
                   !savedDevice?.adbDeviceName &&
                   !savedDevice?.wlrSocketPath &&
                   !savedDevice?.playcoverAddress
                 ) {
-                  // 尝试找出实际匹配到的名称用于提示
                   try {
                     if (controllerType === 'Adb') {
                       const devices = await maaService.findAdbDevices();
@@ -518,7 +518,6 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                   }
                 }
 
-                // 设备就绪后额外延迟，等待应用完全初始化
                 const delaySec = useAppStore.getState().preActionConnectDelaySec ?? 5;
                 if (delaySec > 0) {
                   log.info(`实例 ${targetInstance.name}: 等待 ${delaySec} 秒后再连接...`);
@@ -529,7 +528,6 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                   await waitWithStopCheck(delaySec * 1000, targetId);
                 }
 
-                // 前置程序（重新）启动了应用，旧窗口句柄已失效，必须重新连接
                 needsReconnect = true;
               } else {
                 log.warn(`实例 ${targetInstance.name}: 等待${isWindowType ? '窗口' : '设备'}超时`);
@@ -550,7 +548,6 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
               type: 'error',
               message: t('action.preActionFailed', { error: String(err) }),
             });
-            // 前置动作失败不阻止任务执行，继续
           } finally {
             if (preActionControlStarted) {
               await endPreActionControl(targetId);

--- a/src/components/listItemShared.tsx
+++ b/src/components/listItemShared.tsx
@@ -1,0 +1,199 @@
+import {
+  ChevronUp,
+  ChevronDown,
+  ChevronsUp,
+  ChevronsDown,
+  X,
+  Check,
+  Copy,
+  Edit3,
+  Trash2,
+  ToggleLeft,
+  ToggleRight,
+} from 'lucide-react';
+import type { MenuItem } from './ContextMenu';
+import clsx from 'clsx';
+
+// ---------------------------------------------------------------------------
+// 右键菜单构建器 — TaskItem 和 ActionItem 复用
+// ---------------------------------------------------------------------------
+
+export interface ListItemMenuLabels {
+  duplicate: string;
+  rename: string;
+  enable: string;
+  disable: string;
+  expand: string;
+  collapse: string;
+  moveUp: string;
+  moveDown: string;
+  moveToTop: string;
+  moveToBottom: string;
+  delete: string;
+}
+
+export interface ListItemMenuConfig {
+  labels: ListItemMenuLabels;
+  /** 当前是否启用 */
+  isEnabled: boolean;
+  /** 当前是否展开 */
+  isExpanded: boolean;
+  /** 是否能展开（无内容时为 false 可隐藏此菜单项） */
+  canExpand?: boolean;
+  /** 是否位于列表首位 */
+  isFirst: boolean;
+  /** 是否位于列表末位 */
+  isLast: boolean;
+  /** 项目不可修改（如实例运行中） */
+  isLocked: boolean;
+
+  onDuplicate: () => void;
+  onRename: () => void;
+  onToggle: () => void;
+  onExpand: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onMoveToTop: () => void;
+  onMoveToBottom: () => void;
+  onDelete: () => void;
+}
+
+export function buildListItemMenuItems(cfg: ListItemMenuConfig): MenuItem[] {
+  const { labels, isEnabled, isExpanded, canExpand = true, isFirst, isLast, isLocked } = cfg;
+
+  return [
+    {
+      id: 'duplicate',
+      label: labels.duplicate,
+      icon: Copy,
+      disabled: isLocked,
+      onClick: cfg.onDuplicate,
+    },
+    {
+      id: 'rename',
+      label: labels.rename,
+      icon: Edit3,
+      onClick: cfg.onRename,
+    },
+    { id: 'divider-1', label: '', divider: true },
+    {
+      id: 'toggle',
+      label: isEnabled ? labels.disable : labels.enable,
+      icon: isEnabled ? ToggleLeft : ToggleRight,
+      disabled: isLocked,
+      onClick: cfg.onToggle,
+    },
+    ...(canExpand
+      ? [
+          {
+            id: 'expand',
+            label: isExpanded ? labels.collapse : labels.expand,
+            icon: isExpanded ? ChevronUp : ChevronDown,
+            onClick: cfg.onExpand,
+          },
+        ]
+      : []),
+    { id: 'divider-2', label: '', divider: true },
+    {
+      id: 'move-up',
+      label: labels.moveUp,
+      icon: ChevronUp,
+      disabled: isFirst || isLocked,
+      onClick: cfg.onMoveUp,
+    },
+    {
+      id: 'move-down',
+      label: labels.moveDown,
+      icon: ChevronDown,
+      disabled: isLast || isLocked,
+      onClick: cfg.onMoveDown,
+    },
+    {
+      id: 'move-top',
+      label: labels.moveToTop,
+      icon: ChevronsUp,
+      disabled: isFirst || isLocked,
+      onClick: cfg.onMoveToTop,
+    },
+    {
+      id: 'move-bottom',
+      label: labels.moveToBottom,
+      icon: ChevronsDown,
+      disabled: isLast || isLocked,
+      onClick: cfg.onMoveToBottom,
+    },
+    { id: 'divider-3', label: '', divider: true },
+    {
+      id: 'delete',
+      label: labels.delete,
+      icon: Trash2,
+      danger: true,
+      disabled: isLocked,
+      onClick: cfg.onDelete,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// 内联重命名编辑器 — TaskItem 和 ActionItem 复用
+// ---------------------------------------------------------------------------
+
+interface InlineNameEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  placeholder: string;
+}
+
+export function InlineNameEditor({
+  value,
+  onChange,
+  onSave,
+  onCancel,
+  placeholder,
+}: InlineNameEditorProps) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') onSave();
+    else if (e.key === 'Escape') onCancel();
+  };
+
+  return (
+    <div className="flex-1 flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={onSave}
+        placeholder={placeholder}
+        autoFocus
+        className={clsx(
+          'flex-1 px-2 py-1 text-sm rounded border border-accent',
+          'bg-bg-primary text-text-primary',
+          'focus:outline-none focus:ring-1 focus:ring-accent/20',
+        )}
+      />
+      <button
+        onMouseDown={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onSave();
+        }}
+        className="p-1 rounded hover:bg-success/10 text-success"
+      >
+        <Check className="w-4 h-4" />
+      </button>
+      <button
+        onMouseDown={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onCancel();
+        }}
+        className="p-1 rounded hover:bg-error/10 text-error"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -324,7 +324,9 @@ export default {
     deviceWaitTimeout: 'Device wait timeout',
     windowWaitTimeout: 'Window wait timeout',
     preActionStarting: 'Running pre-program...',
+    preActionStartingNamed: 'Running pre-program: {{name}}...',
     preActionCompleted: 'Pre-program completed',
+    preActionCompletedNamed: 'Pre-program {{name}} completed',
     preActionFailed: 'Pre-program failed: {{error}}',
     preActionExitCode: 'Pre-program exit code: {{code}}',
     preActionConnectDelay: 'Waiting {{seconds}} seconds before connecting...',
@@ -747,6 +749,15 @@ export default {
     closeOtherTabs: 'Close Other Tabs',
     closeAllTabs: 'Close All Tabs',
     closeTabsToRight: 'Close Tabs to the Right',
+
+    // Pre-action context menu
+    duplicateAction: 'Duplicate',
+    deleteAction: 'Delete',
+    renameAction: 'Rename',
+    enableAction: 'Enable',
+    disableAction: 'Disable',
+    expandAction: 'Expand Settings',
+    collapseAction: 'Collapse Settings',
 
     // Task context menu
     addTask: 'Add Task',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -319,7 +319,9 @@ export default {
     deviceWaitTimeout: 'デバイス待機タイムアウト',
     windowWaitTimeout: 'ウィンドウ待機タイムアウト',
     preActionStarting: '前処理プログラムを実行中...',
+    preActionStartingNamed: '前処理プログラムを実行中: {{name}}...',
     preActionCompleted: '前処理プログラム完了',
+    preActionCompletedNamed: '前処理プログラム {{name}} 完了',
     preActionFailed: '前処理プログラム失敗: {{error}}',
     preActionExitCode: '前処理プログラム終了コード: {{code}}',
     preActionConnectDelay: '{{seconds}} 秒後に接続します...',
@@ -746,6 +748,15 @@ export default {
     closeOtherTabs: '他のタブを閉じる',
     closeAllTabs: 'すべてのタブを閉じる',
     closeTabsToRight: '右側のタブを閉じる',
+
+    // 前処理プログラムのコンテキストメニュー
+    duplicateAction: '複製',
+    deleteAction: '削除',
+    renameAction: '名前を変更',
+    enableAction: '有効にする',
+    disableAction: '無効にする',
+    expandAction: '設定を展開',
+    collapseAction: '設定を折りたたむ',
 
     // タスクのコンテキストメニュー
     addTask: 'タスクを追加',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -318,7 +318,9 @@ export default {
     deviceWaitTimeout: '장치 대기 시간 초과',
     windowWaitTimeout: '윈도우 대기 시간 초과',
     preActionStarting: '전처리 프로그램 실행 중...',
+    preActionStartingNamed: '전처리 프로그램 실행 중: {{name}}...',
     preActionCompleted: '전처리 프로그램 완료',
+    preActionCompletedNamed: '전처리 프로그램 {{name}} 완료',
     preActionFailed: '전처리 프로그램 실패: {{error}}',
     preActionExitCode: '전처리 프로그램 종료 코드: {{code}}',
     preActionConnectDelay: '{{seconds}}초 후 연결합니다...',
@@ -741,6 +743,15 @@ export default {
     closeOtherTabs: '다른 탭 닫기',
     closeAllTabs: '모든 탭 닫기',
     closeTabsToRight: '오른쪽 탭 닫기',
+
+    // 전처리 프로그램 컨텍스트 메뉴
+    duplicateAction: '복제',
+    deleteAction: '삭제',
+    renameAction: '이름 변경',
+    enableAction: '활성화',
+    disableAction: '비활성화',
+    expandAction: '설정 펼치기',
+    collapseAction: '설정 접기',
 
     // 작업 컨텍스트 메뉴
     addTask: '작업 추가',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -315,7 +315,9 @@ export default {
     deviceWaitTimeout: '等待设备超时',
     windowWaitTimeout: '等待窗口超时',
     preActionStarting: '正在执行前置程序...',
+    preActionStartingNamed: '正在执行前置程序: {{name}}...',
     preActionCompleted: '前置程序执行完成',
+    preActionCompletedNamed: '前置程序 {{name}} 执行完成',
     preActionFailed: '前置程序执行失败: {{error}}',
     preActionExitCode: '前置程序退出码: {{code}}',
     preActionConnectDelay: '等待 {{seconds}} 秒后连接...',
@@ -742,6 +744,15 @@ export default {
     closeOtherTabs: '关闭其他标签页',
     closeAllTabs: '关闭所有标签页',
     closeTabsToRight: '关闭右侧标签页',
+
+    // 前置程序右键菜单
+    duplicateAction: '复制',
+    deleteAction: '删除',
+    renameAction: '重命名',
+    enableAction: '启用',
+    disableAction: '禁用',
+    expandAction: '展开设置',
+    collapseAction: '折叠设置',
 
     // 任务右键菜单
     addTask: '添加任务',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -311,7 +311,9 @@ export default {
     deviceWaitTimeout: '等待裝置逾時',
     windowWaitTimeout: '等待視窗逾時',
     preActionStarting: '正在執行前置程式...',
+    preActionStartingNamed: '正在執行前置程式: {{name}}...',
     preActionCompleted: '前置程式執行完成',
+    preActionCompletedNamed: '前置程式 {{name}} 執行完成',
     preActionFailed: '前置程式執行失敗: {{error}}',
     preActionExitCode: '前置程式結束碼: {{code}}',
     preActionConnectDelay: '等待 {{seconds}} 秒後連線...',
@@ -727,6 +729,15 @@ export default {
     closeOtherTabs: '關閉其他標籤頁',
     closeAllTabs: '關閉所有標籤頁',
     closeTabsToRight: '關閉右側標籤頁',
+
+    // 前置程式右鍵選單
+    duplicateAction: '複製',
+    deleteAction: '刪除',
+    renameAction: '重新命名',
+    enableAction: '啟用',
+    disableAction: '停用',
+    expandAction: '展開設定',
+    collapseAction: '摺疊設定',
 
     // 任務右鍵選單
     addTask: '新增任務',

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -10,7 +10,7 @@ import {
   resolveThemeMode,
   unregisterCustomAccent,
 } from '@/themes';
-import type { MxuConfig, RecentlyClosedInstance } from '@/types/config';
+import type { MxuConfig, RecentlyClosedInstance, LegacyActionConfig } from '@/types/config';
 import {
   clampAddTaskPanelHeight,
   defaultAddTaskPanelHeight,
@@ -56,6 +56,19 @@ import {
 } from './helpers';
 // 从独立模块导入类型和辅助函数
 import type { AppState, LogEntry, TaskRunStatus } from './types';
+
+/** 向后兼容：将旧版单个 preAction 迁移为 preActions 数组 */
+function migratePreActions(
+  inst: { preActions?: ActionConfig[]; preAction?: LegacyActionConfig },
+): ActionConfig[] | undefined {
+  if (inst.preActions && inst.preActions.length > 0) {
+    return inst.preActions.map((a) => (a.id ? a : { ...a, id: generateId() }));
+  }
+  if (inst.preAction) {
+    return [{ ...inst.preAction, id: generateId() }];
+  }
+  return undefined;
+}
 
 function cleanOptionValues(
   optionValues: Record<string, OptionValue>,
@@ -368,7 +381,7 @@ export const useAppStore = create<AppState>()(
               optionValues: t.optionValues,
             })),
             schedulePolicies: instanceToClose.schedulePolicies,
-            preAction: instanceToClose.preAction,
+            preActions: instanceToClose.preActions,
           };
           // 添加到列表头部，并限制最大条目数
           newRecentlyClosed = [closedRecord, ...state.recentlyClosed].slice(0, MAX_RECENTLY_CLOSED);
@@ -847,7 +860,7 @@ export const useAppStore = create<AppState>()(
           optionValues: { ...t.optionValues },
         })),
         isRunning: false,
-        preAction: sourceInstance.preAction ? { ...sourceInstance.preAction } : undefined,
+        preActions: sourceInstance.preActions?.map((a) => ({ ...a, id: generateId() })),
       };
 
       // 复制源实例的控制器和资源选择
@@ -1050,7 +1063,7 @@ export const useAppStore = create<AppState>()(
           selectedTasks: savedTasks,
           isRunning: prevRunningByInstance.get(inst.id) ?? false,
           schedulePolicies: inst.schedulePolicies,
-          preAction: inst.preAction,
+          preActions: migratePreActions(inst),
         };
       });
 
@@ -1338,11 +1351,75 @@ export const useAppStore = create<AppState>()(
         instances: state.instances.map((i) => (i.id === instanceId ? { ...i, savedDevice } : i)),
       })),
 
-    setInstancePreAction: (instanceId: string, action: ActionConfig | undefined) =>
+    addPreAction: (instanceId: string, action: ActionConfig) =>
       set((state) => ({
         instances: state.instances.map((i) =>
-          i.id === instanceId ? { ...i, preAction: action } : i,
+          i.id === instanceId
+            ? { ...i, preActions: [...(i.preActions || []), action] }
+            : i,
         ),
+      })),
+
+    updatePreAction: (instanceId: string, actionId: string, updates: Partial<ActionConfig>) =>
+      set((state) => ({
+        instances: state.instances.map((i) =>
+          i.id === instanceId
+            ? {
+                ...i,
+                preActions: i.preActions?.map((a) =>
+                  a.id === actionId ? { ...a, ...updates } : a,
+                ),
+              }
+            : i,
+        ),
+      })),
+
+    removePreAction: (instanceId: string, actionId: string) =>
+      set((state) => ({
+        instances: state.instances.map((i) => {
+          if (i.id !== instanceId) return i;
+          const filtered = i.preActions?.filter((a) => a.id !== actionId);
+          return { ...i, preActions: filtered?.length ? filtered : undefined };
+        }),
+      })),
+
+    reorderPreActions: (instanceId: string, oldIndex: number, newIndex: number) =>
+      set((state) => ({
+        instances: state.instances.map((i) => {
+          if (i.id !== instanceId || !i.preActions) return i;
+          const items = [...i.preActions];
+          const [removed] = items.splice(oldIndex, 1);
+          items.splice(newIndex, 0, removed);
+          return { ...i, preActions: items };
+        }),
+      })),
+
+    renamePreAction: (instanceId: string, actionId: string, name: string) =>
+      set((state) => ({
+        instances: state.instances.map((i) =>
+          i.id === instanceId
+            ? {
+                ...i,
+                preActions: i.preActions?.map((a) =>
+                  a.id === actionId ? { ...a, customName: name || undefined } : a,
+                ),
+              }
+            : i,
+        ),
+      })),
+
+    duplicatePreAction: (instanceId: string, actionId: string) =>
+      set((state) => ({
+        instances: state.instances.map((i) => {
+          if (i.id !== instanceId || !i.preActions) return i;
+          const idx = i.preActions.findIndex((a) => a.id === actionId);
+          if (idx === -1) return i;
+          const source = i.preActions[idx];
+          const copy: ActionConfig = { ...source, id: generateId() };
+          const items = [...i.preActions];
+          items.splice(idx + 1, 0, copy);
+          return { ...i, preActions: items };
+        }),
       })),
 
     // 设备列表缓存
@@ -1670,7 +1747,7 @@ export const useAppStore = create<AppState>()(
         })),
         isRunning: false,
         schedulePolicies: closedInstance.schedulePolicies,
-        preAction: closedInstance.preAction,
+        preActions: migratePreActions(closedInstance),
       };
 
       // 恢复选中的控制器和资源状态
@@ -1884,7 +1961,7 @@ function generateConfig(): MxuConfig {
         optionValues: t.optionValues,
       })),
       schedulePolicies: inst.schedulePolicies,
-      preAction: inst.preAction,
+      preActions: inst.preActions,
     })),
     // WebUI 模式下保留后端原始的外观 & 布局设置，避免覆盖桌面端偏好
     ...(() => {

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -244,7 +244,12 @@ export interface AppState {
   // 设备信息保存
   setInstanceSavedDevice: (instanceId: string, savedDevice: SavedDeviceInfo) => void;
 
-  setInstancePreAction: (instanceId: string, action: ActionConfig | undefined) => void;
+  addPreAction: (instanceId: string, action: ActionConfig) => void;
+  updatePreAction: (instanceId: string, actionId: string, updates: Partial<ActionConfig>) => void;
+  removePreAction: (instanceId: string, actionId: string) => void;
+  reorderPreActions: (instanceId: string, oldIndex: number, newIndex: number) => void;
+  renamePreAction: (instanceId: string, actionId: string, name: string) => void;
+  duplicatePreAction: (instanceId: string, actionId: string) => void;
 
   // 设备列表缓存
   cachedAdbDevices: AdbDevice[];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -33,6 +33,16 @@ export interface SavedDeviceInfo {
   playcoverAddress?: string;
 }
 
+/** 旧版单个前置程序配置（不含 id，用于向后兼容读取） */
+export interface LegacyActionConfig {
+  enabled: boolean;
+  program: string;
+  args: string;
+  waitForExit: boolean;
+  skipIfRunning: boolean;
+  useCmd: boolean;
+}
+
 // 保存的实例配置
 export interface SavedInstance {
   id: string;
@@ -47,7 +57,9 @@ export interface SavedInstance {
   tasks: SavedTask[];
   // 定时执行策略列表
   schedulePolicies?: SchedulePolicy[];
-  preAction?: ActionConfig;
+  preActions?: ActionConfig[];
+  /** @deprecated 旧版单前置程序字段，仅用于向后兼容读取 */
+  preAction?: LegacyActionConfig;
 }
 
 // 窗口大小配置
@@ -74,7 +86,9 @@ export interface RecentlyClosedInstance {
   savedDevice?: SavedDeviceInfo;
   tasks: SavedTask[]; // 保存的任务配置
   schedulePolicies?: SchedulePolicy[]; // 定时执行策略
-  preAction?: ActionConfig;
+  preActions?: ActionConfig[];
+  /** @deprecated 旧版单前置程序字段，仅用于向后兼容读取 */
+  preAction?: LegacyActionConfig;
 }
 
 // MirrorChyan 更新频道

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -252,6 +252,8 @@ export interface SchedulePolicy {
 
 // pre-action config
 export interface ActionConfig {
+  id: string; // 唯一标识（用于排序和识别）
+  customName?: string; // 用户自定义名称
   enabled: boolean; // 是否启用
   program: string; // 程序路径
   args: string; // 附加参数
@@ -275,7 +277,7 @@ export interface Instance {
   isRunning: boolean;
   // 定时执行策略列表
   schedulePolicies?: SchedulePolicy[];
-  preAction?: ActionConfig;
+  preActions?: ActionConfig[];
 }
 
 /** v2.3.0: 预设中的任务配置 */


### PR DESCRIPTION
## Summary by Sourcery

支持为每个实例配置和执行多个预操作，并提供更丰富的 UI 控件以及向后兼容的持久化能力。

New Features:
- 允许实例定义多个预操作程序而非仅一个，包括可从任务面板添加并保存到配置中。
- 在连接前按顺序执行所有已启用的预操作，为每个操作提供诸如“等待退出”和“若已在运行则跳过”等选项，并按程序改进日志记录。
- 为预操作引入拖放式排序和上下文菜单，支持重命名、复制、启用/禁用、展开/折叠和删除操作。

Enhancements:
- 改进预操作编辑器 UI，支持自定义名称、参数预览标签和删除确认，同时继续尊重“已禁用”和“运行中”等状态。
- 在预操作配置模型中新增 `id` 和 `customName` 字段，并在实例状态、克隆以及“最近关闭”处理流程中传递这些字段。
- 优化非阻塞预操作后的设备/窗口等待逻辑，使等待依据任何“未设置为等待退出”的操作来决定。

Documentation:
- 在所有受支持的语言环境中扩展 i18n 字符串，以覆盖新的预操作日志和上下文菜单标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support configuring and executing multiple pre-actions per instance, with richer UI controls and backward-compatible persistence.

New Features:
- Allow instances to define multiple pre-action programs instead of a single one, including adding them from the task panel and saving them in config.
- Execute all enabled pre-actions in order before connecting, with per-action options like waiting for exit and skipping if already running, and improved logging per program.
- Introduce drag-and-drop reordering and a context menu for pre-actions, supporting rename, duplicate, enable/disable, expand/collapse, and delete actions.

Enhancements:
- Improve the pre-action editor UI with custom names, parameter preview tags, and delete confirmation, while keeping disabled and running states respected.
- Add id and customName fields to the pre-action config model and propagate them through instance state, cloning, and recently-closed handling.
- Refine device/window wait logic after non-blocking pre-actions by basing the wait on any action that does not wait for exit.

Documentation:
- Extend i18n strings in all supported locales to cover new pre-action logs and context menu labels.

</details>