### PR TITLE
feat(wlroots): support win32 vk keycode mode

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2460,8 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "maa-framework"
-version = "1.15.0"
-source = "git+https://github.com/MaaXYZ/maa-framework-rs.git?branch=main#bf5952c74025910b3b48b547a08b5c5c55d4080d"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19730799faa08dd0dcd7468ed9757f51bcb4f852233279dd374b8ee5a9236bc8"
 dependencies = [
  "bitflags 2.10.0",
  "maa-framework-sys",
@@ -2473,7 +2474,8 @@ dependencies = [
 [[package]]
 name = "maa-framework-sys"
 version = "5.10.2"
-source = "git+https://github.com/MaaXYZ/maa-framework-rs.git?branch=main#bf5952c74025910b3b48b547a08b5c5c55d4080d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557158daf1123352220cbba03259be36017ec0796c1a3cd54a5da9f577c9e70e"
 dependencies = [
  "libloading 0.8.9",
  "once_cell",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2460,9 +2460,8 @@ dependencies = [
 
 [[package]]
 name = "maa-framework"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b770ec175bda1b2c40652cfa990142f438f419d105b2f6b071ee56a205f7cf70"
+version = "1.15.0"
+source = "git+https://github.com/MaaXYZ/maa-framework-rs.git?branch=main#bf5952c74025910b3b48b547a08b5c5c55d4080d"
 dependencies = [
  "bitflags 2.10.0",
  "maa-framework-sys",
@@ -2473,9 +2472,8 @@ dependencies = [
 
 [[package]]
 name = "maa-framework-sys"
-version = "5.9.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cad67fc16ccb938b23b313de7b8e40318117546403d8e59cb396fb0ba5d736d"
+version = "5.10.2"
+source = "git+https://github.com/MaaXYZ/maa-framework-rs.git?branch=main#bf5952c74025910b3b48b547a08b5c5c55d4080d"
 dependencies = [
  "libloading 0.8.9",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,10 +48,7 @@ os_info = "3"
 urlencoding = "2.1"
 notify-rust = "4"
 shell-words = "1.1.1"
-# 暂用 GitHub：crates.io 同步后可改回 `maa-framework = { version = "…", features = ["dynamic"] }` 并 `cargo update -p maa-framework`
-maa-framework = { git = "https://github.com/MaaXYZ/maa-framework-rs.git", branch = "main", features = [
-    "dynamic",
-] }
+maa-framework = { version = "1", features = ["dynamic"] }
 rust-embed = "8"
 
 [profile.release]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,7 +48,10 @@ os_info = "3"
 urlencoding = "2.1"
 notify-rust = "4"
 shell-words = "1.1.1"
-maa-framework = { version = "1", features = ["dynamic"] }
+# 暂用 GitHub：crates.io 同步后可改回 `maa-framework = { version = "…", features = ["dynamic"] }` 并 `cargo update -p maa-framework`
+maa-framework = { git = "https://github.com/MaaXYZ/maa-framework-rs.git", branch = "main", features = [
+    "dynamic",
+] }
 rust-embed = "8"
 
 [profile.release]

--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -559,7 +559,15 @@ pub async fn connect_controller_impl(
                 )
                 .map_err(|e| e.to_string())?
             }
-            ControllerConfig::WlRoots { wlr_socket_path } => {
+            ControllerConfig::WlRoots {
+                wlr_socket_path,
+                use_win32_vk_code,
+            } => {
+                if *use_win32_vk_code {
+                    warn!(
+                        "use_win32_vk_code is set, but current maa-framework crate does not expose this parameter yet; falling back to default wlroots keycode behavior"
+                    );
+                }
                 Controller::new_wlroots(wlr_socket_path).map_err(|e| e.to_string())?
             }
             ControllerConfig::PlayCover { address, uuid } => {

--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -562,14 +562,8 @@ pub async fn connect_controller_impl(
             ControllerConfig::WlRoots {
                 wlr_socket_path,
                 use_win32_vk_code,
-            } => {
-                if *use_win32_vk_code {
-                    warn!(
-                        "use_win32_vk_code is set, but current maa-framework crate does not expose this parameter yet; falling back to default wlroots keycode behavior"
-                    );
-                }
-                Controller::new_wlroots(wlr_socket_path).map_err(|e| e.to_string())?
-            }
+            } => Controller::new_wlroots_with_vk_code(wlr_socket_path, *use_win32_vk_code)
+                .map_err(|e| e.to_string())?,
             ControllerConfig::PlayCover { address, uuid } => {
                 let uuid_str = uuid.as_deref().unwrap_or("");
                 Controller::new_playcover(address, uuid_str).map_err(|e| e.to_string())?

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -79,6 +79,8 @@ pub enum ControllerConfig {
     },
     WlRoots {
         wlr_socket_path: String,
+        #[serde(default)]
+        use_win32_vk_code: bool,
     },
     Gamepad {
         handle: u64,

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -579,7 +579,7 @@ export function ConnectionPanel() {
         config = {
           type: 'WlRoots',
           wlr_socket_path: selectedWlrootsSocket,
-          use_win32_vk_code: currentController.wlroots?.use_win32_vk_code ?? false,
+          use_win32_vk_code: currentController?.wlroots?.use_win32_vk_code ?? false,
         };
         deviceName = selectedWlrootsSocket;
         targetType = 'device';

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -579,6 +579,7 @@ export function ConnectionPanel() {
         config = {
           type: 'WlRoots',
           wlr_socket_path: selectedWlrootsSocket,
+          use_win32_vk_code: currentController.wlroots?.use_win32_vk_code ?? false,
         };
         deviceName = selectedWlrootsSocket;
         targetType = 'device';
@@ -946,6 +947,7 @@ export function ConnectionPanel() {
       const config: ControllerConfig = {
         type: 'WlRoots',
         wlr_socket_path: socketPath,
+        use_win32_vk_code: currentController?.wlroots?.use_win32_vk_code ?? false,
       };
 
       await connectControllerInternal(config, socketPath, 'device');

--- a/src/components/DeviceSelector.tsx
+++ b/src/components/DeviceSelector.tsx
@@ -248,6 +248,7 @@ export function DeviceSelector({
         config = {
           type: 'WlRoots',
           wlr_socket_path: selectedWlrootsSocket,
+          use_win32_vk_code: controllerDef.wlroots?.use_win32_vk_code ?? false,
         };
       } else if (controllerType === 'PlayCover') {
         config = {
@@ -432,6 +433,7 @@ export function DeviceSelector({
       const config: ControllerConfig = {
         type: 'WlRoots',
         wlr_socket_path: socketPath,
+        use_win32_vk_code: controllerDef.wlroots?.use_win32_vk_code ?? false,
       };
 
       const ctrlId = await maaService.connectController(instanceId, config);

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -648,6 +648,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
               config = {
                 type: 'WlRoots',
                 wlr_socket_path: savedDevice.wlrSocketPath,
+                use_win32_vk_code: controller.wlroots?.use_win32_vk_code ?? false,
               };
               deviceName = savedDevice.wlrSocketPath;
               targetType = 'device';
@@ -752,6 +753,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
               config = {
                 type: 'WlRoots',
                 wlr_socket_path: firstSocket,
+                use_win32_vk_code: controller.wlroots?.use_win32_vk_code ?? false,
               };
               deviceName = firstSocket;
               targetType = 'device';

--- a/src/components/connection/useDeviceConnection.ts
+++ b/src/components/connection/useDeviceConnection.ts
@@ -322,6 +322,7 @@ export function useDeviceConnection({
         const config: ControllerConfig = {
           type: 'WlRoots',
           wlr_socket_path: socketPath,
+          use_win32_vk_code: currentController?.wlroots?.use_win32_vk_code ?? false,
         };
 
         await connectControllerInternal(config, socketPath, 'device');

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -91,6 +91,7 @@ export interface Win32Config {
 
 export interface WlRootsConfig {
   wlr_socket_path?: string;
+  use_win32_vk_code?: boolean;
 }
 
 export interface PlayCoverConfig {

--- a/src/types/maa.ts
+++ b/src/types/maa.ts
@@ -40,6 +40,7 @@ export interface Win32ControllerConfig {
 export interface WlRootsControllerConfig {
   type: 'WlRoots';
   wlr_socket_path: string;
+  use_win32_vk_code?: boolean;
 }
 
 /** PlayCover 控制器配置 (macOS) */


### PR DESCRIPTION
[#1283](https://github.com/MaaXYZ/MaaFramework/pull/1283)

## 由 Sourcery 提供的摘要

在后端和前端中，为使用 WlRoots 控制器的 Win32 虚拟键码模式新增可配置支持。

新特性：
- 允许在 WlRoots 控制器配置中指定是否使用 Win32 虚拟键码模式；当未指定时，默认禁用。

增强：
- 将 WlRoots 的 Win32 虚拟键码选项在 Tauri 控制器连接处理流程以及所有相关的 React 连接流程和工具栏操作中进行传递，使现有的选择和已保存设备能够保留这一设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable support for using Win32 virtual keycode mode with WlRoots controllers across the backend and frontend.

New Features:
- Allow WlRoots controller configs to specify whether to use Win32 virtual keycode mode, defaulting to disabled when unspecified.

Enhancements:
- Propagate the WlRoots Win32 virtual keycode option through Tauri controller connection handling and all relevant React connection flows and toolbar actions so existing selections and saved devices preserve this setting.

</details>