### PR TITLE
feat: 新的导入导出功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-dom": "^19.1.0",
     "react-i18next": "^16.5.3",
     "semver": "^7.7.3",
+    "sonner": "^2.0.7",
     "tailwindcss": "^4.1.18",
     "zustand": "^5.0.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       semver:
         specifier: ^7.7.3
         version: 7.7.3
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -1372,6 +1375,12 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2547,6 +2556,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1629,6 +1629,16 @@ function App() {
     };
   }, []);
 
+  const toaster = (
+    <Toaster
+      theme={resolveThemeMode(theme)}
+      position="bottom-center"
+      toastOptions={{
+        className: '!bg-bg-secondary !text-text-primary !border-border',
+      }}
+    />
+  );
+
   // 设置页面
   if (currentPage === 'settings') {
     return (
@@ -1666,13 +1676,7 @@ function App() {
             />
           </div>
         </div>
-        <Toaster
-          theme={resolveThemeMode(theme)}
-          position="bottom-center"
-          toastOptions={{
-            className: '!bg-bg-secondary !text-text-primary !border-border',
-          }}
-        />
+        {toaster}
       </div>
     );
   }
@@ -1920,13 +1924,7 @@ function App() {
           </div>
         )}
       </div>
-      <Toaster
-        theme={resolveThemeMode(theme)}
-        position="bottom-center"
-        toastOptions={{
-          className: '!bg-bg-secondary !text-text-primary !border-border',
-        }}
-      />
+      {toaster}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import { getAllLogsFromBackend } from '@/utils/logStdout';
 import { useMaaCallbackLogger, useMaaAgentLogger } from '@/utils/useMaaCallbackLogger';
 import { getInterfaceLangKey } from '@/i18n';
 import { applyTheme, resolveThemeMode, registerCustomAccent, clearCustomAccents } from '@/themes';
+import { Toaster } from 'sonner';
 import { loadWebUIAppearance, loadWebUILayout } from '@/services/appearanceStorage';
 import {
   isTauri,
@@ -1665,6 +1666,13 @@ function App() {
             />
           </div>
         </div>
+        <Toaster
+          theme={resolveThemeMode(theme)}
+          position="bottom-center"
+          toastOptions={{
+            className: '!bg-bg-secondary !text-text-primary !border-border',
+          }}
+        />
       </div>
     );
   }
@@ -1912,6 +1920,13 @@ function App() {
           </div>
         )}
       </div>
+      <Toaster
+        theme={resolveThemeMode(theme)}
+        position="bottom-center"
+        toastOptions={{
+          className: '!bg-bg-secondary !text-text-primary !border-border',
+        }}
+      />
     </div>
   );
 }

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -20,11 +20,14 @@ import {
   PanelRightClose,
   Bell,
   History,
+  Share2,
 } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
 import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
 import { ConfirmDialog } from './ConfirmDialog';
 import { getInterfaceLangKey } from '@/i18n';
