### PR TITLE
feat: resource hash integrity check (PI v2.6.0)

### DIFF
--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -764,6 +764,27 @@ pub fn maa_is_resource_loaded(
     Ok(instance.resource.as_ref().is_some_and(|r| r.loaded()))
 }
 
+/// 获取已加载资源的 hash 值（用于完整性校验）
+#[tauri::command]
+pub fn maa_get_resource_hash(
+    state: State<Arc<MaaState>>,
+    instance_id: String,
+) -> Result<Option<String>, String> {
+    let instances = state.instances.lock().map_err(|e| e.to_string())?;
+    let instance = instances.get(&instance_id).ok_or("Instance not found")?;
+
+    match instance.resource.as_ref() {
+        Some(r) => match r.hash() {
+            Ok(h) => Ok(Some(h)),
+            Err(e) => {
+                warn!("Failed to get resource hash for {}: {}", instance_id, e);
+                Ok(None)
+            }
+        },
+        None => Ok(None),
+    }
+}
+
 /// 销毁资源（用于切换资源时重新创建）
 #[tauri::command]
 pub fn maa_destroy_resource(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -218,6 +218,7 @@ pub fn run() {
             commands::maa_core::maa_get_connection_status,
             commands::maa_core::maa_load_resource,
             commands::maa_core::maa_is_resource_loaded,
+            commands::maa_core::maa_get_resource_hash,
             commands::maa_core::maa_destroy_resource,
             commands::maa_core::maa_run_task,
             commands::maa_core::maa_get_task_status,

--- a/src/components/connection/useResourceLoading.ts
+++ b/src/components/connection/useResourceLoading.ts
@@ -3,9 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { maaService } from '@/services/maaService';
 import { useAppStore } from '@/stores/appStore';
 import { resolveI18nText } from '@/services/contentResolver';
+import { isDebugVersion } from '@/services/updateService';
 import type { ResourceItem, ControllerItem } from '@/types/interface';
 import { startGlobalCallbackListener, waitForResResult } from './callbackCache';
-import { computeResourcePaths } from '@/utils/resourcePath';
+import { computeBaseResourcePaths, computeAttachResourcePaths } from '@/utils/resourcePath';
 
 interface UseResourceLoadingProps {
   instanceId: string;
@@ -21,7 +22,7 @@ export function useResourceLoading({
   currentController,
 }: UseResourceLoadingProps) {
   const { t } = useTranslation();
-  const { setInstanceResourceLoaded, registerResIdName, registerResBatch } = useAppStore();
+  const { setInstanceResourceLoaded, registerResIdName, registerResBatch, addLog } = useAppStore();
 
   const [isLoadingResource, setIsLoadingResource] = useState(false);
   const [isResourceLoaded, setIsResourceLoaded] = useState(false);
@@ -32,7 +33,6 @@ export function useResourceLoading({
   const resourceDropdownRef = useRef<HTMLButtonElement>(null);
   const resourceMenuRef = useRef<HTMLDivElement>(null);
 
-  // 加载资源内部实现
   const loadResourceInternal = useCallback(
     async (resource: ResourceItem) => {
       setIsLoadingResource(true);
@@ -42,42 +42,84 @@ export function useResourceLoading({
         await maaService.createInstance(instanceId).catch(() => {});
         await startGlobalCallbackListener();
 
-        // 计算完整的资源路径（包括 controller.attach_resource_path）
-        const resourcePaths = computeResourcePaths(resource, currentController, basePath);
-
-        const resIds = await maaService.loadResource(instanceId, resourcePaths);
-
         const resourceDisplayName = resolveI18nText(resource.label, translations) || resource.name;
-        registerResBatch(resIds);
-        resIds.forEach((resId) => {
+
+        // Phase 1: load resource.path
+        const basePaths = computeBaseResourcePaths(resource, basePath);
+        const baseResIds = await maaService.loadResource(instanceId, basePaths);
+
+        registerResBatch(baseResIds);
+        baseResIds.forEach((resId) => {
           registerResIdName(resId, resourceDisplayName);
         });
 
-        if (resIds.length === 0) {
+        if (baseResIds.length === 0) {
           setResourceError(t('resource.loadFailed'));
           setIsLoadingResource(false);
           return false;
         }
 
-        lastLoadedResourceRef.current = resource.name;
-
-        const results = await Promise.all(resIds.map((resId) => waitForResResult(resId)));
-
-        const hasFailed = results.some((r) => r === 'failed');
-
-        if (hasFailed) {
+        const baseResults = await Promise.all(baseResIds.map((resId) => waitForResResult(resId)));
+        if (baseResults.some((r) => r === 'failed')) {
           setResourceError(t('resource.loadFailed'));
           setIsResourceLoaded(false);
           setInstanceResourceLoaded(instanceId, false);
           setIsLoadingResource(false);
           lastLoadedResourceRef.current = null;
           return false;
-        } else {
-          setIsResourceLoaded(true);
-          setInstanceResourceLoaded(instanceId, true);
-          setIsLoadingResource(false);
-          return true;
         }
+
+        // Hash check: after base resource loaded, before attach
+        if (resource.hash) {
+          const piVersion = useAppStore.getState().projectInterface?.version;
+          const skipCheck = import.meta.env.DEV || isDebugVersion(piVersion);
+          if (!skipCheck) {
+            try {
+              const actualHash = await maaService.getResourceHash(instanceId);
+              if (actualHash && actualHash !== resource.hash) {
+                addLog(instanceId, {
+                  type: 'warning',
+                  message: t('resource.hashMismatch', {
+                    expected: resource.hash,
+                    actual: actualHash,
+                  }),
+                });
+              }
+            } catch {
+              // hash check is best-effort
+            }
+          }
+        }
+
+        // Phase 2: load controller.attach_resource_path
+        const attachPaths = computeAttachResourcePaths(currentController, basePath);
+        if (attachPaths.length > 0) {
+          const attachResIds = await maaService.loadResource(instanceId, attachPaths);
+          registerResBatch(attachResIds);
+          attachResIds.forEach((resId) => {
+            registerResIdName(resId, resourceDisplayName);
+          });
+
+          if (attachResIds.length > 0) {
+            const attachResults = await Promise.all(
+              attachResIds.map((resId) => waitForResResult(resId)),
+            );
+            if (attachResults.some((r) => r === 'failed')) {
+              setResourceError(t('resource.loadFailed'));
+              setIsResourceLoaded(false);
+              setInstanceResourceLoaded(instanceId, false);
+              setIsLoadingResource(false);
+              lastLoadedResourceRef.current = null;
+              return false;
+            }
+          }
+        }
+
+        lastLoadedResourceRef.current = resource.name;
+        setIsResourceLoaded(true);
+        setInstanceResourceLoaded(instanceId, true);
+        setIsLoadingResource(false);
+        return true;
       } catch (err) {
         setResourceError(err instanceof Error ? err.message : t('resource.loadFailed'));
         setIsResourceLoaded(false);
@@ -95,11 +137,11 @@ export function useResourceLoading({
       setInstanceResourceLoaded,
       registerResIdName,
       registerResBatch,
+      addLog,
       t,
     ],
   );
 
-  // 切换资源：销毁旧资源后加载新资源
   const switchResource = useCallback(
     async (newResource: ResourceItem) => {
       setIsLoadingResource(true);
@@ -120,7 +162,6 @@ export function useResourceLoading({
     [instanceId, loadResourceInternal, setInstanceResourceLoaded, t],
   );
 
-  // 处理资源选择
   const handleResourceSelect = useCallback(
     async (resource: ResourceItem, isRunning: boolean) => {
       setShowResourceDropdown(false);
@@ -143,7 +184,6 @@ export function useResourceLoading({
     [isResourceLoaded, loadResourceInternal, switchResource, t],
   );
 
-  // 获取资源显示名称
   const getResourceDisplayName = useCallback(
     (resource: ResourceItem) => {
       return resolveI18nText(resource.label, translations) || resource.name;

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -389,6 +389,8 @@ export default {
     loadResource: 'Load Resource',
     switchFailed: 'Failed to switch resource',
     cannotSwitchWhileRunning: 'Cannot switch resource while tasks are running',
+    hashMismatch:
+      'Resource integrity check failed (expected: {{expected}}, actual: {{actual}}). Consider re-downloading the resource package.',
     incompatibleController: 'Not supported by current controller',
   },
 

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -385,6 +385,8 @@ export default {
     loadResource: 'リソースを読み込む',
     switchFailed: 'リソースの切り替えに失敗しました',
     cannotSwitchWhileRunning: 'タスク実行中はリソースを切り替えられません',
+    hashMismatch:
+      'リソースの整合性チェックに失敗しました（期待値: {{expected}}、実際値: {{actual}}）。リソースパックの再ダウンロードをお勧めします。',
     incompatibleController: '現在のコントローラーに対応していません',
   },
 

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -382,6 +382,8 @@ export default {
     loadResource: '리소스 로드',
     switchFailed: '리소스 전환에 실패했습니다',
     cannotSwitchWhileRunning: '작업 실행 중에는 리소스를 전환할 수 없습니다',
+    hashMismatch:
+      '리소스 무결성 검증 실패 (예상: {{expected}}, 실제: {{actual}}). 리소스 팩을 다시 다운로드하는 것을 권장합니다.',
     incompatibleController: '현재 컨트롤러에서 지원되지 않음',
   },
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -380,6 +380,8 @@ export default {
     loadResource: '加载资源',
     switchFailed: '切换资源失败',
     cannotSwitchWhileRunning: '任务运行中无法切换资源',
+    hashMismatch:
+      '资源完整性校验失败（期望: {{expected}}，实际: {{actual}}），建议重新下载资源包',
     incompatibleController: '不支持当前控制器',
   },
 

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -376,6 +376,8 @@ export default {
     loadResource: '載入資源',
     switchFailed: '切換資源失敗',
     cannotSwitchWhileRunning: '任務執行中無法切換資源',
+    hashMismatch:
+      '資源完整性校驗失敗（預期: {{expected}}，實際: {{actual}}），建議重新下載資源包',
     incompatibleController: '不支援目前控制器',
   },
 

--- a/src/services/maaService.ts
+++ b/src/services/maaService.ts
@@ -347,6 +347,19 @@ export const maaService = {
   },
 
   /**
+   * 获取已加载资源的 hash（用于完整性校验）
+   * @param instanceId 实例 ID
+   * @returns hash 字符串；资源未加载或后端获取失败时返回 null
+   */
+  async getResourceHash(instanceId: string): Promise<string | null> {
+    if (!isTauri()) return null;
+    log.debug('获取资源 hash, 实例:', instanceId);
+    const hash = await invoke<string | null>('maa_get_resource_hash', { instanceId });
+    log.debug('资源 hash:', instanceId, '->', hash);
+    return hash;
+  },
+
+  /**
    * 销毁资源（用于切换资源时重新创建）
    * @param instanceId 实例 ID
    */

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -112,6 +112,8 @@ export interface ResourceItem {
   path: string[];
   controller?: string[];
   option?: string[];
+  /** v2.6.0: resource integrity hash from MaaResourceGetHash */
+  hash?: string;
 }
 
 export interface TaskItem {

--- a/src/utils/resourcePath.ts
+++ b/src/utils/resourcePath.ts
@@ -8,7 +8,25 @@ function cleanRelativePath(path: string): string {
 }
 
 /**
- * 计算完整的资源路径列表
+ * 计算 resource.path 的绝对路径列表（不包含 attach_resource_path）
+ */
+export function computeBaseResourcePaths(resource: ResourceItem, basePath: string): string[] {
+  return resource.path.map((p) => `${basePath}/${cleanRelativePath(p)}`);
+}
+
+/**
+ * 计算 controller.attach_resource_path 的绝对路径列表
+ */
+export function computeAttachResourcePaths(
+  controller: ControllerItem | undefined,
+  basePath: string,
+): string[] {
+  if (!controller?.attach_resource_path) return [];
+  return controller.attach_resource_path.map((p) => `${basePath}/${cleanRelativePath(p)}`);
+}
+
+/**
+ * 计算完整的资源路径列表（base + attach）
  *
  * 根据 PI V2.2.0 协议，资源路径应该包括：
  * 1. resource.path - 资源的基础路径
@@ -24,21 +42,8 @@ export function computeResourcePaths(
   controller: ControllerItem | undefined,
   basePath: string,
 ): string[] {
-  const paths: string[] = [];
-
-  // 1. 添加 resource.path
-  for (const p of resource.path) {
-    const cleanPath = cleanRelativePath(p);
-    paths.push(`${basePath}/${cleanPath}`);
-  }
-
-  // 2. 添加 controller.attach_resource_path（如果存在）
-  if (controller?.attach_resource_path) {
-    for (const p of controller.attach_resource_path) {
-      const cleanPath = cleanRelativePath(p);
-      paths.push(`${basePath}/${cleanPath}`);
-    }
-  }
-
-  return paths;
+  return [
+    ...computeBaseResourcePaths(resource, basePath),
+    ...computeAttachResourcePaths(controller, basePath),
+  ];
 }


### PR DESCRIPTION
## Summary
- Add \maa_get_resource_hash\ Tauri command (Rust)
- Add \hash?\ field to \ResourceItem\ type and \getResourceHash\ to maaService
- Split resource loading into two phases: \esource.path\ first, then \controller.attach_resource_path\
- After loading base resources, verify hash against \esource.hash\ from interface.json
- Hash mismatch produces a warning log (does not block usage)
- Debug/pre-release versions skip the check (\isDebugVersion\ + \import.meta.env.DEV\)
- i18n strings added for all 5 locales

Depends on: https://github.com/MaaXYZ/MaaFramework/pull/1284

## Test plan
- [ ] Resource loads successfully when \hash\ field is absent
- [ ] Resource loads successfully when \hash\ matches
- [ ] Warning logged when \hash\ does not match (non-debug build)
- [ ] No warning in dev mode or debug version
- [ ] \ttach_resource_path\ still loaded after hash check

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

在资源加载流程中加入资源完整性哈希校验，并通过新的 Tauri 命令和前端服务对外暴露。

新功能：
- 引入一个 Maa Tauri 命令和前端服务方法，用于获取当前已加载资源的哈希值。
- 在项目接口中为资源增加可选的完整性哈希字段，以支持运行时验证。

增强内容：
- 将资源加载拆分为基础资源路径和控制器附加路径两部分，在基础资源加载完成后、附加路径加载之前执行完整性检查。
- 当检测到资源哈希不匹配时，记录本地化警告日志，但不阻塞资源使用；在开发/调试构建中跳过此检查。
- 重构资源路径工具，以分别计算基础资源路径和附加资源路径，同时保留组合路径的辅助方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add resource integrity hash checking to the resource loading flow and expose it via a new Tauri command and frontend service.

New Features:
- Introduce a Maa Tauri command and frontend service method to retrieve the hash of the currently loaded resource.
- Support an optional integrity hash field on resources from the project interface for runtime verification.

Enhancements:
- Split resource loading into base resource paths and controller attach paths, performing integrity checks after the base resources are loaded but before attach paths are loaded.
- Log a localized warning when a resource hash mismatch is detected without blocking resource usage, skipping the check for dev/debug builds.
- Refactor resource path utilities to separately compute base resource and attach-resource paths while preserving the combined-path helper.

</details>