### PR TITLE
fix: checkbox 选项不渲染 icon

### DIFF
--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -527,7 +527,7 @@ export function OptionEditor({
                 }}
                 disabled={effectiveDisabled}
                 className={clsx(
-                  'px-2 py-1.5 text-xs rounded border transition-colors truncate',
+                  'px-2 py-1.5 text-xs rounded border transition-colors min-w-0',
                   isChecked
                     ? 'bg-accent text-white border-accent'
                     : 'bg-bg-primary text-text-secondary border-border hover:border-accent hover:text-accent',
@@ -535,7 +535,16 @@ export function OptionEditor({
                 )}
                 title={caseLabel}
               >
-                {caseLabel}
+                <span className="flex items-center gap-1.5 min-w-0">
+                  {caseItem.icon && (
+                    <AsyncIcon
+                      icon={caseItem.icon}
+                      basePath={basePath}
+                      className="w-4 h-4 object-contain flex-shrink-0"
+                    />
+                  )}
+                  <span className="truncate">{caseLabel}</span>
+                </span>
               </button>
             );
           })}


### PR DESCRIPTION
## Summary by Sourcery

在复选框选项按钮的标签旁渲染图标，同时保留截断和布局约束。

新功能：
- 当某个选项提供了图标时，在复选框选项标签旁显示可选图标。

增强改进：
- 调整选项按钮布局，以支持图标和文本在一起显示，并具备正确的截断行为和最小宽度处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Render icons alongside labels for checkbox option buttons while preserving truncation and layout constraints.

New Features:
- Display optional icons next to checkbox option labels when an icon is provided for the case item.

Enhancements:
- Adjust option button layout to support icon and text with proper truncation and minimum width handling.

</details>