+import { exportTabConfig } from '@/utils/tabExportImport';
+import { toast } from 'sonner';
 import clsx from 'clsx';
 
 const LazyUpdatePanel = lazy(async () => {
@@ -176,6 +179,26 @@ export function TabBar() {
           label: t('contextMenu.duplicateTab'),
           icon: Copy,
           onClick: () => duplicateInstance(instanceId),
+        },
+        {
+          id: 'export',
+          label: t('contextMenu.exportConfig'),
+          icon: Share2,
+          onClick: () => {
+            const inst = instances.find((i) => i.id === instanceId);
+            const projectName = projectInterface?.name;
+            if (inst && projectName) {
+              const hint = t('preset.exportShareHint', {
+                projectName,
+                tabName: inst.name,
+              });
+              const footer = t('preset.exportShareFooter', { projectName });
+              exportTabConfig(inst, projectName, hint, footer).then(
+                () => toast.success(t('preset.exportSuccess')),
+                () => toast.error(t('preset.importFailed')),
+              );
+            }
+          },
         },
         {
           id: 'rename',

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -26,8 +26,7 @@ import { useAppStore } from '@/stores/appStore';
 import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
 import { ConfirmDialog } from './ConfirmDialog';
 import { getInterfaceLangKey } from '@/i18n';
-import { exportTabConfig } from '@/utils/tabExportImport';
-import { toast } from 'sonner';
+import { exportWithToast } from '@/utils/tabExportImport';
 import clsx from 'clsx';
 
 const LazyUpdatePanel = lazy(async () => {
@@ -188,14 +187,12 @@ export function TabBar() {
             const inst = instances.find((i) => i.id === instanceId);
             const projectName = projectInterface?.name;
             if (inst && projectName) {
-              const hint = t('preset.exportShareHint', {
+              exportWithToast(
+                inst,
                 projectName,
-                tabName: inst.name,
-              });
-              const footer = t('preset.exportShareFooter', { projectName });
-              exportTabConfig(inst, projectName, hint, footer).then(
-                () => toast.success(t('preset.exportSuccess')),
-                () => toast.error(t('preset.importFailed')),
+                t('preset.exportShareHint', { projectName, tabName: inst.name }),
+                t('preset.exportShareFooter', { projectName }),
+                { success: t('preset.exportSuccess'), failed: t('preset.exportFailed') },
               );
             }
           },
@@ -281,7 +278,7 @@ export function TabBar() {
 
       showMenu(e, menuItems);
     },
-    [instances, t, createInstance, duplicateInstance, removeInstance, reorderInstances, showMenu],
+    [instances, t, createInstance, duplicateInstance, removeInstance, reorderInstances, showMenu, projectInterface, confirmBeforeDelete, startTabCloseAnimation],
   );
 
   // 基于鼠标事件的拖拽实现（更可靠，兼容 Tauri）

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -24,6 +24,8 @@ import {
   ChevronUp,
   Sparkles,
   Loader2,
+  Share2,
+  ClipboardPaste,
 } from 'lucide-react';
 import { useAppStore } from '@/stores/appStore';
 import { TaskItem } from './TaskItem';
@@ -32,6 +34,9 @@ import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
 import type { PresetItem } from '@/types/interface';
 import { getInterfaceLangKey } from '@/i18n';
 import { useResolvedContent } from '@/services/contentResolver';
+import { exportTabConfig, importTabConfigFromClipboard, getImportErrorType } from '@/utils/tabExportImport';
+import { generateId } from '@/stores/helpers';
+import { toast } from 'sonner';
 import clsx from 'clsx';
 
 /** 单个预设卡片 */
@@ -81,6 +86,65 @@ function PresetCard({ preset, onApply }: { preset: PresetItem; onApply: () => vo
   );
 }
 
+/** 导入按钮 */
+function ImportConfigButton({ instanceId }: { instanceId: string }) {
+  const { projectInterface, updateInstance, renameInstance, setSelectedController, setSelectedResource } =
+    useAppStore();
+  const { t } = useTranslation();
+
+  const handleImport = async () => {
+    const projectName = projectInterface?.name;
+    if (!projectName) return;
+
+    try {
+      const { tabName, payload } = await importTabConfigFromClipboard(projectName);
+
+      const importedTasks = payload.selectedTasks.map((task) => ({
+        ...task,
+        id: generateId(),
+        expanded: true,
+      }));
+
+      // 任务写入后 PresetSelector 自动消失，无需调用 skipPreset（避免触发 showAddTaskPanel）
+      updateInstance(instanceId, {
+        selectedTasks: importedTasks,
+        controllerName: payload.controllerName,
+        resourceName: payload.resourceName,
+        preActions: payload.preActions,
+      });
+
+      if (payload.controllerName) {
+        setSelectedController(instanceId, payload.controllerName);
+      }
+      if (payload.resourceName) {
+        setSelectedResource(instanceId, payload.resourceName);
+      }
+
+      renameInstance(instanceId, tabName);
+      toast.success(t('preset.importSuccess'));
+    } catch (err) {
+      const errorType = getImportErrorType(err);
+      if (errorType === 'project_mismatch') {
+        toast.error(t('preset.importProjectMismatch'));
+      } else if (errorType === 'unsupported_version') {
+        toast.error(t('preset.importVersionUnsupported'));
+      } else {
+        toast.error(t('preset.importFailed'));
+      }
+    }
+  };
+
+  return (
+    <button
+      onClick={handleImport}
+      className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-accent transition-colors"
+    >
+      <ClipboardPaste className="w-3.5 h-3.5" />
+      {t('preset.importConfig')}
+    </button>
+  );
+}
+
 /** 预设选择器 - 任务列表为空时显示 */
 function PresetSelector({ instanceId }: { instanceId: string }) {
   const { projectInterface, applyPreset, skipPreset, renameInstance, resolveI18nText, language } =
@@ -111,12 +175,16 @@ function PresetSelector({ instanceId }: { instanceId: string }) {
           />
         ))}
       </div>
-      <button
-        onClick={() => skipPreset(instanceId)}
-        className="text-xs text-text-muted hover:text-accent transition-colors"
-      >
-        {t('preset.skipToManual')}
-      </button>
+      <div className="flex items-center gap-4">
+        <ImportConfigButton instanceId={instanceId} />
+        <span className="text-text-muted/30 text-xs">|</span>
+        <button
+          onClick={() => skipPreset(instanceId)}
+          className="text-xs text-text-muted hover:text-accent transition-colors"
+        >
+          {t('preset.skipToManual')}
+        </button>
+      </div>
     </div>
   );
 }
@@ -236,11 +304,32 @@ export function TaskList() {
               },
             ]
           : []),
