### PR TITLE
fix: 修复运行日志意外换行并移动日志清理设置

### DIFF
--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Trash2, Copy, ChevronUp, ChevronDown, Archive, RotateCcw } from 'lucide-react';
+import { Eraser, Copy, ChevronUp, ChevronDown, Archive, RotateCcw } from 'lucide-react';
 import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api/core';
 import { useAppStore, type LogType } from '@/stores/appStore';
@@ -116,7 +116,7 @@ export function LogsPanel() {
         {
           id: 'clear',
           label: t('logs.clear'),
-          icon: Trash2,
+          icon: Eraser,
           disabled: logs.length === 0,
           danger: true,
           onClick: handleClear,
@@ -206,7 +206,7 @@ export function LogsPanel() {
             )}
             title={t('logs.clear')}
           >
-            <Trash2 className="w-3.5 h-3.5" />
+            <Eraser className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={(e) => {

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Eraser, Copy, ChevronUp, ChevronDown, Archive, RotateCcw } from 'lucide-react';
+import { Eraser, Copy, ChevronUp, ChevronDown, Archive } from 'lucide-react';
 import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api/core';
 import { useAppStore, type LogType } from '@/stores/appStore';
@@ -31,9 +31,7 @@ export function LogsPanel() {
     toggleSidePanelExpanded,
     activeInstanceId,
     instanceLogs,
-    autoClearLogsOnLaunch,
     clearLogs,
-    setAutoClearLogsOnLaunch,
   } = useAppStore();
   const { state: menuState, show: showMenu, hide: hideMenu } = useContextMenu();
   const { exportModal, handleExportLogs, closeExportModal, openExportedFile } = useExportLogs();
@@ -207,21 +205,6 @@ export function LogsPanel() {
             title={t('logs.clear')}
           >
             <Eraser className="w-3.5 h-3.5" />
-          </button>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setAutoClearLogsOnLaunch(!autoClearLogsOnLaunch);
-            }}
-            className={clsx(
-              'p-1 rounded-md transition-colors',
-              autoClearLogsOnLaunch
-                ? 'text-accent bg-accent-light'
-                : 'text-text-muted hover:bg-bg-tertiary hover:text-text-secondary',
-            )}
-            title={t('logs.autoClearOnLaunch')}
-          >
-            <RotateCcw className="w-3.5 h-3.5" />
           </button>
           {!isMobile && (
             <span

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -268,7 +268,7 @@ export function LogsPanel() {
                     {formatLogTime(log.timestamp, i18n.language)}
                   </span>
                   <span
-                    className="min-w-0 flex-1 break-words whitespace-pre-wrap leading-5 focus-content"
+                    className="min-w-0 flex-1 break-words leading-5 focus-content"
                     dangerouslySetInnerHTML={{ __html: log.html }}
                   />
                 </div>

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -146,111 +146,108 @@ export function GeneralSection() {
         {t('settings.general')}
       </h2>
 
-      {/* ① 开机自启动 */}
-      {isTauri() && (
-        <div className="bg-bg-secondary rounded-xl p-4 border border-border">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Power className="w-5 h-5 text-accent" />
+      {/* 自动化启动设置组 */}
+      <DesktopOnlyWrapper>
+        <div className="bg-bg-secondary rounded-xl p-4 border border-border space-y-4">
+          {/* ① 开机自启动 */}
+          {isTauri() && (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Power className="w-5 h-5 text-accent" />
+                <div>
+                  <span className="font-medium text-text-primary">{t('settings.autoStart')}</span>
+                  <p className="text-xs text-text-muted mt-0.5">{t('settings.autoStartHint')}</p>
+                </div>
+              </div>
+              <SwitchButton
+                value={autoStartEnabled}
+                onChange={handleAutoStartToggle}
+                disabled={autoStartLoading}
+              />
+            </div>
+          )}
+
+          {/* ② 启动后自动执行 */}
+          <div className={isTauri() ? "pt-4 border-t border-border" : ""}>
+            <div className="flex items-center gap-3 mb-3">
+              <Play className="w-5 h-5 text-accent" />
               <div>
-                <span className="font-medium text-text-primary">{t('settings.autoStart')}</span>
-                <p className="text-xs text-text-muted mt-0.5">{t('settings.autoStartHint')}</p>
+                <span className="font-medium text-text-primary">
+                  {t('settings.autoStartInstance')}
+                </span>
+                <p className="text-xs text-text-muted mt-0.5">
+                  {t('settings.autoStartInstanceHint')}
+                </p>
               </div>
             </div>
-            <SwitchButton
-              value={autoStartEnabled}
-              onChange={handleAutoStartToggle}
-              disabled={autoStartLoading}
-            />
-          </div>
-        </div>
-      )}
 
-      {/* ② 启动后自动执行（独立卡片 + 自定义下拉框） */}
-      <DesktopOnlyWrapper>
-        <div className="bg-bg-secondary rounded-xl p-4 border border-border">
-          <div className="flex items-center gap-3 mb-3">
-            <Play className="w-5 h-5 text-accent" />
-            <div>
-              <span className="font-medium text-text-primary">
-                {t('settings.autoStartInstance')}
-              </span>
-              <p className="text-xs text-text-muted mt-0.5">
-                {t('settings.autoStartInstanceHint')}
-              </p>
-            </div>
-          </div>
-
-          {/* 自定义下拉框 */}
-          <div className="relative" ref={dropdownRef}>
-            <button
-              type="button"
-              onClick={() => setInstanceDropdownOpen((prev) => !prev)}
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') setInstanceDropdownOpen(false);
-              }}
-              className="w-full px-3 py-2.5 text-sm rounded-lg border flex items-center justify-between gap-2 bg-bg-tertiary border-border text-text-primary hover:bg-bg-hover transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50"
-              aria-haspopup="listbox"
-              aria-expanded={instanceDropdownOpen}
-            >
-              <span className="truncate">
-                {selectedOption?.name ?? t('settings.autoStartInstanceNone')}
-              </span>
-              <ChevronDown
-                className={`w-4 h-4 text-text-muted shrink-0 transition-transform ${instanceDropdownOpen ? 'rotate-180' : ''}`}
-              />
-            </button>
-
-            {instanceDropdownOpen && (
-              <div
-                className="absolute right-0 z-20 mt-1 w-full min-w-[160px] max-h-60 overflow-y-auto rounded-lg border border-border bg-bg-primary shadow-lg"
-                role="listbox"
+            {/* 自定义下拉框 */}
+            <div className="relative" ref={dropdownRef}>
+              <button
+                type="button"
+                onClick={() => setInstanceDropdownOpen((prev) => !prev)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') setInstanceDropdownOpen(false);
+                }}
+                className="w-full px-3 py-2.5 text-sm rounded-lg border flex items-center justify-between gap-2 bg-bg-tertiary border-border text-text-primary hover:bg-bg-hover transition-colors focus:outline-none focus:ring-2 focus:ring-accent/50"
+                aria-haspopup="listbox"
+                aria-expanded={instanceDropdownOpen}
               >
-                {dropdownOptions.map((opt) => {
-                  const isSelected = opt.id === (autoStartInstanceId ?? '');
-                  return (
-                    <button
-                      key={opt.id}
-                      type="button"
-                      role="option"
-                      aria-selected={isSelected}
-                      className={`w-full px-3 py-2 text-sm text-left flex items-center gap-2 transition-colors ${
-                        isSelected
-                          ? 'bg-accent/10 text-accent font-medium'
-                          : 'text-text-primary hover:bg-bg-hover'
-                      }`}
-                      onClick={() => {
-                        setAutoStartInstanceId(opt.id || undefined);
-                        setInstanceDropdownOpen(false);
-                      }}
-                    >
-                      <Check
-                        className={`w-4 h-4 shrink-0 ${isSelected ? 'opacity-100' : 'opacity-0'}`}
-                      />
-                      <span className="truncate">{opt.name}</span>
-                    </button>
-                  );
-                })}
+                <span className="truncate">
+                  {selectedOption?.name ?? t('settings.autoStartInstanceNone')}
+                </span>
+                <ChevronDown
+                  className={`w-4 h-4 text-text-muted shrink-0 transition-transform ${instanceDropdownOpen ? 'rotate-180' : ''}`}
+                />
+              </button>
+
+              {instanceDropdownOpen && (
+                <div
+                  className="absolute right-0 z-20 mt-1 w-full min-w-[160px] max-h-60 overflow-y-auto rounded-lg border border-border bg-bg-primary shadow-lg"
+                  role="listbox"
+                >
+                  {dropdownOptions.map((opt) => {
+                    const isSelected = opt.id === (autoStartInstanceId ?? '');
+                    return (
+                      <button
+                        key={opt.id}
+                        type="button"
+                        role="option"
+                        aria-selected={isSelected}
+                        className={`w-full px-3 py-2 text-sm text-left flex items-center gap-2 transition-colors ${
+                          isSelected
+                            ? 'bg-accent/10 text-accent font-medium'
+                            : 'text-text-primary hover:bg-bg-hover'
+                        }`}
+                        onClick={() => {
+                          setAutoStartInstanceId(opt.id || undefined);
+                          setInstanceDropdownOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={`w-4 h-4 shrink-0 ${isSelected ? 'opacity-100' : 'opacity-0'}`}
+                        />
+                        <span className="truncate">{opt.name}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* 被删除的自动执行配置提示 */}
+            {autoStartRemovedInstanceName && (
+              <div className="flex items-center gap-2 mt-2 px-2.5 py-1.5 rounded-md bg-error/10 text-error text-xs">
+                <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
+                <span>
+                  {t('settings.autoStartInstanceRemoved', { name: autoStartRemovedInstanceName })}
+                </span>
               </div>
             )}
           </div>
 
-          {/* 被删除的自动执行配置提示 */}
-          {autoStartRemovedInstanceName && (
-            <div className="flex items-center gap-2 mt-2 px-2.5 py-1.5 rounded-md bg-error/10 text-error text-xs">
-              <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
-              <span>
-                {t('settings.autoStartInstanceRemoved', { name: autoStartRemovedInstanceName })}
-              </span>
-            </div>
-          )}
-        </div>
-      </DesktopOnlyWrapper>
-
-      {/* ③ 手动启动时也自动执行 */}
-      <DesktopOnlyWrapper>
-        <div className="bg-bg-secondary rounded-xl p-4 border border-border">
-          <div className="flex items-center justify-between">
+          {/* ③ 手动启动时也自动执行 */}
+          <div className="flex items-center justify-between pt-4 border-t border-border">
             <div className="flex items-center gap-3">
               <Rocket className="w-5 h-5 text-accent" />
               <div>

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -11,6 +11,7 @@ import {
   Rocket,
   ChevronDown,
   Check,
+  BrushCleaning,
 } from 'lucide-react';
 
 import { useAppStore } from '@/stores/appStore';
@@ -38,6 +39,8 @@ export function GeneralSection() {
     autoRunOnLaunch,
     setAutoRunOnLaunch,
     autoStartRemovedInstanceName,
+    autoClearLogsOnLaunch,
+    setAutoClearLogsOnLaunch,
   } = useAppStore();
 
   // 开机自启动状态（直接从 Tauri 插件查询，不走 store）
@@ -306,6 +309,24 @@ export function GeneralSection() {
 
       {/* ⑥ 帧率选择器 */}
       <FrameRateSelector />
+
+      {/* 自动清理运行日志 */}
+      <div className="bg-bg-secondary rounded-xl p-4 border border-border">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <BrushCleaning className="w-5 h-5 text-accent" />
+            <div>
+              <span className="font-medium text-text-primary">
+                {t('settings.autoClearLogsOnLaunch')}
+              </span>
+              <p className="text-xs text-text-muted mt-0.5">
+                {t('settings.autoClearLogsOnLaunchHint')}
+              </p>
+            </div>
+          </div>
+          <SwitchButton value={autoClearLogsOnLaunch} onChange={(v) => setAutoClearLogsOnLaunch(v)} />
+        </div>
+      </div>
 
       {/* ⑦ 删除确认 */}
       <div className="bg-bg-secondary rounded-xl p-4 border border-border">

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -114,6 +114,8 @@ export default {
       'Oldest logs will be discarded when exceeding the limit (recommended 500–2000)',
     resetWindowLayout: 'Reset Window Layout',
     resetWindowLayoutHint: 'Restore window size to default and center the window',
+    autoClearLogsOnLaunch: 'Auto-clear Runtime Logs',
+    autoClearLogsOnLaunchHint: 'Automatically clear runtime logs and delete old log files every time the project is launched',
   },
 
   // Special tasks

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -111,8 +111,8 @@ export default {
     maxLogsPerInstance: 'インスタンスあたりのログ上限',
     maxLogsPerInstanceHint: '上限を超えると古いログから自動的に破棄します（推奨 500～2000）',
     resetWindowLayout: 'ウィンドウレイアウトをリセット',
-    resetWindowLayoutHint: 'ウィンドウサイズをデフォルトに戻し、中央に配置します',
-  },
+    resetWindowLayoutHint: 'ウィンドウサイズをデフォルトに戻し、中央に配置します',    autoClearLogsOnLaunch: '実行ログの自動クリア',
+    autoClearLogsOnLaunchHint: 'プロジェクトの起動時に自動で実行ログをクリアし、古いログファイルを削除します',  },
 
   // 特殊タスク
   specialTask: {

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -111,6 +111,8 @@ export default {
     maxLogsPerInstanceHint: '한도를 초과하면 가장 오래된 로그가 자동으로 삭제됩니다(권장 500~2000)',
     resetWindowLayout: '창 레이아웃 초기화',
     resetWindowLayoutHint: '창 크기를 기본값으로 복원하고 화면 중앙에 배치합니다',
+    autoClearLogsOnLaunch: '로그 자동 지우기',
+    autoClearLogsOnLaunchHint: '프로젝트를 시작할 때 런타임 로그를 자동으로 지우고 이전 로그 파일을 삭제합니다',
   },
 
   // 특수 작업

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -111,6 +111,8 @@ export default {
     maxLogsPerInstanceHint: '超过上限会自动丢弃最旧的日志（建议 500～2000）',
     resetWindowLayout: '重置窗口布局',
     resetWindowLayoutHint: '将窗口大小恢复为默认值，并居中显示',
+    autoClearLogsOnLaunch: '自动清理运行日志',
+    autoClearLogsOnLaunchHint: '每次启动项目时，自动清理运行日志并删除旧的日志文件',
   },
 
   // 特殊任务

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -109,8 +109,8 @@ export default {
     maxLogsPerInstance: '每個實例保留的日誌上限',
     maxLogsPerInstanceHint: '超出上限會自動丟棄最舊的日誌（建議 500～2000）',
     resetWindowLayout: '重設視窗佈局',
-    resetWindowLayoutHint: '將視窗大小恢復為預設值，並置中顯示',
-  },
+    resetWindowLayoutHint: '將視窗大小恢復為預設值，並置中顯示',    autoClearLogsOnLaunch: '自動清理運行日誌',
+    autoClearLogsOnLaunchHint: '每次啟動項目時，自動清理運行日誌並刪除舊的日誌檔案',  },
 
   // 特殊任務
   specialTask: {


### PR DESCRIPTION
## 概要

~~搞半天我要自己修.jpg~~

此 PR 主要针对运行日志进行了修复和优化，解决意外换行问题、更换按钮图标、移动日志自动清理设置项的位置、合并设置项区域。

## 关联

此 PR 解决了 #193 。

Fix #193

## 由 Sourcery 提供的摘要

优化桌面端启动和日志设置布局，同时改进清除日志的行为和视觉效果。

新功能：
- 添加一个通用设置中的独立开关，用于在项目启动时自动清除运行时日志，并在所有支持的语言中完成本地化。

缺陷修复：
- 通过移除对日志内容中空白字符的保留，防止运行时日志中出现非预期的换行。

增强改进：
- 将桌面端自动启动相关选项分组到同一个设置卡片中，以提供更一致的布局。
- 将“启动时自动清除日志”的控制项从日志面板移至通用设置部分，并以开关形式呈现。
- 将运行时日志清除操作图标替换为橡皮擦，以更准确体现其含义并与 UI 约定保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine desktop startup and logging settings layout while improving log clearing behavior and visuals.

New Features:
- Add a dedicated general-setting switch to automatically clear runtime logs on project launch, with full localization across supported languages.

Bug Fixes:
- Prevent unintended line breaks in runtime logs by removing preservation of whitespace in rendered log content.

Enhancements:
- Group desktop auto-start related options into a single settings card for a more consistent layout.
- Move the auto-clear logs on launch control from the logs panel into the general settings section and present it as a switch.
- Replace the runtime log clear action icon with an eraser to better reflect its meaning and align with UI conventions.

</details>

新功能：
- 为“项目启动时自动清除运行时日志”新增独立的常规设置开关，并在所有支持的语言中完成本地化。

错误修复：
- 通过移除不必要的保留空白格式，防止运行时日志出现非预期的换行。

增强改进：
- 将桌面自动启动相关选项重新分组到同一个设置卡片中，以获得更一致、连贯的布局。
- 将清除日志的图标由垃圾桶更改为橡皮擦，以获得更清晰的含义表达和更一致的界面体验。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

优化桌面端启动和日志设置布局，同时改进清除日志的行为和视觉效果。

新功能：
- 添加一个通用设置中的独立开关，用于在项目启动时自动清除运行时日志，并在所有支持的语言中完成本地化。

缺陷修复：
- 通过移除对日志内容中空白字符的保留，防止运行时日志中出现非预期的换行。

增强改进：
- 将桌面端自动启动相关选项分组到同一个设置卡片中，以提供更一致的布局。
- 将“启动时自动清除日志”的控制项从日志面板移至通用设置部分，并以开关形式呈现。
- 将运行时日志清除操作图标替换为橡皮擦，以更准确体现其含义并与 UI 约定保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine desktop startup and logging settings layout while improving log clearing behavior and visuals.

New Features:
- Add a dedicated general-setting switch to automatically clear runtime logs on project launch, with full localization across supported languages.

Bug Fixes:
- Prevent unintended line breaks in runtime logs by removing preservation of whitespace in rendered log content.

Enhancements:
- Group desktop auto-start related options into a single settings card for a more consistent layout.
- Move the auto-clear logs on launch control from the logs panel into the general settings section and present it as a switch.
- Replace the runtime log clear action icon with an eraser to better reflect its meaning and align with UI conventions.

</details>

</details>