### PR TITLE
fix: 给链接控制器加上 state-changed 判定兜底

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -861,6 +861,9 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
               } else {
                 cb();
               }
+            }).catch((err) => {
+              log.error(`实例 ${targetInstance.name}: 注册 maa-callback 监听失败:`, err);
+              handleFailure();
             });
             const handleStateChanged = (instanceId: string, kind: string) => {
               if (resolved) return;

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -787,7 +787,13 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
             }
           });
 
-          const ctrlId = await maaService.connectController(targetId, config);
+          let ctrlId: number;
+          try {
+            ctrlId = await maaService.connectController(targetId, config);
+          } catch (err) {
+            unsubscribe();
+            throw err;
+          }
 
           // 注册 ctrl_id 与设备名/类型的映射
           registerCtrlIdName(ctrlId, deviceName, targetType);
@@ -824,6 +830,12 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
               }
             }, 30000);
 
+            // 路径 1：继续监听新的 maa-callback（Controller.Action.Succeeded/Failed）
+            let unlistenCb: (() => void) | undefined;
+            // 路径 2：监听 state-changed（兜底：后端已广播 connected 但 Action.Succeeded 可能因竞态丢失）
+            // Tauri 桌面端走 app.emit() → listen()，WebSocket 端走 wsService
+            let unlistenState: (() => void) | undefined;
+
             // 检查已收集的回调（注册监听器在 connectController 之前已完成）
             const match = collectedCallbacks.find((cb) => cb.details.ctrl_id === ctrlId);
             if (match) {
@@ -835,8 +847,6 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
               return;
             }
 
-            // 路径 1：继续监听新的 maa-callback（Controller.Action.Succeeded/Failed）
-            let unlistenCb: (() => void) | undefined;
             maaService.onCallback((message, details) => {
               if (resolved) return;
               if (details.ctrl_id !== ctrlId) return;
@@ -846,17 +856,34 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                 handleFailure();
               }
             }).then((cb) => {
-              if (!resolved) unlistenCb = cb;
+              if (!resolved) {
+                unlistenCb = cb;
+              } else {
+                cb();
+              }
             });
