### PR TITLE
feat: 自动添加启动游戏的前置任务

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -353,6 +353,10 @@ pub fn get_process_path_from_hwnd(hwnd: u64) -> Result<String, String> {
         use winsafe::co::{PROCESS, PROCESS_NAME};
         use winsafe::{HPROCESS, HWND};
 
+        if hwnd == 0 {
+            return Err("Invalid window handle (null)".to_string());
+        }
+
         let hwnd = unsafe { HWND::from_ptr(hwnd as *mut _) };
         let (_, pid) = hwnd.GetWindowThreadProcessId();
 

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -345,6 +345,42 @@ pub fn is_process_running(program: String) -> bool {
     check_process_running(&program)
 }
 
+/// 根据窗口句柄获取对应进程的可执行文件路径
+#[tauri::command]
+pub fn get_process_path_from_hwnd(hwnd: u64) -> Result<String, String> {
+    #[cfg(windows)]
+    {
+        use winsafe::co::{PROCESS, PROCESS_NAME};
+        use winsafe::{HPROCESS, HWND};
+
+        let hwnd = unsafe { HWND::from_ptr(hwnd as *mut _) };
+        let (_, pid) = hwnd.GetWindowThreadProcessId();
+
+        if pid == 0 {
+            return Err("PID is 0".to_string());
+        }
+
+        let process = HPROCESS::OpenProcess(PROCESS::QUERY_LIMITED_INFORMATION, false, pid)
+            .map_err(|e| format!("OpenProcess failed: {}", e))?;
+
+        let path = process
+            .QueryFullProcessImageName(PROCESS_NAME::WIN32)
+            .map_err(|e| format!("QueryFullProcessImageName failed: {}", e))?;
+
+        info!(
+            "get_process_path_from_hwnd: hwnd={} pid={} path={}",
+            hwnd, pid, path
+        );
+        Ok(path)
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = hwnd;
+        Err("This command is only available on Windows".to_string())
+    }
+}
+
 /// Run pre-action (launch program and optionally wait for exit)
 /// program: 程序路径
 /// args: 附加参数（空格分隔）

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -277,6 +277,7 @@ pub fn run() {
             commands::system::set_pre_action_stop,
             commands::system::run_action,
             commands::system::is_process_running,
+            commands::system::get_process_path_from_hwnd,
             commands::system::retry_load_maa_library,
             commands::system::check_vcredist_missing,
             commands::system::autostart_enable,

--- a/src/components/ActionItem.tsx
+++ b/src/components/ActionItem.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronRight, X, Play, GripVertical } from 'lucide-react';
+import { ChevronRight, X, GripVertical } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useAppStore } from '@/stores/appStore';
@@ -249,7 +249,6 @@ export function ActionItem({
                 )}
                 onClick={handleToggleEnabled}
               >