+        { id: 'divider-export', label: '', divider: true },
+        {
+          id: 'export',
+          label: t('contextMenu.exportConfig'),
+          icon: Share2,
+          disabled: !hasTasks,
+          onClick: () => {
+            const projectName = projectInterface?.name;
+            if (projectName) {
+              const hint = t('preset.exportShareHint', {
+                projectName,
+                tabName: instance.name,
+              });
+              const footer = t('preset.exportShareFooter', { projectName });
+              exportTabConfig(instance, projectName, hint, footer).then(
+                () => toast.success(t('preset.exportSuccess')),
+                () => toast.error(t('preset.importFailed')),
+              );
+            }
+          },
+        },
       ];
 
       showMenu(e, menuItems);
     },
-    [t, instance, showAddTaskPanel, setShowAddTaskPanel, selectAllTasks, collapseAllTasks, showMenu],
+    [t, instance, showAddTaskPanel, setShowAddTaskPanel, selectAllTasks, collapseAllTasks, showMenu, projectInterface],
   );
 
   if (!instance) {
@@ -270,6 +359,7 @@ export function TaskList() {
               <ListTodo className="w-12 h-12 opacity-30" />
               <p className="text-sm">{t('taskList.noTasks')}</p>
               <p className="text-xs">{t('taskList.dragToReorder')}</p>
+              <ImportConfigButton instanceId={instance.id} />
             </div>
           )}
         </div>
@@ -322,6 +412,7 @@ export function TaskList() {
               <ListTodo className="w-12 h-12 opacity-30" />
               <p className="text-sm">{t('taskList.noTasks')}</p>
               <p className="text-xs">{t('taskList.dragToReorder')}</p>
+              <ImportConfigButton instanceId={instance.id} />
             </div>
           )}
         </div>

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -34,7 +34,7 @@ import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
 import type { PresetItem } from '@/types/interface';
 import { getInterfaceLangKey } from '@/i18n';
 import { useResolvedContent } from '@/services/contentResolver';
-import { exportTabConfig, importTabConfigFromClipboard, getImportErrorType } from '@/utils/tabExportImport';
+import { exportWithToast, importTabConfigFromClipboard, getImportErrorType } from '@/utils/tabExportImport';
 import { generateId } from '@/stores/helpers';
 import { toast } from 'sonner';
 import clsx from 'clsx';
