### PR TITLE
fix(tauri): 条件化导入 Any，消除 release 的 unused import 警告

### DIFF
--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -18,7 +18,9 @@ use axum::{
 };
 #[cfg(not(debug_assertions))]
 use rust_embed::RustEmbed;
-use tower_http::cors::{Any, CorsLayer};
+#[cfg(debug_assertions)]
+use tower_http::cors::Any;
+use tower_http::cors::CorsLayer;
 
 use crate::commands::{
     app_config::AppConfigState,


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 移除 Tauri Web 服务器在发布版本中的不必要 `Any` 导入，以避免未使用导入的警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove unnecessary Any import in Tauri web server for release builds to prevent unused import warnings.

</details>