### PR TITLE
fix: 修复未能遵守 PI 规定的短边尺寸的问题

### DIFF
--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -515,6 +515,7 @@ pub async fn connect_controller_impl(
                 screencap_methods,
                 input_methods,
                 config,
+                ..
             } => {
                 let screencap = screencap_methods.parse::<u64>().map_err(|e| {
                     format!("Invalid screencap_methods '{}': {}", screencap_methods, e)
@@ -544,6 +545,7 @@ pub async fn connect_controller_impl(
                 screencap_method,
                 mouse_method,
                 keyboard_method,
+                ..
             } => {
                 let hwnd = *handle as *mut std::ffi::c_void;
                 Controller::new_win32(
@@ -562,9 +564,14 @@ pub async fn connect_controller_impl(
             ControllerConfig::WlRoots {
                 wlr_socket_path,
                 use_win32_vk_code,
+                ..
             } => Controller::new_wlroots_with_vk_code(wlr_socket_path, *use_win32_vk_code)
                 .map_err(|e| e.to_string())?,
-            ControllerConfig::PlayCover { address, uuid } => {
+            ControllerConfig::PlayCover {
+                address,
+                uuid,
+                ..
+            } => {
                 let uuid_str = uuid.as_deref().unwrap_or("");
                 Controller::new_playcover(address, uuid_str).map_err(|e| e.to_string())?
             }
@@ -572,6 +579,7 @@ pub async fn connect_controller_impl(
                 handle,
                 gamepad_type,
                 screencap_method,
+                ..
             } => {
                 let hwnd = *handle as *mut std::ffi::c_void;
                 let gp_type = match gamepad_type.as_deref() {
@@ -596,9 +604,34 @@ pub async fn connect_controller_impl(
             })
             .map_err(|e| e.to_string())?;
 
-        // 设置默认参数
-        if let Err(e) = controller.set_screenshot_target_short_side(720) {
-            warn!("Failed to set screenshot target short side to 720: {}", e);
+        let display_short_side = match &config {
+            ControllerConfig::Adb {
+                display_short_side,
+                ..
+            }
+            | ControllerConfig::Win32 {
+                display_short_side,
+                ..
+            }
+            | ControllerConfig::WlRoots {
+                display_short_side,
+                ..
+            }
+            | ControllerConfig::Gamepad {
+                display_short_side,
+                ..
+            }
+            | ControllerConfig::PlayCover {
+                display_short_side,
+                ..
+            } => display_short_side.unwrap_or(720),
+        };
+
+        if let Err(e) = controller.set_screenshot_target_short_side(display_short_side) {
+            warn!(
+                "Failed to set screenshot target short side to {}: {}",
+                display_short_side, e
+            );
         }
 
         // 发起连接

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -70,17 +70,23 @@ pub enum ControllerConfig {
         screencap_methods: String, // u64 作为字符串传递，避免 JS 精度丢失
         input_methods: String,     // u64 作为字符串传递
         config: String,
+        #[serde(default)]
+        display_short_side: Option<i32>,
     },
     Win32 {
         handle: u64,
         screencap_method: u64,
         mouse_method: u64,
         keyboard_method: u64,
+        #[serde(default)]
+        display_short_side: Option<i32>,
     },
     WlRoots {
         wlr_socket_path: String,
         #[serde(default)]
         use_win32_vk_code: bool,
+        #[serde(default)]
+        display_short_side: Option<i32>,
     },
     Gamepad {
         handle: u64,
@@ -88,11 +94,15 @@ pub enum ControllerConfig {
         gamepad_type: Option<String>,
         #[serde(default)]
         screencap_method: Option<u64>,
+        #[serde(default)]
+        display_short_side: Option<i32>,
     },
     PlayCover {
         address: String,
         #[serde(default)]
         uuid: Option<String>,
+        #[serde(default)]
+        display_short_side: Option<i32>,
     },
 }
 

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -562,6 +562,7 @@ export function ConnectionPanel() {
           screencap_methods: selectedAdbDevice.screencap_methods,
           input_methods: selectedAdbDevice.input_methods,
           config: selectedAdbDevice.config,
+          display_short_side: currentController?.display_short_side,
         };
         deviceName = selectedAdbDevice.name || selectedAdbDevice.address;
         targetType = 'device';
@@ -572,6 +573,7 @@ export function ConnectionPanel() {
           screencap_method: parseWin32ScreencapMethod(currentController.win32?.screencap || ''),
           mouse_method: parseWin32InputMethod(currentController.win32?.mouse || ''),
           keyboard_method: parseWin32InputMethod(currentController.win32?.keyboard || ''),
+          display_short_side: currentController?.display_short_side,
         };
         deviceName = selectedWindow.window_name || selectedWindow.class_name;
         targetType = 'window';
@@ -590,6 +592,7 @@ export function ConnectionPanel() {
           type: 'PlayCover',
           address: playcoverAddress,
           uuid: currentController?.playcover?.uuid || 'maa.playcover',
+          display_short_side: currentController?.display_short_side,
         };
         deviceName = playcoverAddress;
         targetType = 'device';
@@ -597,6 +600,7 @@ export function ConnectionPanel() {
         config = {
           type: 'Gamepad',
           handle: selectedWindow.handle,
+          display_short_side: currentController?.display_short_side,
         };
         deviceName = selectedWindow.window_name || selectedWindow.class_name;
         targetType = 'window';
@@ -811,6 +815,7 @@ export function ConnectionPanel() {
         screencap_methods: device.screencap_methods,
         input_methods: device.input_methods,
         config: device.config,
+        display_short_side: currentController?.display_short_side,
       };
 
       await connectControllerInternal(config, device.name || device.address, 'device');
@@ -897,11 +902,13 @@ export function ConnectionPanel() {
           screencap_method: parseWin32ScreencapMethod(currentController?.win32?.screencap || ''),
           mouse_method: parseWin32InputMethod(currentController?.win32?.mouse || ''),
           keyboard_method: parseWin32InputMethod(currentController?.win32?.keyboard || ''),
+          display_short_side: currentController?.display_short_side,
         };
       } else {
         config = {
           type: 'Gamepad',
           handle: win.handle,
+          display_short_side: currentController?.display_short_side,
         };
       }
 

--- a/src/components/DeviceSelector.tsx
+++ b/src/components/DeviceSelector.tsx
@@ -235,6 +235,7 @@ export function DeviceSelector({
           screencap_methods: selectedAdbDevice.screencap_methods,
           input_methods: selectedAdbDevice.input_methods,
           config: selectedAdbDevice.config,
+          display_short_side: controllerDef.display_short_side,
         };
       } else if (controllerType === 'Win32' && selectedWindow) {
         config = {
@@ -243,6 +244,7 @@ export function DeviceSelector({
           screencap_method: parseWin32ScreencapMethod(controllerDef.win32?.screencap || ''),
           mouse_method: parseWin32InputMethod(controllerDef.win32?.mouse || ''),
           keyboard_method: parseWin32InputMethod(controllerDef.win32?.keyboard || ''),
+          display_short_side: controllerDef.display_short_side,
         };
       } else if (controllerType === 'WlRoots' && selectedWlrootsSocket) {
         config = {
@@ -254,11 +256,13 @@ export function DeviceSelector({
         config = {
           type: 'PlayCover',
           address: playcoverAddress,
+          display_short_side: controllerDef.display_short_side,
         };
       } else if (controllerType === 'Gamepad' && selectedWindow) {
         config = {
           type: 'Gamepad',
           handle: selectedWindow.handle,
+          display_short_side: controllerDef.display_short_side,
         };
       } else {
         throw new Error('请先选择设备');
@@ -346,6 +350,7 @@ export function DeviceSelector({
         screencap_methods: device.screencap_methods,
         input_methods: device.input_methods,
         config: device.config,
+        display_short_side: controllerDef.display_short_side,
       };
 
       const ctrlId = await maaService.connectController(instanceId, config);
@@ -389,11 +394,13 @@ export function DeviceSelector({
           screencap_method: parseWin32ScreencapMethod(controllerDef.win32?.screencap || ''),
           mouse_method: parseWin32InputMethod(controllerDef.win32?.mouse || ''),
           keyboard_method: parseWin32InputMethod(controllerDef.win32?.keyboard || ''),
+          display_short_side: controllerDef.display_short_side,
         };
       } else {
         config = {
           type: 'Gamepad',
           handle: win.handle,
+          display_short_side: controllerDef.display_short_side,
         };
       }
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -605,6 +605,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                 screencap_methods: matchedDevice.screencap_methods,
                 input_methods: matchedDevice.input_methods,
                 config: matchedDevice.config,
+                display_short_side: controller.display_short_side,
               };
               deviceName = matchedDevice.name || matchedDevice.address;
               targetType = 'device';
@@ -628,11 +629,13 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                   screencap_method: parseWin32ScreencapMethod(controller.win32?.screencap || ''),
                   mouse_method: parseWin32InputMethod(controller.win32?.mouse || ''),
                   keyboard_method: parseWin32InputMethod(controller.win32?.keyboard || ''),
+                  display_short_side: controller.display_short_side,
                 };
               } else {
                 config = {
                   type: 'Gamepad',
                   handle: matchedWindow.handle,
+                  display_short_side: controller.display_short_side,
                 };
               }
               deviceName = matchedWindow.window_name || matchedWindow.class_name;
@@ -656,6 +659,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
               config = {
                 type: 'PlayCover',
                 address: savedDevice.playcoverAddress,
+                display_short_side: controller.display_short_side,
               };
               deviceName = savedDevice.playcoverAddress;
               targetType = 'device';
@@ -691,6 +695,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                 screencap_methods: firstDevice.screencap_methods,
                 input_methods: firstDevice.input_methods,
                 config: firstDevice.config,
+                display_short_side: controller.display_short_side,
               };
               deviceName = firstDevice.name || firstDevice.address;
               targetType = 'device';
@@ -723,11 +728,13 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                   screencap_method: parseWin32ScreencapMethod(controller.win32?.screencap || ''),
                   mouse_method: parseWin32InputMethod(controller.win32?.mouse || ''),
                   keyboard_method: parseWin32InputMethod(controller.win32?.keyboard || ''),
+                  display_short_side: controller.display_short_side,
                 };
               } else {
                 config = {
                   type: 'Gamepad',
                   handle: firstWindow.handle,
+                  display_short_side: controller.display_short_side,
                 };
               }
               deviceName = firstWindow.window_name || firstWindow.class_name;

--- a/src/components/connection/useDeviceConnection.ts
+++ b/src/components/connection/useDeviceConnection.ts
@@ -211,6 +211,7 @@ export function useDeviceConnection({
           screencap_methods: device.screencap_methods,
           input_methods: device.input_methods,
           config: device.config,
+          display_short_side: currentController?.display_short_side,
         };
 
         await connectControllerInternal(config, device.name || device.address, 'device');
@@ -265,11 +266,13 @@ export function useDeviceConnection({
             screencap_method: parseWin32ScreencapMethod(currentController?.win32?.screencap || ''),
             mouse_method: parseWin32InputMethod(currentController?.win32?.mouse || ''),
             keyboard_method: parseWin32InputMethod(currentController?.win32?.keyboard || ''),
+            display_short_side: currentController?.display_short_side,
           };
         } else {
           config = {
             type: 'Gamepad',
             handle: win.handle,
+            display_short_side: currentController?.display_short_side,
           };
         }
 
@@ -363,6 +366,7 @@ export function useDeviceConnection({
         type: 'PlayCover',
         address: playcoverAddress,
         uuid: currentController?.playcover?.uuid || 'maa.playcover',
+        display_short_side: currentController?.display_short_side,
       };
 
       await connectControllerInternal(config, playcoverAddress, 'device');

--- a/src/types/maa.ts
+++ b/src/types/maa.ts
@@ -25,6 +25,7 @@ export interface AdbControllerConfig {
   screencap_methods: string; // u64 作为字符串传递
   input_methods: string; // u64 作为字符串传递
   config: string;
+  display_short_side?: number;
 }
 
 /** Win32 控制器配置 */
@@ -34,6 +35,7 @@ export interface Win32ControllerConfig {
   screencap_method: number;
   mouse_method: number;
   keyboard_method: number;
+  display_short_side?: number;
 }
 
 /** WlRoots 控制器配置 (Linux) */
@@ -48,12 +50,14 @@ export interface PlayCoverControllerConfig {
   type: 'PlayCover';
   address: string;
   uuid?: string;
+  display_short_side?: number;
 }
 
 /** Gamepad 控制器配置 */
 export interface GamepadControllerConfig {
   type: 'Gamepad';
   handle: number;
+  display_short_side?: number;
 }
 
 /** 控制器配置 */


### PR DESCRIPTION
## 概要

此 PR 是为了解决 #198 

## 关联

Fix #198

## Summary by Sourcery

通过所有连接路径传播控制器显示短边设置，并在建立控制器连接时应用该设置。

Bug Fixes:
- 在设置截图时，按照每个控制器配置的 `display_short_side` 值来处理，而不是始终使用硬编码的短边值。

Enhancements:
- 为所有控制器配置类型添加可选的 `display_short_side` 字段，并将其贯通到前端和后端的配置结构中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate the controller display short side setting through all connection paths and apply it when establishing controller connections.

Bug Fixes:
- Honor the configured display_short_side per controller instead of always using a hardcoded short-side value when setting up screenshots.

Enhancements:
- Add an optional display_short_side field to all controller configuration types and wire it through the frontend and backend config structures.

</details>

Bug 修复：
- 在通过连接面板、设备选择器、工具栏和设备连接钩子连接控制器时，保留并传递 `display_short_side` 配置，以修复短边尺寸行为不正确的问题。

增强功能：
- 扩展控制器配置的 TypeScript 类型，在所有控制器类型（Adb、Win32、PlayCover、Gamepad）中加入可选的 `display_short_side` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过所有连接路径传播控制器显示短边设置，并在建立控制器连接时应用该设置。

Bug Fixes:
- 在设置截图时，按照每个控制器配置的 `display_short_side` 值来处理，而不是始终使用硬编码的短边值。

Enhancements:
- 为所有控制器配置类型添加可选的 `display_short_side` 字段，并将其贯通到前端和后端的配置结构中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate the controller display short side setting through all connection paths and apply it when establishing controller connections.

Bug Fixes:
- Honor the configured display_short_side per controller instead of always using a hardcoded short-side value when setting up screenshots.

Enhancements:
- Add an optional display_short_side field to all controller configuration types and wire it through the frontend and backend config structures.

</details>

</details>