### PR TITLE
feat: 添加独立选项区域

### DIFF
--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -180,7 +180,7 @@ function OptionDescription({
       {/* 内容 */}
       {resolved.html && (
         <div
-          className="text-xs text-text-secondary [&_p]:my-0.5 [&_a]:text-accent [&_a]:hover:underline"
+          className="text-[11px] text-text-secondary [&_p]:my-0.5 [&_a]:text-accent [&_a]:hover:underline"
           dangerouslySetInnerHTML={{ __html: resolved.html }}
         />
       )}

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -2,13 +2,11 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, ChevronRight, X, Loader2, FileText, Link, AlertCircle } from 'lucide-react';
+import { GripVertical, ChevronRight, X, AlertCircle } from 'lucide-react';
 import { useAppStore, type TaskRunStatus } from '@/stores/appStore';
 import { maaService } from '@/services/maaService';
-import { useResolvedContent } from '@/services/contentResolver';
 import { generateTaskPipelineOverride } from '@/utils';
-import { OptionEditor, SwitchGrid, switchHasNestedOptions } from './OptionEditor';
-import { ContextMenu, useContextMenu } from './ContextMenu';
+import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
 import { Tooltip } from './ui/Tooltip';
 import { ConfirmDialog } from './ConfirmDialog';
 import { buildListItemMenuItems, InlineNameEditor } from './listItemShared';
@@ -67,235 +65,11 @@ function OptionPreviewTag({
 interface TaskItemProps {
   instanceId: string;
   task: SelectedTask;
+  optionsOpen: boolean;
+  onToggleOptions: () => void;
 }
 
-/** 描述内容组件：显示从文件/URL/直接文本解析的内容 */
-function DescriptionContent({
-  html,
-  loading,
-  type,
-  loaded,
-  error,
-}: {
-  html: string;
-  loading: boolean;
-  type: 'url' | 'file' | 'text';
-  loaded: boolean;
-  error?: string;
-}) {
-  const { t } = useTranslation();
-
-  if (loading) {
-    return (
-      <div className="flex items-center gap-1.5 text-xs text-text-muted">
-        <Loader2 className="w-3 h-3 animate-spin" />
-        <span>{t('taskItem.loadingDescription')}</span>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-1">
-      {/* 来源提示 */}
-      {loaded && type !== 'text' && (
-        <div className="flex items-center gap-1 text-[10px] text-text-muted">
-          {type === 'file' ? <FileText className="w-3 h-3" /> : <Link className="w-3 h-3" />}
-          <span>{t(type === 'file' ? 'taskItem.loadedFromFile' : 'taskItem.loadedFromUrl')}</span>
-        </div>
-      )}
-      {/* 加载错误提示 */}
-      {error && type !== 'text' && (
-        <div className="flex items-center gap-1 text-[10px] text-warning">
-          <AlertCircle className="w-3 h-3" />
-          <span>
-            {t('taskItem.loadDescriptionFailed')}: {error}
-          </span>
-        </div>
-      )}
-      {/* 内容 */}
-      {html && (
-        <div
-          className="text-xs text-text-secondary [&_p]:my-0.5 [&_a]:text-accent [&_a]:hover:underline"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      )}
-    </div>
-  );
-}
-
-/** 选项分组项类型 */
-type OptionGroup =
-  | { type: 'single'; optionKey: string }
-  | { type: 'switchGrid'; optionKeys: string[] };
-
-/** 检查选项是否与当前控制器不兼容 */
-function isOptionControllerIncompatible(
-  optionDef: import('@/types/interface').OptionDefinition | null | undefined,
-  currentControllerName: string | undefined,
-): boolean {
-  if (!optionDef?.controller || optionDef.controller.length === 0) return false;
-  if (!currentControllerName) return false;
-  return !optionDef.controller.includes(currentControllerName);
-}
-
-/** v2.3.0: 检查选项是否与当前资源不兼容 */
-function isOptionResourceIncompatible(
-  optionDef: import('@/types/interface').OptionDefinition | null | undefined,
-  currentResourceName: string | undefined,
-): boolean {
-  if (!optionDef?.resource || optionDef.resource.length === 0) return false;
-  if (!currentResourceName) return false;
-  return !optionDef.resource.includes(currentResourceName);
-}
-
-/** 选项列表渲染器：自动将连续的无子选项 switch 分组为网格 */
-function OptionListRenderer({
-  instanceId,
-  taskId,
-  optionKeys,
-  optionValues,
-  disabled,
-  currentControllerName,
-  currentResourceName,
-}: {
-  instanceId: string;
-  taskId: string;
-  optionKeys: string[];
-  optionValues: Record<string, import('@/types/interface').OptionValue>;
-  disabled: boolean;
-  currentControllerName: string | undefined;
-  currentResourceName: string | undefined;
-}) {
-  const { projectInterface, resolveI18nText, language } = useAppStore();
-  const { t } = useTranslation();
-  const langKey = getInterfaceLangKey(language);
-
-  // 获取选项定义（支持 MXU 特殊任务）
-  const getOptionDef = (optionKey: string) => {
-    const isMxuOption = optionKey.startsWith('__MXU_');
-    return isMxuOption ? findMxuOptionByKey(optionKey) : projectInterface?.option?.[optionKey];
-  };
-
-  // 将选项分组：连续 5 个以上无子选项的 switch 合并为网格
-  const groups = useMemo(() => {
-    const result: OptionGroup[] = [];
-    let currentSwitchGroup: string[] = [];
-
-    const flushSwitchGroup = () => {
-      if (currentSwitchGroup.length > 4) {
-        // 超过 4 个，使用网格
-        result.push({ type: 'switchGrid', optionKeys: [...currentSwitchGroup] });
-      } else {
-        // 4 个及以下，单独渲染
-        for (const key of currentSwitchGroup) {
-          result.push({ type: 'single', optionKey: key });
-        }
-      }
-      currentSwitchGroup = [];
-    };
-
-    for (const optionKey of optionKeys) {
-      const optionDef = getOptionDef(optionKey);
-
-      // 判断是否为无子选项的 switch
-      const isSimpleSwitch = optionDef?.type === 'switch' && !switchHasNestedOptions(optionDef);
-
-      if (isSimpleSwitch) {
-        currentSwitchGroup.push(optionKey);
-      } else {
-        // 非 switch 或有子选项，先刷新当前 switch 组
-        flushSwitchGroup();
-        result.push({ type: 'single', optionKey });
-      }
-    }
-
-    // 处理末尾的 switch 组
-    flushSwitchGroup();
-
-    return result;
-  }, [optionKeys, projectInterface?.option]);
-
-  // 构建 SwitchGrid 的数据
-  const buildSwitchGridItems = (keys: string[]) => {
-    return keys.map((optionKey) => {
-      const optionDef = getOptionDef(optionKey);
-      const value = optionValues[optionKey];
-      const isChecked = value?.type === 'switch' ? value.value : false;
-      const isMxuOption = optionKey.startsWith('__MXU_');
-
-      // 对于 MXU 内置选项，使用 t() 翻译；否则使用 resolveI18nText
-      const label = isMxuOption
-        ? t(optionDef?.label || optionKey)
-        : resolveI18nText(optionDef?.label, langKey) || optionKey;
-      const description = isMxuOption
-        ? optionDef?.description
-          ? t(optionDef.description)
-          : undefined
-        : resolveI18nText(optionDef?.description, langKey);
-
-      const controllerIncompatible = isOptionControllerIncompatible(
-        optionDef,
-        currentControllerName,
-      );
-      const resourceIncompatible = isOptionResourceIncompatible(optionDef, currentResourceName);
-
-      return {
-        optionKey,
-        label,
-        description,
-        isChecked,
-        controllerIncompatible: controllerIncompatible || resourceIncompatible,
-      };
-    });
-  };
-
-  return (
-    <div className="space-y-4">
-      {groups.map((group, index) => {
-        if (group.type === 'switchGrid') {
-          return (
-            <SwitchGrid
-              key={`grid-${index}`}
-              instanceId={instanceId}
-              taskId={taskId}
-              items={buildSwitchGridItems(group.optionKeys)}
-              disabled={disabled}
-            />
-          );
-        }
-        const optionDef = getOptionDef(group.optionKey);
-        const optionControllerIncompatible = isOptionControllerIncompatible(
-          optionDef,
-          currentControllerName,
-        );
-        const optionResourceIncompatible = isOptionResourceIncompatible(
-          optionDef,
-          currentResourceName,
-        );
-        const optionIncompatible = optionControllerIncompatible || optionResourceIncompatible;
-        const parentIncompatibilityReason = optionControllerIncompatible
-          ? 'controller'
-          : optionResourceIncompatible
-            ? 'resource'
-            : undefined;
-        return (
-          <OptionEditor
-            key={group.optionKey}
-            instanceId={instanceId}
-            taskId={taskId}
-            optionKey={group.optionKey}
-            value={optionValues[group.optionKey]}
-            disabled={disabled || optionIncompatible}
-            controllerIncompatible={optionIncompatible}
-            parentIncompatibilityReason={parentIncompatibilityReason}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-export function TaskItem({ instanceId, task }: TaskItemProps) {
+export function TaskItem({ instanceId, task, optionsOpen, onToggleOptions }: TaskItemProps) {
   const { t } = useTranslation();
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -304,7 +78,6 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
   const {
     projectInterface,
     toggleTaskEnabled,
-    toggleTaskExpanded,
     removeTaskFromInstance,
     confirmBeforeDelete,
     renameTask,
@@ -463,13 +236,6 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
   // 获取翻译表
   const translations = interfaceTranslations[langKey];
 
-  // 使用新的 Hook 解析任务描述（支持文件/URL/直接文本）
-  const resolvedDescription = useResolvedContent(
-    taskDef?.description ? resolveI18nText(taskDef.description, langKey) : undefined,
-    basePath,
-    translations,
-  );
-
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task.id,
     disabled: !canReorder,
@@ -520,11 +286,9 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
       : resolveI18nText(taskDef.label, langKey) || taskDef.name
     : '';
   const displayName = task.customName || originalLabel;
-  const hasOptions = !!taskDef?.option && taskDef.option.length > 0;
-  // 判断是否有描述内容（包括正在加载的情况）
-  const hasDescription = !!resolvedDescription.html || resolvedDescription.loading;
-  // 有选项或有描述时都可以展开
-  const canExpand = hasOptions || hasDescription;
+  const hasOptions = taskDef.option && taskDef.option.length > 0;
+  // 只有有选项时才显示“展开”入口；描述与选项一起放到右侧面板展示
+  const canExpand = hasOptions;
 
   // 生成选项预览信息（最多显示3个）
   const optionPreviews = useMemo(() => {
@@ -664,7 +428,7 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
           delete: t('contextMenu.deleteTask'),
         },
         isEnabled: task.enabled,
-        isExpanded: !!task.expanded,
+        isExpanded: optionsOpen,
         canExpand,
         isFirst: taskIndex === 0,
         isLast: taskIndex === tasks.length - 1,
@@ -675,7 +439,7 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
           setIsEditing(true);
         },
         onToggle: () => toggleTaskEnabled(instanceId, task.id),
-        onExpand: () => toggleTaskExpanded(instanceId, task.id),
+        onExpand: () => onToggleOptions(),
         onMoveUp: () => moveTaskUp(instanceId, task.id),
         onMoveDown: () => moveTaskDown(instanceId, task.id),
         onMoveToTop: () => moveTaskToTop(instanceId, task.id),
@@ -699,7 +463,6 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
       getActiveInstance,
       duplicateTask,
       toggleTaskEnabled,
-      toggleTaskExpanded,
       moveTaskUp,
       moveTaskDown,
       moveTaskToTop,
@@ -708,6 +471,9 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
       confirmBeforeDelete,
       showMenu,
       isInstanceRunning,
+      canExpand,
+      optionsOpen,
+      onToggleOptions,
     ],
   );
 
@@ -879,12 +645,12 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
               {/* 展开/折叠点击区域（包含选项预览） */}
               {canExpand && (
                 <div
-                  onClick={() => toggleTaskExpanded(instanceId, task.id)}
+                  onClick={() => onToggleOptions()}
                   className="flex-1 min-w-0 flex items-center self-stretch min-h-[28px] cursor-pointer"
-                  title={task.expanded ? t('taskItem.collapse') : t('taskItem.expand')}
+                  title={optionsOpen ? t('taskItem.collapse') : t('taskItem.expand')}
                 >
                   {/* 选项预览标签 - 未展开时显示：不兼容时显示警告，否则显示选项预览 */}
-                  {!task.expanded && (
+                  {!optionsOpen && (
                     <div className="flex-1 flex items-center gap-1.5 mx-2 overflow-hidden">
                       {isIncompatible ? (
                         <Tooltip content={supportedControllerHint || undefined}>
@@ -912,7 +678,7 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
                     <ChevronRight
                       className={clsx(
                         'w-4 h-4 text-text-secondary transition-transform duration-150 ease-out',
-                        task.expanded && 'rotate-90',
+                        optionsOpen && 'rotate-90',
                       )}
                     />
                   </div>
@@ -942,57 +708,6 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
           </button>
         )}
       </div>
-
-      {/* 展开面板（描述和/或选项）- 使用 grid 动画实现平滑展开/折叠 */}
-      {canExpand && (
-        <div
-          className="grid transition-[grid-template-rows] duration-150 ease-out"
-          style={{ gridTemplateRows: task.expanded ? '1fr' : '0fr' }}
-        >
-          <div className={clsx('min-h-0', task.expanded ? 'overflow-visible' : 'overflow-hidden')}>
-            <div className="border-t border-border bg-bg-tertiary p-3 rounded-b-lg">
-              {/* 任务描述 */}
-              {hasDescription && (
-                <div className={hasOptions || isIncompatible ? 'mb-5' : ''}>
-                  <DescriptionContent
-                    html={resolvedDescription.html}
-                    loading={resolvedDescription.loading}
-                    type={resolvedDescription.type}
-                    loaded={resolvedDescription.loaded}
-                    error={resolvedDescription.error}
-                  />
-                </div>
-              )}
-              {/* 不兼容提示 - 独立于选项列表显示 */}
-              {isIncompatible && (
-                <Tooltip content={supportedControllerHint || undefined}>
-                  <div
-                    className={clsx(
-                      'flex items-center gap-1.5 px-2 py-1.5 rounded-md bg-warning/10 text-warning text-xs',
-                      hasOptions && 'mb-3',
-                    )}
-                  >
-                    <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
-                    <span>{incompatibleReason}</span>
-                  </div>
-                </Tooltip>
-              )}
-              {/* 选项列表 - 仅在有选项时显示 */}
-              {hasOptions && (
-                <OptionListRenderer
-                  instanceId={instanceId}
-                  taskId={task.id}
-                  optionKeys={taskDef.option || []}
-                  optionValues={task.optionValues}
-                  disabled={!canEditOptions || isIncompatible}
-                  currentControllerName={currentControllerName}
-                  currentResourceName={currentResourceName}
-                />
-              )}
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* 右键菜单 */}
       {menuState.isOpen && (

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -6,7 +6,7 @@ import { GripVertical, ChevronRight, X, AlertCircle } from 'lucide-react';
 import { useAppStore, type TaskRunStatus } from '@/stores/appStore';
 import { maaService } from '@/services/maaService';
 import { generateTaskPipelineOverride } from '@/utils';
-import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
+import { ContextMenu, useContextMenu } from './ContextMenu';
 import { Tooltip } from './ui/Tooltip';
 import { ConfirmDialog } from './ConfirmDialog';
 import { buildListItemMenuItems, InlineNameEditor } from './listItemShared';
@@ -93,7 +93,6 @@ export function TaskItem({ instanceId, task, optionsOpen, onToggleOptions }: Tas
     instanceTaskRunStatus,
     instances,
     findMaaTaskIdBySelectedTaskId,
-    basePath,
     interfaceTranslations,
     animatingTaskIds,
     removeAnimatingTaskId,
@@ -167,10 +166,6 @@ export function TaskItem({ instanceId, task, optionsOpen, onToggleOptions }: Tas
   // 紧凑模式：实例运行时，未启用的任务显示为紧凑样式
   const isCompact = isInstanceRunning && !task.enabled;
 
-  // 判断是否可以编辑选项：实例未运行时始终可以编辑，运行中只有 pending 或 idle 状态的任务可以编辑
-  const canEditOptions =
-    !isInstanceRunning || taskRunStatus === 'idle' || taskRunStatus === 'pending';
-
   // 判断是否可以调整顺序/删除（实例运行时禁用）
   const canReorder = !isInstanceRunning;
   const canDelete = !isInstanceRunning;
@@ -233,9 +228,6 @@ export function TaskItem({ instanceId, task, optionsOpen, onToggleOptions }: Tas
 
   const { state: menuState, show: showMenu, hide: hideMenu } = useContextMenu();
 
-  // 获取翻译表
-  const translations = interfaceTranslations[langKey];
-
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task.id,
     disabled: !canReorder,
@@ -286,7 +278,7 @@ export function TaskItem({ instanceId, task, optionsOpen, onToggleOptions }: Tas
       : resolveI18nText(taskDef.label, langKey) || taskDef.name
     : '';
   const displayName = task.customName || originalLabel;
-  const hasOptions = taskDef.option && taskDef.option.length > 0;
+  const hasOptions = (taskDef?.option?.length ?? 0) > 0;
   // 只有有选项时才显示“展开”入口；描述与选项一起放到右侧面板展示
   const canExpand = hasOptions;
 
@@ -303,7 +295,7 @@ export function TaskItem({ instanceId, task, optionsOpen, onToggleOptions }: Tas
     }[] = [];
     const maxPreviews = 3;
 
-    for (const optionKey of taskDef.option || []) {
+    for (const optionKey of taskDef?.option || []) {
       if (previews.length >= maxPreviews) break;
 
       // 优先从 projectInterface 查找，MXU 特殊任务从注册表查找

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect } from 'react';
+import { useCallback, useRef, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DndContext,
@@ -42,6 +42,7 @@ import {
 import { generateId } from '@/stores/helpers';
 import { toast } from 'sonner';
 import clsx from 'clsx';
+import { TaskOptionsPanel } from './TaskOptionsPanel';
 
 /** 单个预设卡片 */
 function PresetCard({ preset, onApply }: { preset: PresetItem; onApply: () => void }) {
@@ -205,7 +206,6 @@ export function TaskList() {
     reorderTasks,
     reorderPreActions,
     selectAllTasks,
-    collapseAllTasks,
     setShowAddTaskPanel,
     showAddTaskPanel,
     lastAddedTaskId,
@@ -217,6 +217,8 @@ export function TaskList() {
   const instance = getActiveInstance();
   const isInstanceRunning = instance?.isRunning || false;
   const { state: menuState, show: showMenu, hide: hideMenu } = useContextMenu();
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  const [optionsOpen, setOptionsOpen] = useState(false);
 
   // 滚动容器引用
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -284,7 +286,7 @@ export function TaskList() {
 
       const tasks = instance.selectedTasks;
       const hasEnabledTasks = tasks.some((t) => t.enabled);
-      const hasExpandedTasks = tasks.some((t) => t.expanded);
+      const hasExpandedTasks = optionsOpen;
       const hasTasks = tasks.length > 0;
 
       const menuItems: MenuItem[] = [
@@ -309,7 +311,17 @@ export function TaskList() {
                   ? t('contextMenu.collapseAllTasks')
                   : t('contextMenu.expandAllTasks'),
                 icon: hasExpandedTasks ? ChevronUp : ChevronDown,
-                onClick: () => collapseAllTasks(instance.id, !hasExpandedTasks),
+                onClick: () => {
+                  if (hasExpandedTasks) {
+                    setOptionsOpen(false);
+                    return;
+                  }
+                  const fallback = instance.selectedTasks[0]?.id;
+                  if (fallback) {
+                    setActiveTaskId(fallback);
+                    setOptionsOpen(true);
+                  }
+                },
               },
             ]
           : []),
@@ -342,9 +354,9 @@ export function TaskList() {
       showAddTaskPanel,
       setShowAddTaskPanel,
       selectAllTasks,
-      collapseAllTasks,
       showMenu,
       projectInterface,
+      optionsOpen,
     ],
   );
 
@@ -357,12 +369,37 @@ export function TaskList() {
   }
 
   const tasks = instance.selectedTasks;
+  const activeTask = activeTaskId ? tasks.find((x) => x.id === activeTaskId) : undefined;
 
   const preActions = instance.preActions ?? [];
   const showPreActions = preActions.length > 0;
   const canReorderPreActions = !isInstanceRunning && preActions.length > 1;
   const hasPresets =
     (projectInterface?.preset?.length ?? 0) > 0 && !skippedPresetInstanceIds.has(instance.id);
+
+  // 当任务列表变化/切换实例时，确保右侧面板不指向已不存在的任务
+  useEffect(() => {
+    if (!optionsOpen) return;
+    if (!activeTaskId) {
+      setOptionsOpen(false);
+      return;
+    }
+    if (!tasks.some((t) => t.id === activeTaskId)) {
+      setOptionsOpen(false);
+      setActiveTaskId(null);
+    }
+  }, [optionsOpen, activeTaskId, tasks]);
+
+  const handleToggleTaskOptions = useCallback(
+    (taskId: string) => {
+      setActiveTaskId((prev) => (prev === taskId ? prev : taskId));
+      setOptionsOpen((prevOpen) => {
+        const isSame = activeTaskId === taskId;
+        return isSame ? !prevOpen : true;
+      });
+    },
+    [activeTaskId],
+  );
 
   if (tasks.length === 0 && !showPreActions) {
     return (
@@ -441,55 +478,91 @@ export function TaskList() {
 
   return (
     <>
-      <div
-        ref={scrollContainerRef}
-        className="flex-1 overflow-y-auto overflow-x-hidden p-3"
-        onClick={() => showAddTaskPanel && setShowAddTaskPanel(false)}
-        onContextMenu={handleListContextMenu}
-      >
-        <div className="space-y-2">
-          {/* 前置动作列表（支持拖拽排序） */}
-          {showPreActions && (
+      <div className="flex-1 flex overflow-hidden">
+        <div
+          ref={scrollContainerRef}
+          className="flex-1 overflow-y-auto overflow-x-hidden p-3"
+          onClick={() => showAddTaskPanel && setShowAddTaskPanel(false)}
+          onContextMenu={handleListContextMenu}
+        >
+          <div className="space-y-2">
+            {/* 前置动作列表（支持拖拽排序） */}
+            {showPreActions && (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handlePreActionDragEnd}
+                modifiers={[restrictHorizontalMovement]}
+              >
+                <SortableContext
+                  items={preActions.map((a) => a.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-2">
+                    {preActions.map((action, idx) => (
+                      <ActionItem
+                        key={action.id}
+                        instanceId={instance.id}
+                        action={action}
+                        disabled={isInstanceRunning}
+                        canReorder={canReorderPreActions}
+                        index={idx}
+                        total={preActions.length}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            )}
+
+            {/* 任务列表 */}
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
-              onDragEnd={handlePreActionDragEnd}
+              onDragEnd={handleDragEnd}
               modifiers={[restrictHorizontalMovement]}
             >
-              <SortableContext
-                items={preActions.map((a) => a.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                {preActions.map((action, idx) => (
-                  <ActionItem
-                    key={action.id}
-                    instanceId={instance.id}
-                    action={action}
-                    disabled={isInstanceRunning}
-                    canReorder={canReorderPreActions}
-                    index={idx}
-                    total={preActions.length}
-                  />
-                ))}
+              <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
+                <div className="space-y-2">
+                  {tasks.map((task) => (
+                    <TaskItem
+                      key={task.id}
+                      instanceId={instance.id}
+                      task={task}
+                      optionsOpen={optionsOpen && activeTaskId === task.id}
+                      onToggleOptions={() => handleToggleTaskOptions(task.id)}
+                    />
+                  ))}
+                </div>
               </SortableContext>
             </DndContext>
-          )}
+          </div>
+        </div>
 
-          {/* 任务列表 */}
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-            modifiers={[restrictHorizontalMovement]}
+        <div
+          className={clsx(
+            'flex-shrink-0 h-full border-l border-border bg-bg-primary overflow-hidden',
+            'transition-[width] duration-200 ease-out',
+            optionsOpen ? 'w-[420px]' : 'w-0',
+          )}
+        >
+          <div
+            className={clsx(
+              'h-full',
+              'transition-[opacity,transform] duration-200 ease-out',
+              optionsOpen
+                ? 'opacity-100 translate-x-0'
+                : 'opacity-0 translate-x-2 pointer-events-none',
+            )}
           >
-            <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
-              <div className="space-y-2">
-                {tasks.map((task) => (
-                  <TaskItem key={task.id} instanceId={instance.id} task={task} />
-                ))}
-              </div>
-            </SortableContext>
-          </DndContext>
+            {activeTask && optionsOpen && (
+              <TaskOptionsPanel
+                instanceId={instance.id}
+                task={activeTask}
+                onClose={() => setOptionsOpen(false)}
+              />
+            )}
+          </div>
         </div>
       </div>
       {menuState.isOpen && (

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect, useMemo, useState } from 'react';
+import { useCallback, useRef, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DndContext,

--- a/src/components/TaskOptionsPanel.tsx
+++ b/src/components/TaskOptionsPanel.tsx
@@ -1,0 +1,366 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X, AlertCircle, Loader2, FileText, Link } from 'lucide-react';
+import clsx from 'clsx';
+import { useAppStore, type TaskRunStatus } from '@/stores/appStore';
+import { useResolvedContent } from '@/services/contentResolver';
+import { OptionEditor, SwitchGrid, switchHasNestedOptions } from './OptionEditor';
+import type { SelectedTask } from '@/types/interface';
+import { isMxuSpecialTask, getMxuSpecialTask, findMxuOptionByKey } from '@/types/specialTasks';
+import { getInterfaceLangKey } from '@/i18n';
+import { Tooltip } from './ui/Tooltip';
+
+/** 描述内容组件：显示从文件/URL/直接文本解析的内容 */
+function DescriptionContent({
+  html,
+  loading,
+  type,
+  loaded,
+  error,
+}: {
+  html: string;
+  loading: boolean;
+  type: 'url' | 'file' | 'text';
+  loaded: boolean;
+  error?: string;
+}) {
+  const { t } = useTranslation();
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-text-muted">
+        <Loader2 className="w-3 h-3 animate-spin" />
+        <span>{t('taskItem.loadingDescription')}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {loaded && type !== 'text' && (
+        <div className="flex items-center gap-1 text-[10px] text-text-muted">
+          {type === 'file' ? <FileText className="w-3 h-3" /> : <Link className="w-3 h-3" />}
+          <span>{t(type === 'file' ? 'taskItem.loadedFromFile' : 'taskItem.loadedFromUrl')}</span>
+        </div>
+      )}
+      {error && type !== 'text' && (
+        <div className="flex items-center gap-1 text-[10px] text-warning">
+          <AlertCircle className="w-3 h-3" />
+          <span>
+            {t('taskItem.loadDescriptionFailed')}: {error}
+          </span>
+        </div>
+      )}
+      {html && (
+        <div
+          className="text-xs text-text-secondary [&_p]:my-0.5 [&_a]:text-accent [&_a]:hover:underline"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      )}
+    </div>
+  );
+}
+
+/** 选项分组项类型 */
+type OptionGroup =
+  | { type: 'single'; optionKey: string }
+  | { type: 'switchGrid'; optionKeys: string[] };
+
+function isOptionControllerIncompatible(
+  optionDef: import('@/types/interface').OptionDefinition | null | undefined,
+  currentControllerName: string | undefined,
+): boolean {
+  if (!optionDef?.controller || optionDef.controller.length === 0) return false;
+  if (!currentControllerName) return false;
+  return !optionDef.controller.includes(currentControllerName);
+}
+
+function isOptionResourceIncompatible(
+  optionDef: import('@/types/interface').OptionDefinition | null | undefined,
+  currentResourceName: string | undefined,
+): boolean {
+  if (!optionDef?.resource || optionDef.resource.length === 0) return false;
+  if (!currentResourceName) return false;
+  return !optionDef.resource.includes(currentResourceName);
+}
+
+function OptionListRenderer({
+  instanceId,
+  taskId,
+  optionKeys,
+  optionValues,
+  disabled,
+  currentControllerName,
+  currentResourceName,
+}: {
+  instanceId: string;
+  taskId: string;
+  optionKeys: string[];
+  optionValues: Record<string, import('@/types/interface').OptionValue>;
+  disabled: boolean;
+  currentControllerName: string | undefined;
+  currentResourceName: string | undefined;
+}) {
+  const { projectInterface, resolveI18nText, language } = useAppStore();
+  const { t } = useTranslation();
+  const langKey = getInterfaceLangKey(language);
+
+  const getOptionDef = (optionKey: string) => {
+    const isMxuOption = optionKey.startsWith('__MXU_');
+    return isMxuOption ? findMxuOptionByKey(optionKey) : projectInterface?.option?.[optionKey];
+  };
+
+  const groups = useMemo(() => {
+    const result: OptionGroup[] = [];
+    let currentSwitchGroup: string[] = [];
+
+    const flushSwitchGroup = () => {
+      if (currentSwitchGroup.length > 4) {
+        result.push({ type: 'switchGrid', optionKeys: [...currentSwitchGroup] });
+      } else {
+        for (const key of currentSwitchGroup) {
+          result.push({ type: 'single', optionKey: key });
+        }
+      }
+      currentSwitchGroup = [];
+    };
+
+    for (const optionKey of optionKeys) {
+      const optionDef = getOptionDef(optionKey);
+      const isSimpleSwitch = optionDef?.type === 'switch' && !switchHasNestedOptions(optionDef);
+
+      if (isSimpleSwitch) {
+        currentSwitchGroup.push(optionKey);
+      } else {
+        flushSwitchGroup();
+        result.push({ type: 'single', optionKey });
+      }
+    }
+    flushSwitchGroup();
+    return result;
+  }, [optionKeys, projectInterface?.option]);
+
+  const buildSwitchGridItems = (keys: string[]) => {
+    return keys.map((optionKey) => {
+      const optionDef = getOptionDef(optionKey);
+      const value = optionValues[optionKey];
+      const isChecked = value?.type === 'switch' ? value.value : false;
+      const isMxuOption = optionKey.startsWith('__MXU_');
+
+      const label = isMxuOption
+        ? t(optionDef?.label || optionKey)
+        : resolveI18nText(optionDef?.label, langKey) || optionKey;
+      const description = isMxuOption
+        ? optionDef?.description
+          ? t(optionDef.description)
+          : undefined
+        : resolveI18nText(optionDef?.description, langKey);
+
+      const controllerIncompatible = isOptionControllerIncompatible(optionDef, currentControllerName);
+      const resourceIncompatible = isOptionResourceIncompatible(optionDef, currentResourceName);
+
+      return {
+        optionKey,
+        label,
+        description,
+        isChecked,
+        controllerIncompatible: controllerIncompatible || resourceIncompatible,
+      };
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {groups.map((group, index) => {
+        if (group.type === 'switchGrid') {
+          return (
+            <SwitchGrid
+              key={`grid-${index}`}
+              instanceId={instanceId}
+              taskId={taskId}
+              items={buildSwitchGridItems(group.optionKeys)}
+              disabled={disabled}
+            />
+          );
+        }
+        const optionDef = getOptionDef(group.optionKey);
+        const optionControllerIncompatible = isOptionControllerIncompatible(
+          optionDef,
+          currentControllerName,
+        );
+        const optionResourceIncompatible = isOptionResourceIncompatible(optionDef, currentResourceName);
+        const optionIncompatible = optionControllerIncompatible || optionResourceIncompatible;
+        const parentIncompatibilityReason = optionControllerIncompatible
+          ? 'controller'
+          : optionResourceIncompatible
+            ? 'resource'
+            : undefined;
+        return (
+          <OptionEditor
+            key={group.optionKey}
+            instanceId={instanceId}
+            taskId={taskId}
+            optionKey={group.optionKey}
+            value={optionValues[group.optionKey]}
+            disabled={disabled || optionIncompatible}
+            controllerIncompatible={optionIncompatible}
+            parentIncompatibilityReason={parentIncompatibilityReason}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export function TaskOptionsPanel({
+  instanceId,
+  task,
+  onClose,
+}: {
+  instanceId: string;
+  task: SelectedTask;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const {
+    projectInterface,
+    resolveI18nText,
+    language,
+    instances,
+    basePath,
+    interfaceTranslations,
+    instanceTaskRunStatus,
+  } = useAppStore();
+
+  const langKey = getInterfaceLangKey(language);
+  const translations = interfaceTranslations[langKey];
+
+  const instance = instances.find((i) => i.id === instanceId);
+  const isInstanceRunning = instance?.isRunning || false;
+  const taskRunStatus: TaskRunStatus = instanceTaskRunStatus[instanceId]?.[task.id] || 'idle';
+
+  const isMxuTask = isMxuSpecialTask(task.taskName);
+  const mxuSpecialTask = isMxuTask ? getMxuSpecialTask(task.taskName) : null;
+  const taskDef = isMxuTask
+    ? mxuSpecialTask?.taskDef
+    : projectInterface?.task.find((td) => td.name === task.taskName);
+  if (!taskDef) return null;
+
+  const currentControllerName = instance?.controllerName || projectInterface?.controller[0]?.name;
+  const currentResourceName = instance?.resourceName || projectInterface?.resource[0]?.name;
+
+  const canEditOptions =
+    !isInstanceRunning || taskRunStatus === 'idle' || taskRunStatus === 'pending';
+
+  const originalLabel = isMxuTask
+    ? t(taskDef.label || taskDef.name)
+    : resolveI18nText(taskDef.label, langKey) || taskDef.name;
+  const displayName = task.customName || originalLabel;
+
+  const resolvedDescription = useResolvedContent(
+    taskDef?.description ? resolveI18nText(taskDef.description, langKey) : undefined,
+    basePath,
+    translations,
+  );
+  const hasDescription = !!resolvedDescription.html || resolvedDescription.loading;
+
+  const hasOptions = taskDef.option && taskDef.option.length > 0;
+
+  // 不兼容判断（沿用 TaskItem 的语义：与当前 controller/resource 不匹配时提示）
+  const isControllerIncompatible = useMemo(() => {
+    if (!taskDef?.controller || taskDef.controller.length === 0) return false;
+    if (!currentControllerName) return false;
+    return !taskDef.controller.includes(currentControllerName);
+  }, [taskDef?.controller, currentControllerName]);
+
+  const isResourceIncompatible = useMemo(() => {
+    if (!taskDef?.resource || taskDef.resource.length === 0) return false;
+    if (!currentResourceName) return false;
+    return !taskDef.resource.includes(currentResourceName);
+  }, [taskDef?.resource, currentResourceName]);
+
+  const isIncompatible = isControllerIncompatible || isResourceIncompatible;
+
+  const incompatibleReason = useMemo(() => {
+    if (!isIncompatible) return '';
+    const reasons: string[] = [];
+    if (isControllerIncompatible) reasons.push(t('taskItem.incompatibleController'));
+    if (isResourceIncompatible) reasons.push(t('taskItem.incompatibleResource'));
+    return reasons.join(', ');
+  }, [isIncompatible, isControllerIncompatible, isResourceIncompatible, t]);
+
+  const supportedControllerHint = useMemo(() => {
+    if (!isControllerIncompatible || !taskDef?.controller || taskDef.controller.length === 0) return '';
+    const labels = taskDef.controller.map((name) => {
+      const ctrl = projectInterface?.controller.find((c) => c.name === name);
+      return ctrl ? resolveI18nText(ctrl.label, langKey) || ctrl.name : name;
+    });
+    return t('taskItem.supportedControllers', { controllers: labels.join(', ') });
+  }, [isControllerIncompatible, taskDef?.controller, projectInterface?.controller, resolveI18nText, langKey, t]);
+
+  return (
+    <div className="h-full flex flex-col min-w-0">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-bg-secondary/60">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-text-primary truncate">{displayName}</div>
+          {task.customName && (
+            <div className="text-xs text-text-muted truncate">{originalLabel}</div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-bg-hover transition-colors"
+          title={t('common.close')}
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3">
+        <div className="space-y-4">
+          {hasDescription && (
+            <div className="rounded-lg border border-border bg-bg-tertiary p-3">
+              <DescriptionContent
+                html={resolvedDescription.html}
+                loading={resolvedDescription.loading}
+                type={resolvedDescription.type}
+                loaded={resolvedDescription.loaded}
+                error={resolvedDescription.error}
+              />
+            </div>
+          )}
+
+          {isIncompatible && (
+            <Tooltip content={supportedControllerHint || undefined}>
+              <div
+                className={clsx(
+                  'flex items-center gap-1.5 px-2.5 py-2 rounded-lg border',
+                  'bg-warning/10 text-warning text-xs border-warning/20',
+                )}
+              >
+                <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
+                <span className="min-w-0 truncate">{incompatibleReason}</span>
+              </div>
+            </Tooltip>
+          )}
+
+          {hasOptions && (
+            <div className="rounded-lg border border-border bg-bg-tertiary p-3">
+              <OptionListRenderer
+                instanceId={instanceId}
+                taskId={task.id}
+                optionKeys={taskDef.option || []}
+                optionValues={task.optionValues}
+                disabled={!canEditOptions || isIncompatible}
+                currentControllerName={currentControllerName}
+                currentResourceName={currentResourceName}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

引入一个专用的右侧面板用于展示任务描述和选项，将选项展开状态从单个任务中解耦，并在任务列表视图中进行集中管理。

New Features:
- 添加一个持久存在的 `TaskOptionsPanel` 组件，在单独的侧边面板中显示所选任务的描述、兼容性警告以及选项编辑器。
- 允许用户从每个 `TaskItem` 中切换任务选项，由 `TaskList` 层级管理当前激活任务以及面板的打开/关闭状态，并在列表的上下文菜单中提供全局展开/折叠入口。

Enhancements:
- 通过移除 `TaskItem` 内联的可展开选项/描述区域并将选项渲染委托给新的侧边面板来简化 `TaskItem`。
- 调整 `OptionEditor` 中选项描述文本的样式，以在新的布局中获得更好的可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated right-side panel for task descriptions and options, decoupling option expansion state from individual tasks and centralizing it in the task list view.

New Features:
- Add a persistent TaskOptionsPanel component to display the selected task’s description, compatibility warnings, and option editors in a separate side pane.
- Allow users to toggle task options from each TaskItem, with the active task and panel open/close state managed at the TaskList level, including a global expand/collapse entry in the list context menu.

Enhancements:
- Simplify TaskItem by removing its inline expandable options/description section and delegating option rendering to the new side panel.
- Adjust option description text styling in OptionEditor for better readability in the new layout.

</details>