### PR TITLE
feat: 删除操作默认二次确认，弹窗内可快捷关闭

### DIFF
--- a/src/components/ActionItem.tsx
+++ b/src/components/ActionItem.tsx
@@ -63,12 +63,14 @@ export function ActionItem({
     duplicatePreAction,
     reorderPreActions,
     confirmBeforeDelete,
+    setConfirmBeforeDelete,
   } = useAppStore();
 
   const [expanded, setExpanded] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [dontAskAgain, setDontAskAgain] = useState(false);
   const { state: menuState, show: showMenu, hide: hideMenu } = useContextMenu();
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -373,8 +375,11 @@ export function ActionItem({
         cancelText={t('common.cancel')}
         confirmText={t('common.delete')}
         destructive
+        dontAskAgain={dontAskAgain}
+        onToggleDontAskAgain={setDontAskAgain}
         onCancel={() => setShowDeleteConfirm(false)}
         onConfirm={() => {
+          if (dontAskAgain) setConfirmBeforeDelete(false);
           setShowDeleteConfirm(false);
           removePreAction(instanceId, action.id);
         }}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, type ReactNode } from 'react';
 import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
 
 export function ConfirmDialog({
   open,
@@ -13,6 +14,8 @@ export function ConfirmDialog({
   confirmDisabled,
   secondaryConfirmDisabled,
   secondaryDestructive,
+  dontAskAgain,
+  onToggleDontAskAgain,
   onConfirm,
   onSecondaryConfirm,
   onCancel,
@@ -28,10 +31,13 @@ export function ConfirmDialog({
   confirmDisabled?: boolean;
   secondaryConfirmDisabled?: boolean;
   secondaryDestructive?: boolean;
+  dontAskAgain?: boolean;
+  onToggleDontAskAgain?: (v: boolean) => void;
   onConfirm: () => void;
   onSecondaryConfirm?: () => void;
   onCancel: () => void;
 }) {
+  const { t } = useTranslation();
   const panelRef = useRef<HTMLDivElement>(null);
   const cancelBtnRef = useRef<HTMLButtonElement>(null);
 
@@ -122,7 +128,21 @@ export function ConfirmDialog({
 
         {children && <div className="px-5 py-4 overflow-auto flex-1 min-h-0">{children}</div>}
 
-        <div className="px-5 py-4 flex justify-end gap-2 bg-bg-tertiary/30 flex-shrink-0">
+        <div className="px-5 py-4 flex items-center justify-between bg-bg-tertiary/30 flex-shrink-0">
+          {onToggleDontAskAgain ? (
+            <label className="flex items-center gap-1.5 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={dontAskAgain}
+                onChange={(e) => onToggleDontAskAgain(e.target.checked)}
+                className="rounded border-border text-accent focus:ring-accent"
+              />
+              <span className="text-xs text-text-muted">{t('common.dontAskAgain')}</span>
+            </label>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
           <button
             type="button"
             onClick={onCancel}
@@ -163,6 +183,7 @@ export function ConfirmDialog({
           >
             {confirmText}
           </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/RecentlyClosedPanel.tsx
+++ b/src/components/RecentlyClosedPanel.tsx
@@ -103,6 +103,7 @@ export function RecentlyClosedPanel({ onClose, anchorRef }: RecentlyClosedPanelP
   const panelRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState({ top: 0, right: 0 });
   const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [dontAskAgain, setDontAskAgain] = useState(false);
 
   const {
     recentlyClosed,
@@ -110,6 +111,7 @@ export function RecentlyClosedPanel({ onClose, anchorRef }: RecentlyClosedPanelP
     removeFromRecentlyClosed,
     clearRecentlyClosed,
     confirmBeforeDelete,
+    setConfirmBeforeDelete,
     projectInterface,
     language,
     resolveI18nText,
@@ -343,8 +345,11 @@ export function RecentlyClosedPanel({ onClose, anchorRef }: RecentlyClosedPanelP
         cancelText={t('common.cancel')}
         confirmText={t('recentlyClosed.clearAll')}
         destructive
+        dontAskAgain={dontAskAgain}
+        onToggleDontAskAgain={setDontAskAgain}
         onCancel={() => setShowClearConfirm(false)}
         onConfirm={() => {
+          if (dontAskAgain) setConfirmBeforeDelete(false);
           clearRecentlyClosed();
           setShowClearConfirm(false);
         }}

--- a/src/components/SchedulePanel.tsx
+++ b/src/components/SchedulePanel.tsx
@@ -41,8 +41,9 @@ function PolicyCard({
   onToggleExpand: () => void;
 }) {
   const { t } = useTranslation();
-  const { confirmBeforeDelete } = useAppStore();
+  const { confirmBeforeDelete, setConfirmBeforeDelete } = useAppStore();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [dontAskAgain, setDontAskAgain] = useState(false);
 
   const weekdayLabels = t('schedule.weekdays', { returnObjects: true }) as string[];
 
@@ -281,8 +282,11 @@ function PolicyCard({
         cancelText={t('common.cancel')}
         confirmText={t('common.confirm')}
         destructive
+        dontAskAgain={dontAskAgain}
+        onToggleDontAskAgain={setDontAskAgain}
         onCancel={() => setShowDeleteConfirm(false)}
         onConfirm={() => {
+          if (dontAskAgain) setConfirmBeforeDelete(false);
           setShowDeleteConfirm(false);
           onDelete();
         }}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -31,6 +31,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     updateCustomAccent,
     removeCustomAccent,
     confirmBeforeDelete,
+    setConfirmBeforeDelete,
   } = useAppStore();
 
   // 自定义强调色编辑状态
@@ -38,6 +39,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
   const [editingAccent, setEditingAccent] = useState<CustomAccent | null>(null);
   const [pendingDeleteAccentId, setPendingDeleteAccentId] = useState<string | null>(null);
   const [undoDeletedAccent, setUndoDeletedAccent] = useState<CustomAccent | null>(null);
+  const [dontAskAgain, setDontAskAgain] = useState(false);
   const undoTimerRef = useRef<number | null>(null);
 
   // 打开创建模态框
@@ -340,8 +342,11 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
         cancelText={t('common.cancel')}
         confirmText={t('common.confirm')}
         destructive
+        dontAskAgain={dontAskAgain}
+        onToggleDontAskAgain={setDontAskAgain}
         onCancel={() => setPendingDeleteAccentId(null)}
         onConfirm={() => {
+          if (dontAskAgain) setConfirmBeforeDelete(false);
           if (pendingDeleteAccentId) performDeleteCustomAccent(pendingDeleteAccentId);
           setPendingDeleteAccentId(null);
         }}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -81,7 +81,10 @@ export function TabBar() {
     removeAnimatingTabId,
     startTabCloseAnimation,
     confirmBeforeDelete,
+    setConfirmBeforeDelete,
   } = useAppStore();
+
+  const [dontAskAgain, setDontAskAgain] = useState(false);
 
   // 使用全局状态控制更新面板显示
   const showUpdatePanel = showUpdateDialog;
@@ -599,7 +602,12 @@ export function TabBar() {
         confirmText={t('common.confirm')}
         cancelText={t('common.cancel')}
         destructive
-        onConfirm={handleConfirmClose}
+        dontAskAgain={dontAskAgain}
+        onToggleDontAskAgain={setDontAskAgain}
+        onConfirm={() => {
+          if (dontAskAgain) setConfirmBeforeDelete(false);
+          handleConfirmClose();
+        }}
         onCancel={handleCancelClose}
       />
     </div>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -299,6 +299,7 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
   const { t } = useTranslation();
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [dontAskAgain, setDontAskAgain] = useState(false);
   const [editName, setEditName] = useState('');
 
   const {
@@ -307,6 +308,7 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
     toggleTaskExpanded,
     removeTaskFromInstance,
     confirmBeforeDelete,
+    setConfirmBeforeDelete,
     renameTask,
     duplicateTask,
     moveTaskUp,
@@ -1007,8 +1009,11 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
         cancelText={t('common.cancel')}
         confirmText={t('common.delete')}
         destructive
+        dontAskAgain={dontAskAgain}
+        onToggleDontAskAgain={setDontAskAgain}
         onCancel={() => setShowDeleteConfirm(false)}
         onConfirm={() => {
+          if (dontAskAgain) setConfirmBeforeDelete(false);
           setShowDeleteConfirm(false);
           removeTaskFromInstance(instanceId, task.id);
         }}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -6,6 +6,7 @@ export default {
     undo: 'Undo',
     save: 'Save',
     delete: 'Delete',
+    dontAskAgain: "Don't ask again",
     edit: 'Edit',
     add: 'Add',
     open: 'Open',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -6,6 +6,7 @@ export default {
     undo: '元に戻す',
     save: '保存',
     delete: '削除',
+    dontAskAgain: '今後この確認を表示しない',
     edit: '編集',
     add: '追加',
     open: '開く',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -6,6 +6,7 @@ export default {
     undo: '실행 취소',
     save: '저장',
     delete: '삭제',
+    dontAskAgain: '다시 묻지 않음',
     edit: '편집',
     add: '추가',
     open: '열기',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -6,6 +6,7 @@ export default {
     undo: '撤销',
     save: '保存',
     delete: '删除',
+    dontAskAgain: '不再显示此确认对话框',
     edit: '编辑',
     add: '添加',
     open: '打开',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -6,6 +6,7 @@ export default {
     undo: '復原',
     save: '儲存',
     delete: '刪除',
+    dontAskAgain: '不再顯示此確認對話框',
     edit: '編輯',
     add: '新增',
     open: '開啟',

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -135,7 +135,7 @@ export const useAppStore = create<AppState>()(
     language: 'system',
     backgroundImage: undefined,
     backgroundOpacity: 50,
-    confirmBeforeDelete: false,
+    confirmBeforeDelete: true,
     maxLogsPerInstance: DEFAULT_MAX_LOGS_PER_INSTANCE,
     autoClearLogsOnLaunch: true,
     customAccents: [],

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -228,7 +228,7 @@ export const defaultConfig: MxuConfig = {
     theme: 'system',
     accentColor: defaultAccentColor,
     language: 'system',
-    confirmBeforeDelete: false,
+    confirmBeforeDelete: true,
     maxLogsPerInstance: DEFAULT_MAX_LOGS_PER_INSTANCE,
     autoClearLogsOnLaunch: true,
     windowSize: defaultWindowSize,


### PR DESCRIPTION
confirmBeforeDelete 默认值改为 true，新增用户无需手动去设置页
开启二次确认。ConfirmDialog 增加"不再显示此确认对话框"勾选框，
勾选后自动关闭 confirmBeforeDelete，也可以在设置手动开启和关闭

- close #201 
- close https://github.com/MaaEnd/MaaEnd/issues/2668

## Summary by Sourcery

默认启用删除确认，并在确认对话框中添加一个行内选项，用于禁用未来的提示。

New Features:
- 为与删除相关的操作在确认对话框中添加可复用的“不要再询问”复选框，可在对话框内切换关闭删除确认。

Enhancements:
- 将全局“删除前确认”设置在新配置和应用状态中默认设为启用。
- 将与删除相关的组件（标签页、计划、动作、任务、最近关闭的项目、自定义强调项）接入新的对话框选项，以遵守并更新全局“删除前确认”设置。
- 为新对话框控件添加各受支持语言的本地化“不要再询问”文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable delete confirmation by default and add an inline option in confirmation dialogs to disable future prompts.

New Features:
- Add a reusable 'don’t ask again' checkbox to confirmation dialogs for delete-related actions that can toggle delete confirmations off from within the dialog.

Enhancements:
- Default the global confirm-before-delete setting to enabled for new configs and app state.
- Wire delete-related components (tabs, schedules, actions, tasks, recently closed items, custom accents) to respect and update the global confirm-before-delete setting via the new dialog option.
- Add localized 'don’t ask again' strings across supported languages for the new dialog control.

</details>