-
-            // 路径 2：监听 state-changed（兜底：后端已广播 connected 但 Action.Succeeded 可能因竞态丢失）
-            const unlistenState = onStateChanged((instanceId, kind) => {
+            const handleStateChanged = (instanceId: string, kind: string) => {
               if (resolved) return;
               if (instanceId === targetId && kind === 'connected') {
                 log.info(`实例 ${targetInstance.name}: 通过 state-changed 兜底判定连接成功`);
                 handleSuccess();
               }
-            });
+            };
+
+            if (isTauri()) {
+              import('@tauri-apps/api/event').then(({ listen }) =>
+                listen<{ instance_id: string; kind: string }>('state-changed', (event) =>
+                  handleStateChanged(event.payload.instance_id, event.payload.kind),
+                ),
+              ).then((dispose) => {
+                if (resolved) dispose();
+                else unlistenState = dispose;
+              }).catch((err) => {
+                log.warn('注册 state-changed 监听失败:', err);
+              });
+            } else {
+              unlistenState = onStateChanged(handleStateChanged);
+            }
           });
 
           if (!connectResult) {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -32,6 +32,7 @@ import {
 import { scheduleService } from '@/services/scheduleService';
 import { stopInstanceTasks } from '@/services/taskStopService';
 import { isTauri } from '@/utils/paths';
+import { onStateChanged } from '@/services/wsService';
 import { buildPiEnvVars } from '@/utils/piEnv';
 
 const log = loggers.task;
@@ -775,9 +776,9 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
 
           onPhaseChange?.('connecting');
 
-          // 收集回调（避免快速连接时错过）
+          // 提前注册回调收集器，await 完成后再发起连接，避免竞态
           const collectedCallbacks: Array<{ message: string; details: { ctrl_id?: number } }> = [];
-          const unsubscribePromise = maaService.onCallback((message, details) => {
+          const unsubscribe = await maaService.onCallback((message, details) => {
             if (
               message === 'Controller.Action.Succeeded' ||
               message === 'Controller.Action.Failed'
@@ -791,58 +792,69 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
           // 注册 ctrl_id 与设备名/类型的映射
           registerCtrlIdName(ctrlId, deviceName, targetType);
 
-          // 等待初始回调收集器设置完成
-          const unsubscribe = await unsubscribePromise;
-
-          // 等待连接完成
+          // 等待连接完成（同时监听 maa-callback 和 state-changed 两条路径）
           const connectResult = await new Promise<boolean>((resolve) => {
             let resolved = false;
 
-            const cleanup = (unlisten?: () => void) => {
+            const handleSuccess = () => {
+              if (resolved) return;
+              resolved = true;
+              clearTimeout(timeout);
               unsubscribe();
-              unlisten?.();
+              unlistenCb?.();
+              unlistenState?.();
+              setInstanceConnectionStatus(targetId, 'Connected');
+              resolve(true);
+            };
+
+            const handleFailure = () => {
+              if (resolved) return;
+              resolved = true;
+              clearTimeout(timeout);
+              unsubscribe();
+              unlistenCb?.();
+              unlistenState?.();
+              resolve(false);
             };
 
             const timeout = setTimeout(() => {
               if (!resolved) {
                 log.warn(`实例 ${targetInstance.name}: 连接超时`);
-                cleanup();
-                resolve(false);
+                handleFailure();
               }
             }, 30000);
 
-            // 检查已收集的回调
+            // 检查已收集的回调（注册监听器在 connectController 之前已完成）
             const match = collectedCallbacks.find((cb) => cb.details.ctrl_id === ctrlId);
             if (match) {
-              resolved = true;
-              clearTimeout(timeout);
-              cleanup();
               if (match.message === 'Controller.Action.Succeeded') {
-                setInstanceConnectionStatus(targetId, 'Connected');
-                resolve(true);
+                handleSuccess();
               } else {
-                resolve(false);
+                handleFailure();
               }
               return;
             }
 
-            // 继续监听新回调
+            // 路径 1：继续监听新的 maa-callback（Controller.Action.Succeeded/Failed）
+            let unlistenCb: (() => void) | undefined;
             maaService.onCallback((message, details) => {
               if (resolved) return;
               if (details.ctrl_id !== ctrlId) return;
-              if (
-                message === 'Controller.Action.Succeeded' ||
-                message === 'Controller.Action.Failed'
-              ) {
-                resolved = true;
-                clearTimeout(timeout);
-                cleanup();
-                if (message === 'Controller.Action.Succeeded') {
-                  setInstanceConnectionStatus(targetId, 'Connected');
-                  resolve(true);
-                } else {
-                  resolve(false);
-                }
+              if (message === 'Controller.Action.Succeeded') {
+                handleSuccess();
+              } else if (message === 'Controller.Action.Failed') {
+                handleFailure();
+              }
+            }).then((cb) => {
+              if (!resolved) unlistenCb = cb;
+            });
+
+            // 路径 2：监听 state-changed（兜底：后端已广播 connected 但 Action.Succeeded 可能因竞态丢失）
+            const unlistenState = onStateChanged((instanceId, kind) => {
+              if (resolved) return;
+              if (instanceId === targetId && kind === 'connected') {
+                log.info(`实例 ${targetInstance.name}: 通过 state-changed 兜底判定连接成功`);
+                handleSuccess();
               }
             });
           });


### PR DESCRIPTION
- fix https://github.com/MaaEnd/MaaEnd/issues/2643

## Summary by Sourcery

改进控制器连接流程，使连接结果检测更加可靠并避免竞争条件问题。

Bug Fixes:
- 确保即使由于竞争条件导致初始操作回调被遗漏时，控制器连接也能被正确解析/完成。
- 当控制器连接失败时，取消订阅回调监听器，以防止内存泄漏和状态不一致。

Enhancements:
- 新增基于状态变更的备用路径（Tauri 事件和 WebSocket），在未收到操作回调时，用于确认控制器连接是否成功。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve controller connection flow to make connection result detection more reliable and race-safe.

Bug Fixes:
- Ensure controller connection correctly resolves even when the initial action callbacks are missed due to race conditions.
- Unsubscribe callback listeners when controller connection fails to prevent leaks and inconsistent state.

Enhancements:
- Add a state-changed based fallback path (Tauri events and WebSocket) to confirm controller connection success when action callbacks are not received.

</details>