-                <Play className="w-4 h-4 mr-0.5 flex-shrink-0 text-success" />
                 <span
                   className={clsx(
                     'min-w-0 text-sm font-medium truncate',

--- a/src/components/AddTaskPanel.tsx
+++ b/src/components/AddTaskPanel.tsx
@@ -7,7 +7,6 @@ import {
   Sparkles,
   Loader2,
   AlertCircle,
-  Play,
   ChevronsDown,
   ChevronDown,
   ChevronRight,
@@ -751,7 +750,6 @@ export function AddTaskPanel() {
                         instance.isRunning && 'opacity-50 cursor-not-allowed',
                       )}
                     >
-                      <Play className="w-3.5 h-3.5 text-success/80" />
                       <span>{t('action.preAction')}</span>
                     </button>
                     {/* 动态渲染所有注册的特殊任务按钮 */}

--- a/src/components/AddTaskPanel.tsx
+++ b/src/components/AddTaskPanel.tsx
@@ -26,7 +26,11 @@ import {
 import { Tooltip } from './ui/Tooltip';
 import type { TaskItem, ActionConfig, GroupItem } from '@/types/interface';
 import type { MxuSpecialTaskDefinition } from '@/types/specialTasks';
-import { getAllMxuSpecialTasks } from '@/types/specialTasks';
+import {
+  getAllMxuSpecialTasks,
+  MXU_LAUNCH_TASK_NAME,
+  MXU_KILLPROC_TASK_NAME,
+} from '@/types/specialTasks';
 import { generateId } from '@/stores/helpers';
 import clsx from 'clsx';
 
@@ -144,11 +148,11 @@ function TaskButton({
 }
 
 // 生成带新 id 的默认动作配置
-function createDefaultAction(): ActionConfig {
+function createDefaultAction(defaultProgram?: string): ActionConfig {
   return {
     id: generateId(),
     enabled: true,
-    program: '',
+    program: defaultProgram || '',
     args: '',
     waitForExit: false,
     skipIfRunning: true,
@@ -261,8 +265,19 @@ export function AddTaskPanel() {
     // 收起添加任务面板
     setShowAddTaskPanel(false);
 
+    // 根据 connectedProgramPath 为特定任务提供默认值
+    const connectedPath = instance.savedDevice?.connectedProgramPath;
+    let initialValues: Record<string, string> | undefined;
+    if (connectedPath) {
+      if (specialTask.taskName === MXU_LAUNCH_TASK_NAME) {
+        initialValues = { program: connectedPath };
+      } else if (specialTask.taskName === MXU_KILLPROC_TASK_NAME) {
+        initialValues = { process_name: connectedPath.split(/[/\\]/).pop() || connectedPath };
+      }
+    }
+
     // 添加特殊任务到列表
-    const taskId = addMxuSpecialTask(instance.id, specialTask.taskName);
+    const taskId = addMxuSpecialTask(instance.id, specialTask.taskName, initialValues);
 
     // 如果实例正在运行，立即调用 PostTask 追加到执行队列
     if (instance.isRunning) {
@@ -723,7 +738,10 @@ export function AddTaskPanel() {
                     {/* 前置任务按钮：可添加多个 */}
                     <button
                       onClick={() => {
-                        addPreAction(instance.id, createDefaultAction());
+                        addPreAction(
+                          instance.id,
+                          createDefaultAction(instance.savedDevice?.connectedProgramPath),
+                        );
                         setShowAddTaskPanel(false);
                       }}
                       disabled={instance.isRunning}

--- a/src/components/AddTaskPanel.tsx
+++ b/src/components/AddTaskPanel.tsx
@@ -31,6 +31,7 @@ import {
   MXU_KILLPROC_TASK_NAME,
 } from '@/types/specialTasks';
 import { generateId } from '@/stores/helpers';
+import { getProcessNameFromPath } from '@/utils/paths';
 import clsx from 'clsx';
 
 const log = loggers.task;
@@ -271,7 +272,7 @@ export function AddTaskPanel() {
       if (specialTask.taskName === MXU_LAUNCH_TASK_NAME) {
         initialValues = { program: connectedPath };
       } else if (specialTask.taskName === MXU_KILLPROC_TASK_NAME) {
-        initialValues = { process_name: connectedPath.split(/[/\\]/).pop() || connectedPath };
+        initialValues = { process_name: getProcessNameFromPath(connectedPath) };
       }
     }
 

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -23,6 +23,7 @@ import { resolveI18nText } from '@/services/contentResolver';
 import type { AdbDevice, Win32Window, ControllerConfig } from '@/types/maa';
 import type { ControllerItem, ResourceItem } from '@/types/interface';
 import { computeResourcePaths } from '@/utils/resourcePath';
+import { getProcessNameFromPath } from '@/utils/paths';
 import { parseWin32ScreencapMethod, parseWin32InputMethod } from '@/types/maa';
 import { getInterfaceLangKey } from '@/i18n';
 import { generateId } from '@/stores/helpers';
@@ -828,13 +829,13 @@ export function ConnectionPanel() {
       const programPath = await maaService.getProcessPathFromHwnd(hwnd);
       if (!programPath) return;
 
+      const inst = useAppStore.getState().instances.find((i) => i.id === instanceId);
       setInstanceSavedDevice(instanceId, {
-        ...activeInstance?.savedDevice,
+        ...inst?.savedDevice,
         connectedProgramPath: programPath,
       });
 
-      const processName = programPath.split(/[/\\]/).pop() || programPath;
-      const inst = useAppStore.getState().instances.find((i) => i.id === instanceId);
+      const processName = getProcessNameFromPath(programPath);
 
       // 自动添加禁用的前置程序（启动进程）
       const hasPreAction = inst?.preActions?.some(

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -26,6 +26,7 @@ import { computeResourcePaths } from '@/utils/resourcePath';
 import { parseWin32ScreencapMethod, parseWin32InputMethod } from '@/types/maa';
 import { getInterfaceLangKey } from '@/i18n';
 import { generateId } from '@/stores/helpers';
+import { MXU_KILLPROC_TASK_NAME } from '@/types/specialTasks';
 import {
   startGlobalCallbackListener,
   waitForCtrlResult,
@@ -64,6 +65,7 @@ export function ConnectionPanel() {
     registerResBatch,
     addLog,
     addPreAction,
+    addMxuSpecialTask,
   } = useAppStore();
 
   // 获取当前活动实例
@@ -820,7 +822,7 @@ export function ConnectionPanel() {
     }
   };
 
-  // 连接成功后尝试获取窗口进程路径并自动添加前置程序
+  // 连接成功后尝试获取窗口进程路径，自动添加前置程序和结束进程任务
   const fetchAndStoreProcessPath = async (hwnd: number) => {
     try {
       const programPath = await maaService.getProcessPathFromHwnd(hwnd);
@@ -831,13 +833,17 @@ export function ConnectionPanel() {
         connectedProgramPath: programPath,
       });
 
+      const processName = programPath.split(/[/\\]/).pop() || programPath;
       const inst = useAppStore.getState().instances.find((i) => i.id === instanceId);
-      const alreadyHas = inst?.preActions?.some(
+
+      // 自动添加禁用的前置程序（启动进程）
+      const hasPreAction = inst?.preActions?.some(
         (a) => a.program.toLowerCase() === programPath.toLowerCase(),
       );
-      if (!alreadyHas) {
+      if (!hasPreAction) {
         addPreAction(instanceId, {
           id: generateId(),
+          customName: t('action.autoPreActionName', { name: processName }),
           enabled: false,
           program: programPath,
           args: '',
@@ -845,10 +851,36 @@ export function ConnectionPanel() {
           skipIfRunning: true,
           useCmd: false,
         });
-        const processName = programPath.split(/[/\\]/).pop() || programPath;
         addLog(instanceId, {
           type: 'info',
           message: t('action.autoPreActionAdded', { name: processName }),
+        });
+      }
+
+      // 自动添加禁用的结束进程任务
+      const hasKillTask = inst?.selectedTasks.some((task) => {
+        if (task.taskName !== MXU_KILLPROC_TASK_NAME) return false;
+        const nameOpt = task.optionValues?.['__MXU_KILLPROC_NAME_OPTION__'];
+        return (
+          nameOpt?.type === 'input' &&
+          nameOpt.values?.process_name?.toLowerCase() === processName.toLowerCase()
+        );
+      });
+      if (!hasKillTask) {
+        addMxuSpecialTask(
+          instanceId,
+          MXU_KILLPROC_TASK_NAME,
+          { process_name: processName },
+          {
+            enabled: false,
+            expanded: false,
+            customName: t('action.autoKillTaskName', { name: processName }),
+            switchOverrides: { __MXU_KILLPROC_SELF_OPTION__: false },
+          },
+        );
+        addLog(instanceId, {
+          type: 'info',
+          message: t('action.autoKillTaskAdded', { name: processName }),
         });
       }
     } catch {

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -25,6 +25,7 @@ import type { ControllerItem, ResourceItem } from '@/types/interface';
 import { computeResourcePaths } from '@/utils/resourcePath';
 import { parseWin32ScreencapMethod, parseWin32InputMethod } from '@/types/maa';
 import { getInterfaceLangKey } from '@/i18n';
+import { generateId } from '@/stores/helpers';
 import {
   startGlobalCallbackListener,
   waitForCtrlResult,
@@ -62,6 +63,7 @@ export function ConnectionPanel() {
     registerResIdName,
     registerResBatch,
     addLog,
+    addPreAction,
   } = useAppStore();
 
   // 获取当前活动实例
@@ -818,6 +820,42 @@ export function ConnectionPanel() {
     }
   };
 
+  // 连接成功后尝试获取窗口进程路径并自动添加前置程序
+  const fetchAndStoreProcessPath = async (hwnd: number) => {
+    try {
+      const programPath = await maaService.getProcessPathFromHwnd(hwnd);
+      if (!programPath) return;
+
+      setInstanceSavedDevice(instanceId, {
+        ...activeInstance?.savedDevice,
+        connectedProgramPath: programPath,
+      });
+
+      const inst = useAppStore.getState().instances.find((i) => i.id === instanceId);
+      const alreadyHas = inst?.preActions?.some(
+        (a) => a.program.toLowerCase() === programPath.toLowerCase(),
+      );
+      if (!alreadyHas) {
+        addPreAction(instanceId, {
+          id: generateId(),
+          enabled: false,
+          program: programPath,
+          args: '',
+          waitForExit: false,
+          skipIfRunning: true,
+          useCmd: false,
+        });
+        const processName = programPath.split(/[/\\]/).pop() || programPath;
+        addLog(instanceId, {
+          type: 'info',
+          message: t('action.autoPreActionAdded', { name: processName }),
+        });
+      }
+    } catch {
+      // best-effort, 静默忽略
+    }
+  };
+
   // 选择 Win32 窗口并自动连接（如已连接会先断开旧连接）
   const handleSelectWindow = async (win: Win32Window) => {
     setSelectedWindow(win);
@@ -862,6 +900,9 @@ export function ConnectionPanel() {
       }
 
       await connectControllerInternal(config, win.window_name || win.class_name, 'window');
+
+      // 连接成功后异步获取进程路径（Win32 和 Gamepad 都基于窗口句柄）
+      void fetchAndStoreProcessPath(win.handle);
     } catch (err) {
       setDeviceError(err instanceof Error ? err.message : t('controller.connectionFailed'));
       setIsConnected(false);

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -295,7 +295,7 @@ export default {
   },
 
   action: {
-    preAction: 'Pre-Program',
+    preAction: '▶️ Pre-Program',
     program: 'Program Path',
     programPlaceholder: 'Enter program path or browse...',
     args: 'Arguments',
@@ -330,7 +330,10 @@ export default {
     preActionFailed: 'Pre-program failed: {{error}}',
     preActionExitCode: 'Pre-program exit code: {{code}}',
     preActionConnectDelay: 'Waiting {{seconds}} seconds before connecting...',
+    autoPreActionName: '▶️ Launch {{name}}',
     autoPreActionAdded: 'Auto-added pre-action: {{name}} (disabled by default)',
+    autoKillTaskName: '⛔ Kill {{name}}',
+    autoKillTaskAdded: 'Auto-added kill process task: {{name}} (disabled by default)',
     removeConfirmTitle: 'Delete pre-action',
     removeConfirmMessage: 'Are you sure you want to delete this pre-action?',
   },

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -330,6 +330,7 @@ export default {
     preActionFailed: 'Pre-program failed: {{error}}',
     preActionExitCode: 'Pre-program exit code: {{code}}',
     preActionConnectDelay: 'Waiting {{seconds}} seconds before connecting...',
+    autoPreActionAdded: 'Auto-added pre-action: {{name}} (disabled by default)',
     removeConfirmTitle: 'Delete pre-action',
     removeConfirmMessage: 'Are you sure you want to delete this pre-action?',
   },

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -290,7 +290,7 @@ export default {
   },
 
   action: {
-    preAction: '前処理プログラム',
+    preAction: '▶️ 前処理プログラム',
     program: 'プログラムパス',
     programPlaceholder: 'プログラムパスを入力または参照...',
     args: '追加引数',
@@ -325,7 +325,10 @@ export default {
     preActionFailed: '前処理プログラム失敗: {{error}}',
     preActionExitCode: '前処理プログラム終了コード: {{code}}',
     preActionConnectDelay: '{{seconds}} 秒後に接続します...',
+    autoPreActionName: '▶️ {{name}} を起動',
     autoPreActionAdded: '前処理プログラムを自動追加しました: {{name}}（デフォルトでは無効）',
+    autoKillTaskName: '⛔ {{name}} を終了',
+    autoKillTaskAdded: 'プロセス終了タスクを自動追加しました: {{name}}（デフォルトでは無効）',
     removeConfirmTitle: '前処理プログラムを削除',
     removeConfirmMessage: 'この前処理プログラムを削除してもよろしいですか？',
   },

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -325,6 +325,7 @@ export default {
     preActionFailed: '前処理プログラム失敗: {{error}}',
     preActionExitCode: '前処理プログラム終了コード: {{code}}',
     preActionConnectDelay: '{{seconds}} 秒後に接続します...',
+    autoPreActionAdded: '前処理プログラムを自動追加しました: {{name}}（デフォルトでは無効）',
     removeConfirmTitle: '前処理プログラムを削除',
     removeConfirmMessage: 'この前処理プログラムを削除してもよろしいですか？',
   },

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -289,7 +289,7 @@ export default {
   },
 
   action: {
-    preAction: '전처리 프로그램',
+    preAction: '▶️ 전처리 프로그램',
     program: '프로그램 경로',
     programPlaceholder: '프로그램 경로를 입력하거나 찾아보기...',
     args: '추가 인수',
@@ -324,7 +324,10 @@ export default {
     preActionFailed: '전처리 프로그램 실패: {{error}}',
     preActionExitCode: '전처리 프로그램 종료 코드: {{code}}',
     preActionConnectDelay: '{{seconds}}초 후 연결합니다...',
+    autoPreActionName: '▶️ {{name}} 실행',
     autoPreActionAdded: '전처리 프로그램 자동 추가: {{name}} (기본적으로 비활성화)',
+    autoKillTaskName: '⛔ {{name}} 종료',
+    autoKillTaskAdded: '프로세스 종료 작업 자동 추가: {{name}} (기본적으로 비활성화)',
     removeConfirmTitle: '전처리 프로그램 삭제',
     removeConfirmMessage: '이 전처리 프로그램을 삭제하시겠습니까?',
   },

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -324,6 +324,7 @@ export default {
     preActionFailed: '전처리 프로그램 실패: {{error}}',
     preActionExitCode: '전처리 프로그램 종료 코드: {{code}}',
     preActionConnectDelay: '{{seconds}}초 후 연결합니다...',
+    autoPreActionAdded: '전처리 프로그램 자동 추가: {{name}} (기본적으로 비활성화)',
     removeConfirmTitle: '전처리 프로그램 삭제',
     removeConfirmMessage: '이 전처리 프로그램을 삭제하시겠습니까?',
   },

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -287,7 +287,7 @@ export default {
   },
 
   action: {
-    preAction: '前置程序',
+    preAction: '▶️ 前置程序',
     program: '程序路径',
     programPlaceholder: '输入程序路径或点击右侧浏览...',
     args: '附加参数',
@@ -321,7 +321,10 @@ export default {
     preActionFailed: '前置程序执行失败: {{error}}',
     preActionExitCode: '前置程序退出码: {{code}}',
     preActionConnectDelay: '等待 {{seconds}} 秒后连接...',
+    autoPreActionName: '▶️ 启动 {{name}}',
     autoPreActionAdded: '已自动添加前置程序: {{name}}（默认未启用）',
+    autoKillTaskName: '⛔ 结束 {{name}}',
+    autoKillTaskAdded: '已自动添加结束进程任务: {{name}}（默认未启用）',
     removeConfirmTitle: '删除前置程序',
     removeConfirmMessage: '确定要删除这个前置程序吗？',
   },

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -321,6 +321,7 @@ export default {
     preActionFailed: '前置程序执行失败: {{error}}',
     preActionExitCode: '前置程序退出码: {{code}}',
     preActionConnectDelay: '等待 {{seconds}} 秒后连接...',
+    autoPreActionAdded: '已自动添加前置程序: {{name}}（默认未启用）',
     removeConfirmTitle: '删除前置程序',
     removeConfirmMessage: '确定要删除这个前置程序吗？',
   },

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -317,6 +317,7 @@ export default {
     preActionFailed: '前置程式執行失敗: {{error}}',
     preActionExitCode: '前置程式結束碼: {{code}}',
     preActionConnectDelay: '等待 {{seconds}} 秒後連線...',
+    autoPreActionAdded: '已自動新增前置程式: {{name}}（預設未啟用）',
     removeConfirmTitle: '刪除前置程式',
     removeConfirmMessage: '確定要刪除這個前置程式嗎？',
   },

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -283,7 +283,7 @@ export default {
   },
 
   action: {
-    preAction: '前置程式',
+    preAction: '▶️ 前置程式',
     program: '程式路徑',
     programPlaceholder: '輸入程式路徑或點擊右側瀏覽...',
     args: '附加參數',
@@ -317,7 +317,10 @@ export default {
     preActionFailed: '前置程式執行失敗: {{error}}',
     preActionExitCode: '前置程式結束碼: {{code}}',
     preActionConnectDelay: '等待 {{seconds}} 秒後連線...',
+    autoPreActionName: '▶️ 啟動 {{name}}',
     autoPreActionAdded: '已自動新增前置程式: {{name}}（預設未啟用）',
+    autoKillTaskName: '⛔ 結束 {{name}}',
+    autoKillTaskAdded: '已自動新增結束處理程序任務: {{name}}（預設未啟用）',
     removeConfirmTitle: '刪除前置程式',
     removeConfirmMessage: '確定要刪除這個前置程式嗎？',
   },

--- a/src/services/maaService.ts
+++ b/src/services/maaService.ts
@@ -1018,6 +1018,21 @@ export const maaService = {
       return false;
     }
   },
+
+  /**
+   * 根据窗口句柄获取对应进程的可执行文件路径（仅 Windows）
+   */
+  async getProcessPathFromHwnd(hwnd: number): Promise<string> {
+    if (!isTauri()) {
+      return '';
+    }
+    try {
+      return await invoke<string>('get_process_path_from_hwnd', { hwnd });
+    } catch (err) {
+      log.warn('获取窗口进程路径失败:', err);
+      return '';
+    }
+  },
 };
 
 export default maaService;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -520,6 +520,12 @@ export const useAppStore = create<AppState>()(
       instanceId: string,
       taskName: string,
       initialValues?: Record<string, string>,
+      taskOptions?: {
+        enabled?: boolean;
+        expanded?: boolean;
+        customName?: string;
+        switchOverrides?: Record<string, boolean>;
+      },
     ) => {
       // 从注册表获取特殊任务定义
       const specialTask = getMxuSpecialTask(taskName);
@@ -543,9 +549,14 @@ export const useAppStore = create<AppState>()(
           }
           optionValues[optionKey] = { type: 'input', values };
         } else if (optionDef.type === 'switch') {
-          const defaultCase = optionDef.default_case;
-          const isOn = defaultCase === 'Yes' || defaultCase === optionDef.cases[0]?.name;
-          optionValues[optionKey] = { type: 'switch', value: isOn };
+          const overridden = taskOptions?.switchOverrides?.[optionKey];
+          if (overridden !== undefined) {
+            optionValues[optionKey] = { type: 'switch', value: overridden };
+          } else {
+            const defaultCase = optionDef.default_case;
+            const isOn = defaultCase === 'Yes' || defaultCase === optionDef.cases[0]?.name;
+            optionValues[optionKey] = { type: 'switch', value: isOn };
+          }
         } else if (optionDef.type === 'checkbox') {
           const defaultCases = optionDef.default_case || [];
           optionValues[optionKey] = { type: 'checkbox', caseNames: [...defaultCases] };
@@ -560,9 +571,10 @@ export const useAppStore = create<AppState>()(
       const newTask: SelectedTask = {
         id: generateId(),
         taskName,
-        enabled: true,
+        customName: taskOptions?.customName,
+        enabled: taskOptions?.enabled ?? true,
         optionValues,
-        expanded: true,
+        expanded: taskOptions?.expanded ?? true,
       };
 
       set((state) => ({

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -164,6 +164,13 @@ export interface AppState {
     instanceId: string,
     taskName: string,
     initialValues?: Record<string, string>,
+    taskOptions?: {
+      enabled?: boolean;
+      expanded?: boolean;
+      customName?: string;
+      /** 覆盖 switch 选项的初始值（key 为选项 key，value 为 boolean） */
+      switchOverrides?: Record<string, boolean>;
+    },
   ) => string;
   removeTaskFromInstance: (instanceId: string, taskId: string) => void;
   reorderTasks: (instanceId: string, oldIndex: number, newIndex: number) => void;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -31,6 +31,8 @@ export interface SavedDeviceInfo {
   wlrSocketPath?: string;
   // PlayCover：保存地址
   playcoverAddress?: string;
+  /** Win32 连接窗口对应的进程可执行文件路径 */
+  connectedProgramPath?: string;
 }
 
 /** 旧版单个前置程序配置（不含 id，用于向后兼容读取） */

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -239,6 +239,8 @@ export interface SavedDeviceInfo {
   windowName?: string;
   wlrSocketPath?: string;
   playcoverAddress?: string;
+  /** Win32 连接窗口对应的进程可执行文件路径 */
+  connectedProgramPath?: string;
 }
 
 // 定时执行策略

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -84,6 +84,13 @@ export async function getCacheDir(): Promise<string> {
 }
 
 /**
+ * 从完整路径中提取文件名（进程名）
+ */
+export function getProcessNameFromPath(path: string): string {
+  return path.split(/[/\\]/).pop() || path;
+}
+
+/**
  * 打开指定目录（仅 Tauri 环境有效）
  */
 export async function openDirectory(dirPath: string): Promise<void> {


### PR DESCRIPTION
## 由 Sourcery 生成的摘要

在连接到 Win32 窗口时，自动推导并复用已连接游戏进程的路径，用于预填充并自动创建相关任务。

新特性：
- 新增 Tauri 命令和服务 API，用于从 Win32 窗口句柄获取可执行文件路径，并将其作为 `connectedProgramPath` 存储在实例上。
- 在 Win32 连接成功后，为已连接的游戏进程自动创建处于禁用状态的预操作“启动”和“结束进程”任务，并带有本地化的日志消息和标签。
- 当在任务面板中添加新的预操作任务以及特殊的启动/结束任务时，使用已连接程序路径或进程名进行预填充。

增强项：
- 扩展特殊任务的创建逻辑，使其可以接受任务选项，如启用状态、展开状态、自定义名称以及开关覆盖配置。
- 调整各语言环境中的预操作 UI 标签和图标，以强化“启动”语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically derive and reuse the connected game process path to pre-fill and auto-create related tasks when connecting to a Win32 window.

New Features:
- Add a Tauri command and service API to fetch an executable path from a Win32 window handle and store it on the instance as connectedProgramPath.
- Auto-create disabled pre-action launch and kill-process tasks for the connected game process after a successful Win32 connection, with localized log messages and labels.
- Pre-fill new pre-action and special launch/kill tasks with the connected program path or process name when adding them from the task panel.

Enhancements:
- Extend special-task creation to accept task options such as enabled state, expansion state, custom name, and switch overrides.
- Adjust UI labels and icons for pre-actions across locales to emphasize launch semantics.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 生成的摘要

在连接到 Win32 窗口时，自动推导并复用已连接游戏进程的路径，用于预填充并自动创建相关任务。

新特性：
- 新增 Tauri 命令和服务 API，用于从 Win32 窗口句柄获取可执行文件路径，并将其作为 `connectedProgramPath` 存储在实例上。
- 在 Win32 连接成功后，为已连接的游戏进程自动创建处于禁用状态的预操作“启动”和“结束进程”任务，并带有本地化的日志消息和标签。
- 当在任务面板中添加新的预操作任务以及特殊的启动/结束任务时，使用已连接程序路径或进程名进行预填充。

增强项：
- 扩展特殊任务的创建逻辑，使其可以接受任务选项，如启用状态、展开状态、自定义名称以及开关覆盖配置。
- 调整各语言环境中的预操作 UI 标签和图标，以强化“启动”语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically derive and reuse the connected game process path to pre-fill and auto-create related tasks when connecting to a Win32 window.

New Features:
- Add a Tauri command and service API to fetch an executable path from a Win32 window handle and store it on the instance as connectedProgramPath.
- Auto-create disabled pre-action launch and kill-process tasks for the connected game process after a successful Win32 connection, with localized log messages and labels.
- Pre-fill new pre-action and special launch/kill tasks with the connected program path or process name when adding them from the task panel.

Enhancements:
- Extend special-task creation to accept task options such as enabled state, expansion state, custom name, and switch overrides.
- Adjust UI labels and icons for pre-actions across locales to emphasize launch semantics.

</details>

</details>