### PR TITLE
fix: WelcomeDialog 相对路径图片转为 data URL 内联显示

### DIFF
--- a/src/components/WelcomeDialog.tsx
+++ b/src/components/WelcomeDialog.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { X, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/stores/appStore';
-import { resolveContent, simpleMarkdownToHtml } from '@/services/contentResolver';
+import { resolveContent, markdownToHtmlWithLocalImages } from '@/services/contentResolver';
 import { getInterfaceLangKey } from '@/i18n';
 
 /**
@@ -31,6 +31,7 @@ export function WelcomeDialog() {
 
   const [isOpen, setIsOpen] = useState(false);
   const [content, setContent] = useState('');
+  const [html, setHtml] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   // 保存当前内容的 hash，关闭时写入配置
   const contentHashRef = useRef<string>('');
@@ -69,6 +70,8 @@ export function WelcomeDialog() {
       }
 
       setContent(resolvedContent);
+      const renderedHtml = await markdownToHtmlWithLocalImages(resolvedContent, basePath);
+      setHtml(renderedHtml);
       setIsLoading(false);
       setIsOpen(true);
     };
@@ -115,7 +118,7 @@ export function WelcomeDialog() {
         <div className="flex-1 overflow-y-auto px-6 py-4">
           <div
             className="prose prose-sm max-w-none text-text-secondary"
-            dangerouslySetInnerHTML={{ __html: simpleMarkdownToHtml(content) }}
+            dangerouslySetInnerHTML={{ __html: html }}
           />
         </div>
 

--- a/src/components/WelcomeDialog.tsx
+++ b/src/components/WelcomeDialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/stores/appStore';
 import { resolveContent, markdownToHtmlWithLocalImages, markdownToHtml } from '@/services/contentResolver';
 import { getInterfaceLangKey } from '@/i18n';
+import { loggers } from '@/utils/logger';
 
 /**
  * 计算字符串的简单 hash，用于判断内容是否变化
@@ -71,7 +72,8 @@ export function WelcomeDialog() {
       try {
         const renderedHtml = await markdownToHtmlWithLocalImages(resolvedContent, basePath);
         setHtml(renderedHtml);
-      } catch {
+      } catch (err) {
+        loggers.ui.warn('Welcome markdown 转 HTML 失败，降级为纯 markdown 渲染:', err);
         setHtml(markdownToHtml(resolvedContent));
       }
       setIsLoading(false);

--- a/src/components/WelcomeDialog.tsx
+++ b/src/components/WelcomeDialog.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { X, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/stores/appStore';
-import { resolveContent, markdownToHtmlWithLocalImages } from '@/services/contentResolver';
+import { resolveContent, markdownToHtmlWithLocalImages, markdownToHtml } from '@/services/contentResolver';
 import { getInterfaceLangKey } from '@/i18n';
 
 /**
@@ -30,7 +30,6 @@ export function WelcomeDialog() {
   } = useAppStore();
 
   const [isOpen, setIsOpen] = useState(false);
-  const [content, setContent] = useState('');
   const [html, setHtml] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   // 保存当前内容的 hash，关闭时写入配置
@@ -69,9 +68,12 @@ export function WelcomeDialog() {
         return;
       }
 
-      setContent(resolvedContent);
-      const renderedHtml = await markdownToHtmlWithLocalImages(resolvedContent, basePath);
-      setHtml(renderedHtml);
+      try {
+        const renderedHtml = await markdownToHtmlWithLocalImages(resolvedContent, basePath);
+        setHtml(renderedHtml);
+      } catch {
+        setHtml(markdownToHtml(resolvedContent));
+      }
       setIsLoading(false);
       setIsOpen(true);
     };


### PR DESCRIPTION
修复无法正常读取本地路径图片

## Summary by Sourcery

错误修复：
- 通过在渲染前将本地或相对路径引用的图片转换为内联数据 URL，确保 WelcomeDialog 能正确显示这些图片。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure WelcomeDialog correctly displays images referenced via local or relative paths by converting them to inline data URLs before rendering.

</details>
- 通过在渲染前将通过本地或相对路径引用的图像转换为内联数据 URL，修复了 WelcomeDialog 无法显示这些图像的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 通过在渲染前将本地或相对路径引用的图片转换为内联数据 URL，确保 WelcomeDialog 能正确显示这些图片。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure WelcomeDialog correctly displays images referenced via local or relative paths by converting them to inline data URLs before rendering.

</details>

</details>