@@ -313,14 +313,12 @@ export function TaskList() {
           onClick: () => {
             const projectName = projectInterface?.name;
             if (projectName) {
-              const hint = t('preset.exportShareHint', {
+              exportWithToast(
+                instance,
                 projectName,
-                tabName: instance.name,
-              });
-              const footer = t('preset.exportShareFooter', { projectName });
-              exportTabConfig(instance, projectName, hint, footer).then(
-                () => toast.success(t('preset.exportSuccess')),
-                () => toast.error(t('preset.importFailed')),
+                t('preset.exportShareHint', { projectName, tabName: instance.name }),
+                t('preset.exportShareFooter', { projectName }),
+                { success: t('preset.exportSuccess'), failed: t('preset.exportFailed') },
               );
             }
           },

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -338,6 +338,14 @@ export default {
     hint: 'Apply a predefined task configuration to get started quickly',
     taskCount: 'tasks',
     skipToManual: 'Skip, add tasks manually',
+    importConfig: 'Import config from clipboard',
+    importSuccess: 'Config imported successfully',
+    importFailed: 'Import failed: invalid format',
+    importProjectMismatch: 'Import failed: project mismatch',
+    importVersionUnsupported: 'Import failed: unsupported version',
+    exportSuccess: 'Config copied to clipboard',
+    exportShareHint: 'Sharing my {{projectName}} config "{{tabName}}" with you~',
+    exportShareFooter: '👆 Copy this message, open {{projectName}}, create a new tab, and tap "Import Config" to use it instantly',
   },
 
   // Controller
@@ -737,6 +745,7 @@ export default {
     closeOtherTabs: 'Close Other Tabs',
     closeAllTabs: 'Close All Tabs',
     closeTabsToRight: 'Close Tabs to the Right',
+    exportConfig: 'Export Config',
 
     // Pre-action context menu
     duplicateAction: 'Duplicate',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -344,6 +344,7 @@ export default {
     importProjectMismatch: 'Import failed: project mismatch',
     importVersionUnsupported: 'Import failed: unsupported version',
     exportSuccess: 'Config copied to clipboard',
+    exportFailed: 'Export failed: unable to write to clipboard',
     exportShareHint: 'Sharing my {{projectName}} config "{{tabName}}" with you~',
     exportShareFooter: '👆 Copy this message, open {{projectName}}, create a new tab, and tap "Import Config" to use it instantly',
   },

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -333,6 +333,14 @@ export default {
     hint: 'ワンクリックでタスク構成を適用し、すぐに開始できます',
     taskCount: 'タスク',
     skipToManual: 'スキップして手動でタスクを追加',
+    importConfig: 'クリップボードから設定をインポート',
+    importSuccess: '設定のインポートに成功しました',
+    importFailed: 'インポート失敗：無効な形式',
+    importProjectMismatch: 'インポート失敗：プロジェクトが一致しません',
+    importVersionUnsupported: 'インポート失敗：サポートされていないバージョン',
+    exportSuccess: '設定をクリップボードにコピーしました',
+    exportShareHint: '{{projectName}} の「{{tabName}}」設定をシェアするよ～',
+    exportShareFooter: '👆 このメッセージをコピーして、{{projectName}} で新しいタブを開き「設定をインポート」を押すだけでOK',
   },
 
   // コントローラー
@@ -736,6 +744,7 @@ export default {
     closeOtherTabs: '他のタブを閉じる',
     closeAllTabs: 'すべてのタブを閉じる',
     closeTabsToRight: '右側のタブを閉じる',
+    exportConfig: '設定をエクスポート',
 
     // 前処理プログラムのコンテキストメニュー
     duplicateAction: '複製',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -339,6 +339,7 @@ export default {
     importProjectMismatch: 'インポート失敗：プロジェクトが一致しません',
     importVersionUnsupported: 'インポート失敗：サポートされていないバージョン',
     exportSuccess: '設定をクリップボードにコピーしました',
+    exportFailed: 'エクスポート失敗：クリップボードに書き込めません',
     exportShareHint: '{{projectName}} の「{{tabName}}」設定をシェアするよ～',
     exportShareFooter: '👆 このメッセージをコピーして、{{projectName}} で新しいタブを開き「設定をインポート」を押すだけでOK',
   },

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -337,6 +337,7 @@ export default {
     importProjectMismatch: '가져오기 실패: 프로젝트 불일치',
     importVersionUnsupported: '가져오기 실패: 지원되지 않는 버전',
     exportSuccess: '설정이 클립보드에 복사되었습니다',
+    exportFailed: '내보내기 실패: 클립보드에 쓸 수 없습니다',
     exportShareHint: '{{projectName}} 의 「{{tabName}}」 설정 공유해요~',
     exportShareFooter: '👆 이 메시지를 복사해서 {{projectName}} 에서 새 탭을 만들고 「설정 가져오기」를 누르면 바로 사용할 수 있어요',
   },

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -331,6 +331,14 @@ export default {
     hint: '미리 정의된 작업 구성을 원클릭으로 적용하여 빠르게 시작하세요',
     taskCount: '개 작업',
     skipToManual: '건너뛰고 수동으로 작업 추가',
+    importConfig: '클립보드에서 설정 가져오기',
+    importSuccess: '설정 가져오기 성공',
+    importFailed: '가져오기 실패: 잘못된 형식',
+    importProjectMismatch: '가져오기 실패: 프로젝트 불일치',
+    importVersionUnsupported: '가져오기 실패: 지원되지 않는 버전',
+    exportSuccess: '설정이 클립보드에 복사되었습니다',
+    exportShareHint: '{{projectName}} 의 「{{tabName}}」 설정 공유해요~',
+    exportShareFooter: '👆 이 메시지를 복사해서 {{projectName}} 에서 새 탭을 만들고 「설정 가져오기」를 누르면 바로 사용할 수 있어요',
   },
 
   // 컨트롤러
@@ -730,6 +738,7 @@ export default {
     closeOtherTabs: '다른 탭 닫기',
     closeAllTabs: '모든 탭 닫기',
     closeTabsToRight: '오른쪽 탭 닫기',
+    exportConfig: '설정 내보내기',
 
     // 전처리 프로그램 컨텍스트 메뉴
     duplicateAction: '복제',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -331,6 +331,14 @@ export default {
     hint: '一键应用预定义的任务配置，快速开始',
     taskCount: '个任务',
     skipToManual: '跳过，手动添加任务',
+    importConfig: '从剪贴板导入配置',
+    importSuccess: '配置导入成功',
+    importFailed: '导入失败：格式无效',
+    importProjectMismatch: '导入失败：项目不匹配',
+    importVersionUnsupported: '导入失败：不支持的版本',
+    exportSuccess: '配置已复制到剪贴板',
+    exportShareHint: '「{{tabName}}」的 {{projectName}} 配置，发给你啦~',
+    exportShareFooter: '👆 复制这段文字，在 {{projectName}} 里新建标签页，点「导入配置」就能直接用',
   },
 
   // 控制器
@@ -734,6 +742,7 @@ export default {
     closeOtherTabs: '关闭其他标签页',
     closeAllTabs: '关闭所有标签页',
     closeTabsToRight: '关闭右侧标签页',
+    exportConfig: '导出配置',
 
     // 前置程序右键菜单
     duplicateAction: '复制',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -337,6 +337,7 @@ export default {
     importProjectMismatch: '导入失败：项目不匹配',
     importVersionUnsupported: '导入失败：不支持的版本',
     exportSuccess: '配置已复制到剪贴板',
+    exportFailed: '导出失败：无法写入剪贴板',
     exportShareHint: '「{{tabName}}」的 {{projectName}} 配置，发给你啦~',
     exportShareFooter: '👆 复制这段文字，在 {{projectName}} 里新建标签页，点「导入配置」就能直接用',
   },

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -333,6 +333,7 @@ export default {
     importProjectMismatch: '匯入失敗：專案不匹配',
     importVersionUnsupported: '匯入失敗：不支援的版本',
     exportSuccess: '設定已複製到剪貼簿',
+    exportFailed: '匯出失敗：無法寫入剪貼簿',
     exportShareHint: '「{{tabName}}」的 {{projectName}} 設定，分享給你囉~',
     exportShareFooter: '👆 複製這段文字，在 {{projectName}} 裡新建標籤頁，點「匯入設定」就能直接用',
   },

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -327,6 +327,14 @@ export default {
     hint: '一鍵套用預定義的任務設定，快速開始',
     taskCount: '個任務',
     skipToManual: '跳過，手動新增任務',
+    importConfig: '從剪貼簿匯入設定',
+    importSuccess: '設定匯入成功',
+    importFailed: '匯入失敗：格式無效',
+    importProjectMismatch: '匯入失敗：專案不匹配',
+    importVersionUnsupported: '匯入失敗：不支援的版本',
+    exportSuccess: '設定已複製到剪貼簿',
+    exportShareHint: '「{{tabName}}」的 {{projectName}} 設定，分享給你囉~',
+    exportShareFooter: '👆 複製這段文字，在 {{projectName}} 裡新建標籤頁，點「匯入設定」就能直接用',
   },
 
   // 控制器
@@ -719,6 +727,7 @@ export default {
     closeOtherTabs: '關閉其他標籤頁',
     closeAllTabs: '關閉所有標籤頁',
     closeTabsToRight: '關閉右側標籤頁',
+    exportConfig: '匯出設定',
 
     // 前置程式右鍵選單
     duplicateAction: '複製',

--- a/src/utils/tabExportImport.ts
+++ b/src/utils/tabExportImport.ts
@@ -1,0 +1,320 @@
+import type { SavedTask } from '@/types/config';
+import type { ActionConfig, Instance, OptionValue } from '@/types/interface';
+
+const PROTOCOL_SEGMENT = 'tab-sharing';
+const CURRENT_VERSION = 'v1';
+
+export interface TabExportPayload {
+  controllerName?: string;
+  resourceName?: string;
+  selectedTasks: SavedTask[];
+  preActions?: ActionConfig[];
+}
+
+export interface TabImportResult {
+  tabName: string;
+  payload: TabExportPayload;
+}
+
+export type ImportError = 'invalid_format' | 'project_mismatch' | 'unsupported_version';
+
+// ── v1 短 key 内部序列化结构 ─────────────────────────────────────────────────
+// 仅在 wire 格式中使用，不对外暴露
+
+type WireOptionValue =
+  | { t: 's'; c: string }       // select:   caseName
+  | { t: 'cb'; c: string[] }    // checkbox: caseNames
+  | { t: 'sw'; v: boolean }     // switch:   value
+  | { t: 'in'; v: Record<string, string> }; // input: values
+
+interface WireTask {
+  i: string;           // id
+  tn: string;          // taskName
+  cn?: string;         // customName
+  e: boolean;          // enabled
+  ov: Record<string, WireOptionValue>; // optionValues
+}
+
+interface WireAction {
+  i: string;           // id
+  cn?: string;         // customName
+  e: boolean;          // enabled
+  p: string;           // program
+  a: string;           // args
+  w: boolean;          // waitForExit
+  s: boolean;          // skipIfRunning
+  u: boolean;          // useCmd
+}
+
+interface WirePayload {
+  cn?: string;         // controllerName
+  rn?: string;         // resourceName
+  t: WireTask[];       // selectedTasks
+  pa?: WireAction[];   // preActions
+}
+
+// ── 序列化：业务结构 → 短 key wire 格式 ─────────────────────────────────────
+
+function encodeOptionValue(v: OptionValue): WireOptionValue {
+  switch (v.type) {
+    case 'select':   return { t: 's',  c: v.caseName };
+    case 'checkbox': return { t: 'cb', c: v.caseNames };
+    case 'switch':   return { t: 'sw', v: v.value };
+    case 'input':    return { t: 'in', v: v.values };
+  }
+}
+
+function encodeTask(task: SavedTask): WireTask {
+  const wire: WireTask = {
+    i:  task.id,
+    tn: task.taskName,
+    e:  task.enabled,
+    ov: Object.fromEntries(
+      Object.entries(task.optionValues).map(([k, v]) => [k, encodeOptionValue(v)]),
+    ),
+  };
+  if (task.customName !== undefined) wire.cn = task.customName;
+  return wire;
+}
+
+function encodeAction(action: ActionConfig): WireAction {
+  const wire: WireAction = {
+    i: action.id,
+    e: action.enabled,
+    p: action.program,
+    a: action.args,
+    w: action.waitForExit,
+    s: action.skipIfRunning,
+    u: action.useCmd,
+  };
+  if (action.customName !== undefined) wire.cn = action.customName;
+  return wire;
+}
+
+function encodePayload(payload: TabExportPayload): WirePayload {
+  const wire: WirePayload = {
+    t: payload.selectedTasks.map(encodeTask),
+  };
+  if (payload.controllerName !== undefined) wire.cn = payload.controllerName;
+  if (payload.resourceName   !== undefined) wire.rn = payload.resourceName;
+  if (payload.preActions?.length)           wire.pa = payload.preActions.map(encodeAction);
+  return wire;
+}
+
+// ── 反序列化：短 key wire 格式 → 业务结构 ───────────────────────────────────
+
+function decodeOptionValue(w: WireOptionValue): OptionValue {
+  switch (w.t) {
+    case 's':  return { type: 'select',   caseName:  w.c };
+    case 'cb': return { type: 'checkbox', caseNames: w.c };
+    case 'sw': return { type: 'switch',   value:     w.v };
+    case 'in': return { type: 'input',    values:    w.v };
+  }
+}
+
+function decodeTask(w: WireTask): SavedTask {
+  return {
+    id:           w.i,
+    taskName:     w.tn,
+    customName:   w.cn,
+    enabled:      w.e,
+    optionValues: Object.fromEntries(
+      Object.entries(w.ov).map(([k, v]) => [k, decodeOptionValue(v)]),
+    ),
+  };
+}
+
+function decodeAction(w: WireAction): ActionConfig {
+  return {
+    id:            w.i,
+    customName:    w.cn,
+    enabled:       w.e,
+    program:       w.p,
+    args:          w.a,
+    waitForExit:   w.w,
+    skipIfRunning: w.s,
+    useCmd:        w.u,
+  };
+}
+
+function decodePayload(wire: WirePayload): TabExportPayload {
+  return {
+    controllerName: wire.cn,
+    resourceName:   wire.rn,
+    selectedTasks:  wire.t.map(decodeTask),
+    preActions:     wire.pa?.map(decodeAction),
+  };
+}
+
+// ── gzip helpers ─────────────────────────────────────────────────────────────
+
+async function gzipCompress(str: string): Promise<Uint8Array> {
+  const encoded = new TextEncoder().encode(str);
+  const cs = new CompressionStream('gzip');
+  const writer = cs.writable.getWriter();
+  writer.write(encoded);
+  writer.close();
+  const chunks: Uint8Array[] = [];
+  const reader = cs.readable.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    result.set(c, offset);
+    offset += c.length;
+  }
+  return result;
+}
+
+async function gzipDecompress(bytes: Uint8Array): Promise<string> {
+  const ds = new DecompressionStream('gzip');
+  const writer = ds.writable.getWriter();
+  writer.write(bytes as Uint8Array<ArrayBuffer>);
+  writer.close();
+  const chunks: Uint8Array[] = [];
+  const reader = ds.readable.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    result.set(c, offset);
+    offset += c.length;
+  }
+  return new TextDecoder().decode(result);
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(str: string): Uint8Array {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = (4 - (padded.length % 4)) % 4;
+  const base64 = padded + '='.repeat(padding);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ── 公开 API ──────────────────────────────────────────────────────────────────
+
+/**
+ * 将当前 Tab 的配置序列化并写入剪贴板。
+ * 格式（三行）：
+ *   {hint}          ← 开头说明（调用方传入，本地化）
+ *   {projectName}://tab-sharing/v1/{tabName}/{base64url(gzip(JSON))}
+ *   {footer}        ← 结尾签名（调用方传入，本地化）
+ */
+export async function exportTabConfig(
+  instance: Instance,
+  projectName: string,
+  hint?: string,
+  footer?: string,
+): Promise<void> {
+  const payload: TabExportPayload = {
+    controllerName: instance.controllerName,
+    resourceName:   instance.resourceName,
+    selectedTasks:  instance.selectedTasks.map((t) => ({
+      id:           t.id,
+      taskName:     t.taskName,
+      customName:   t.customName,
+      enabled:      t.enabled,
+      optionValues: t.optionValues,
+    })),
+    preActions: instance.preActions,
+  };
+
+  const wire = encodePayload(payload);
+  const jsonStr = JSON.stringify(wire);
+  const compressed = await gzipCompress(jsonStr);
+  const base64 = toBase64Url(compressed);
+  const tabNameEncoded = encodeURIComponent(instance.name);
+
+  const dataLine = `${projectName}://${PROTOCOL_SEGMENT}/${CURRENT_VERSION}/${tabNameEncoded}/${base64}`;
+  const hintLine = hint ?? `[MXU] ${projectName} · ${instance.name}`;
+  const lines = footer ? `${hintLine}\n${dataLine}\n${footer}` : `${hintLine}\n${dataLine}`;
+  await navigator.clipboard.writeText(lines);
+}
+
+/**
+ * 从剪贴板读取并解析 Tab 配置导入数据。
+ * 返回解析后的 tabName + payload，或抛出带有 ImportError 类型的错误。
+ */
+export async function importTabConfigFromClipboard(
+  projectName: string,
+): Promise<TabImportResult> {
+  const rawText = (await navigator.clipboard.readText()).trim();
+
+  // 从任意行里提取协议行（忽略前缀说明文字）
+  const dataLineMatch = rawText.match(/(.+:\/\/tab-sharing\/.+)/m);
+  const text = dataLineMatch ? dataLineMatch[1].trim() : rawText;
+
+  const protocolPrefix = `${projectName}://${PROTOCOL_SEGMENT}/`;
+  if (!text.startsWith(protocolPrefix)) {
+    if (/^.+:\/\/tab-sharing\//.test(text)) {
+      throw createImportError('project_mismatch');
+    }
+    throw createImportError('invalid_format');
+  }
+
+  const rest = text.slice(protocolPrefix.length);
+  // rest = "v1/{tabName}/{base64url}"
+  const parts = rest.split('/');
+  if (parts.length < 3) {
+    throw createImportError('invalid_format');
+  }
+
+  const version = parts[0];
+  if (version !== CURRENT_VERSION) {
+    throw createImportError('unsupported_version');
+  }
+
+  const tabName = decodeURIComponent(parts[1]);
+  const base64Data = parts.slice(2).join('/');
+
+  let payload: TabExportPayload;
+  try {
+    const compressed = fromBase64Url(base64Data);
+    const jsonStr = await gzipDecompress(compressed);
+    const wire: WirePayload = JSON.parse(jsonStr);
+    payload = decodePayload(wire);
+  } catch {
+    throw createImportError('invalid_format');
+  }
+
+  if (!payload || !Array.isArray(payload.selectedTasks)) {
+    throw createImportError('invalid_format');
+  }
+
+  return { tabName, payload };
+}
+
+function createImportError(type: ImportError): Error {
+  const err = new Error(type);
+  (err as Error & { importErrorType: ImportError }).importErrorType = type;
+  return err;
+}
+
+export function getImportErrorType(err: unknown): ImportError | undefined {
+  if (err instanceof Error && 'importErrorType' in err) {
+    return (err as Error & { importErrorType: ImportError }).importErrorType;
+  }
+  return undefined;
+}

--- a/src/utils/tabExportImport.ts
+++ b/src/utils/tabExportImport.ts
@@ -148,9 +148,9 @@ function decodePayload(wire: WirePayload): TabExportPayload {
 
 // ── gzip helpers ─────────────────────────────────────────────────────────────
 
-async function gzipCompress(str: string): Promise<Uint8Array> {
+async function compress(str: string): Promise<Uint8Array> {
   const encoded = new TextEncoder().encode(str);
-  const cs = new CompressionStream('gzip');
+  const cs = new CompressionStream('deflate-raw');
   const writer = cs.writable.getWriter();
   writer.write(encoded);
   writer.close();
@@ -171,8 +171,8 @@ async function gzipCompress(str: string): Promise<Uint8Array> {
   return result;
 }
 
-async function gzipDecompress(bytes: Uint8Array): Promise<string> {
-  const ds = new DecompressionStream('gzip');
+async function decompress(bytes: Uint8Array): Promise<string> {
+  const ds = new DecompressionStream('deflate-raw');
   const writer = ds.writable.getWriter();
   writer.write(bytes as Uint8Array<ArrayBuffer>);
   writer.close();
@@ -243,7 +243,7 @@ export async function exportTabConfig(
 
   const wire = encodePayload(payload);
   const jsonStr = JSON.stringify(wire);
-  const compressed = await gzipCompress(jsonStr);
+  const compressed = await compress(jsonStr);
   const base64 = toBase64Url(compressed);
   const tabNameEncoded = encodeURIComponent(instance.name);
 
@@ -292,7 +292,7 @@ export async function importTabConfigFromClipboard(
   let payload: TabExportPayload;
   try {
     const compressed = fromBase64Url(base64Data);
-    const jsonStr = await gzipDecompress(compressed);
+    const jsonStr = await decompress(compressed);
     const wire: WirePayload = JSON.parse(jsonStr);
     payload = decodePayload(wire);
   } catch {

--- a/src/utils/tabExportImport.ts
+++ b/src/utils/tabExportImport.ts
@@ -1,5 +1,6 @@
 import type { SavedTask } from '@/types/config';
 import type { ActionConfig, Instance, OptionValue } from '@/types/interface';
+import { toast } from 'sonner';
 
 const PROTOCOL_SEGMENT = 'tab-sharing';
 const CURRENT_VERSION = 'v1';
@@ -109,6 +110,7 @@ function decodeOptionValue(w: WireOptionValue): OptionValue {
     case 'cb': return { type: 'checkbox', caseNames: w.c };
     case 'sw': return { type: 'switch',   value:     w.v };
     case 'in': return { type: 'input',    values:    w.v };
+    default:   throw new Error('invalid_format');
   }
 }
 
@@ -146,7 +148,7 @@ function decodePayload(wire: WirePayload): TabExportPayload {
   };
 }
 
-// ── gzip helpers ─────────────────────────────────────────────────────────────
+// ── deflate helpers ──────────────────────────────────────────────────────────
 
 async function compress(str: string): Promise<Uint8Array> {
   const encoded = new TextEncoder().encode(str);
@@ -194,11 +196,12 @@ async function decompress(bytes: Uint8Array): Promise<string> {
 }
 
 function toBase64Url(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+  const chunkSize = 0x8000;
+  const chunks: string[] = [];
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    chunks.push(String.fromCharCode(...bytes.subarray(i, i + chunkSize)));
   }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return btoa(chunks.join('')).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
 function fromBase64Url(str: string): Uint8Array {
@@ -219,7 +222,7 @@ function fromBase64Url(str: string): Uint8Array {
  * 将当前 Tab 的配置序列化并写入剪贴板。
  * 格式（三行）：
  *   {hint}          ← 开头说明（调用方传入，本地化）
- *   {projectName}://tab-sharing/v1/{tabName}/{base64url(gzip(JSON))}
+ *   {projectName}://tab-sharing/v1/{tabName}/{base64url(deflate(JSON))}
  *   {footer}        ← 结尾签名（调用方传入，本地化）
  */
 export async function exportTabConfig(
@@ -262,13 +265,15 @@ export async function importTabConfigFromClipboard(
 ): Promise<TabImportResult> {
   const rawText = (await navigator.clipboard.readText()).trim();
 
-  // 从任意行里提取协议行（忽略前缀说明文字）
-  const dataLineMatch = rawText.match(/(.+:\/\/tab-sharing\/.+)/m);
+  const escapedSegment = PROTOCOL_SEGMENT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const dataLineRegex = new RegExp(`(.+://${escapedSegment}/.+)`, 'm');
+  const dataLineMatch = rawText.match(dataLineRegex);
   const text = dataLineMatch ? dataLineMatch[1].trim() : rawText;
 
   const protocolPrefix = `${projectName}://${PROTOCOL_SEGMENT}/`;
   if (!text.startsWith(protocolPrefix)) {
-    if (/^.+:\/\/tab-sharing\//.test(text)) {
+    const mismatchRegex = new RegExp(`^.+://${escapedSegment}/`);
+    if (mismatchRegex.test(text)) {
       throw createImportError('project_mismatch');
     }
     throw createImportError('invalid_format');
@@ -317,4 +322,17 @@ export function getImportErrorType(err: unknown): ImportError | undefined {
     return (err as Error & { importErrorType: ImportError }).importErrorType;
   }
   return undefined;
+}
+
+export function exportWithToast(
+  instance: Instance,
+  projectName: string,
+  hint: string,
+  footer: string,
+  messages: { success: string; failed: string },
+): void {
+  exportTabConfig(instance, projectName, hint, footer).then(
+    () => toast.success(messages.success),
+    () => toast.error(messages.failed),
+  );
 }


### PR DESCRIPTION
## Summary by Sourcery

为任务和预设添加基于剪贴板的标签页配置导入/导出功能，并提供本地化消息和吐司通知。

New Features:
- 允许通过任务列表和标签栏中的上下文菜单，将当前标签页的任务配置导出为压缩的、可分享的剪贴板字符串。
- 允许从剪贴板向某个标签页导入任务配置，并自动应用任务、控制器/资源选择以及预执行操作。

Enhancements:
- 在空任务状态和预设选择器中显示内联导入按钮，以简化从共享配置开始的流程。
- 在所有受支持的语言中添加本地化的预设导入/导出标签、提示和错误消息。
- 引入与应用主题风格一致的底部居中吐司通知，用于显示导入/导出反馈。

Build:
- 添加 `sonner` 依赖以支持吐司通知功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add clipboard-based tab configuration import/export for tasks and presets, with localized messaging and toast notifications.

New Features:
- Allow exporting the current tab's task configuration to a compressed, shareable clipboard string via context menus in the task list and tab bar.
- Allow importing task configurations from the clipboard into a tab, automatically applying tasks, controller/resource selection, and pre-actions.

Enhancements:
- Show inline import buttons in empty task states and preset selector to streamline starting from shared configurations.
- Add localized preset import/export labels, hints, and error messages across supported languages.
- Introduce consistent bottom-center toast notifications styled to match the app theme for import/export feedback.

Build:
- Add the sonner dependency for toast notification support.

</details>