### PR TITLE
feat: 导出日志时在保存调试图像开启状态下同时打包 vision 目录

### DIFF
--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -472,6 +472,7 @@ pub fn set_executable(file_path: String) -> Result<(), String> {
 pub fn export_logs(
     project_name: Option<String>,
     project_version: Option<String>,
+    save_draw: Option<bool>,
 ) -> Result<String, String> {
     use std::fs::File;
     use zip::write::SimpleFileOptions;
@@ -596,6 +597,66 @@ pub fn export_logs(
             }
         } else {
             log::warn!("无法读取 on_error 目录");
+        }
+    }
+
+    // 处理 vision 文件夹（保存调试图像开启时），同样按最新优先并受大小上限约束
+    if save_draw.unwrap_or(false) {
+        let vision_dir = debug_dir.join("vision");
+        if vision_dir.exists() && vision_dir.is_dir() {
+            if let Ok(rd) = std::fs::read_dir(&vision_dir) {
+                let mut images: Vec<_> = rd.flatten().filter(|e| is_image_file(&e.path())).collect();
+
+                images.sort_by(|a, b| {
+                    let time_a = a.metadata().and_then(|m| m.modified()).ok();
+                    let time_b = b.metadata().and_then(|m| m.modified()).ok();
+                    time_b.cmp(&time_a)
+                });
+
+                for entry in images {
+                    let path = entry.path();
+                    let Some(name) = path.file_name() else {
+                        continue;
+                    };
+                    let archive_name = format!("vision/{}", name.to_string_lossy());
+
+                    if estimated_archive_size > MAX_EXPORT_ARCHIVE_BYTES {
+                        break;
+                    }
+
+                    let image_entry = ExportEntry {
+                        source_path: path,
+                        archive_name,
+                    };
+                    let Some(estimated_delta_upper_bound) =
+                        estimate_entry_upper_bound(&image_entry)
+                    else {
+                        log::warn!("无法获取图片大小，跳过 {:?}", image_entry.source_path);
+                        continue;
+                    };
+
+                    if estimated_archive_size + estimated_delta_upper_bound
+                        > MAX_EXPORT_ARCHIVE_BYTES
+                    {
+                        log::info!(
+                            "vision 图片已截断：当前预计 {} bytes，再加入 {} 后会超过 {} bytes",
+                            estimated_archive_size,
+                            estimated_archive_size + estimated_delta_upper_bound,
+                            MAX_EXPORT_ARCHIVE_BYTES
+                        );
+                        break;
+                    }
+
+                    if !archive_measurer.try_add_entry(&image_entry, options) {
+                        continue;
+                    }
+
+                    estimated_archive_size = archive_measurer.projected_size();
+                    selected_images.push(image_entry);
+                }
+            } else {
+                log::warn!("无法读取 vision 目录");
+            }
         }
     }
 

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -466,6 +466,74 @@ pub fn set_executable(file_path: String) -> Result<(), String> {
     Ok(())
 }
 
+/// 从指定目录收集图片，按最新优先排序，受压缩包大小上限约束
+fn collect_debug_images(
+    dir: &Path,
+    archive_prefix: &str,
+    archive_measurer: &mut ArchiveMeasurer,
+    estimated_archive_size: &mut u64,
+    selected_images: &mut Vec<ExportEntry>,
+    options: zip::write::SimpleFileOptions,
+) {
+    if !dir.exists() || !dir.is_dir() {
+        return;
+    }
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => {
+            log::warn!("无法读取 {} 目录", archive_prefix);
+            return;
+        }
+    };
+
+    let mut images: Vec<_> = rd.flatten().filter(|e| is_image_file(&e.path())).collect();
+
+    images.sort_by(|a, b| {
+        let time_a = a.metadata().and_then(|m| m.modified()).ok();
+        let time_b = b.metadata().and_then(|m| m.modified()).ok();
+        time_b.cmp(&time_a)
+    });
+
+    for entry in images {
+        let path = entry.path();
+        let Some(name) = path.file_name() else {
+            continue;
+        };
+        let archive_name = format!("{}/{}", archive_prefix, name.to_string_lossy());
+
+        if *estimated_archive_size > MAX_EXPORT_ARCHIVE_BYTES {
+            break;
+        }
+
+        let image_entry = ExportEntry {
+            source_path: path,
+            archive_name,
+        };
+        let Some(estimated_delta_upper_bound) = estimate_entry_upper_bound(&image_entry) else {
+            log::warn!("无法获取图片大小，跳过 {:?}", image_entry.source_path);
+            continue;
+        };
+
+        if *estimated_archive_size + estimated_delta_upper_bound > MAX_EXPORT_ARCHIVE_BYTES {
+            log::info!(
+                "{} 图片已截断：当前预计 {} bytes，再加入 {} 后会超过 {} bytes",
+                archive_prefix,
+                *estimated_archive_size,
+                *estimated_archive_size + estimated_delta_upper_bound,
+                MAX_EXPORT_ARCHIVE_BYTES
+            );
+            break;
+        }
+
+        if !archive_measurer.try_add_entry(&image_entry, options) {
+            continue;
+        }
+
+        *estimated_archive_size = archive_measurer.projected_size();
+        selected_images.push(image_entry);
+    }
+}
+
 /// 导出日志文件为 zip 压缩包
 /// 返回生成的 zip 文件路径
 #[tauri::command]
@@ -539,125 +607,32 @@ pub fn export_logs(
 
     if estimated_archive_size > MAX_EXPORT_ARCHIVE_BYTES {
         log::warn!(
-            "日志与配置压缩后预计已有 {} bytes，已超过 {} bytes 的导出目标，on_error 图片将全部跳过",
+            "日志与配置压缩后预计已有 {} bytes，已超过 {} bytes 的导出目标，调试图片将全部跳过",
             estimated_archive_size,
             MAX_EXPORT_ARCHIVE_BYTES
         );
     }
 
-    // 处理 on_error 文件夹，按最新优先，直到压缩包接近 24.5 MB
-    let on_error_dir = debug_dir.join("on_error");
-    if on_error_dir.exists() && on_error_dir.is_dir() {
-        if let Ok(rd) = std::fs::read_dir(&on_error_dir) {
-            let mut images: Vec<_> = rd.flatten().filter(|e| is_image_file(&e.path())).collect();
+    // 处理 on_error 文件夹
+    collect_debug_images(
+        &debug_dir.join("on_error"),
+        "on_error",
+        &mut archive_measurer,
+        &mut estimated_archive_size,
+        &mut selected_images,
+        options,
+    );
 
-            images.sort_by(|a, b| {
-                let time_a = a.metadata().and_then(|m| m.modified()).ok();
-                let time_b = b.metadata().and_then(|m| m.modified()).ok();
-                time_b.cmp(&time_a)
-            });
-
-            for entry in images {
-                let path = entry.path();
-                let Some(name) = path.file_name() else {
-                    continue;
-                };
-                let archive_name = format!("on_error/{}", name.to_string_lossy());
-
-                if estimated_archive_size > MAX_EXPORT_ARCHIVE_BYTES {
-                    break;
-                }
-
-                let image_entry = ExportEntry {
-                    source_path: path,
-                    archive_name,
-                };
-                let Some(estimated_delta_upper_bound) = estimate_entry_upper_bound(&image_entry)
-                else {
-                    log::warn!("无法获取图片大小，跳过 {:?}", image_entry.source_path);
-                    continue;
-                };
-
-                if estimated_archive_size + estimated_delta_upper_bound > MAX_EXPORT_ARCHIVE_BYTES {
-                    log::info!(
-                        "on_error 图片已截断：当前预计 {} bytes，再加入 {} 后会超过 {} bytes",
-                        estimated_archive_size,
-                        estimated_archive_size + estimated_delta_upper_bound,
-                        MAX_EXPORT_ARCHIVE_BYTES
-                    );
-                    break;
-                }
-
-                if !archive_measurer.try_add_entry(&image_entry, options) {
-                    continue;
-                }
-
-                estimated_archive_size = archive_measurer.projected_size();
-                selected_images.push(image_entry);
-            }
-        } else {
-            log::warn!("无法读取 on_error 目录");
-        }
-    }
-
-    // 处理 vision 文件夹（保存调试图像开启时），同样按最新优先并受大小上限约束
+    // 处理 vision 文件夹（保存调试图像开启时）
     if save_draw.unwrap_or(false) {
-        let vision_dir = debug_dir.join("vision");
-        if vision_dir.exists() && vision_dir.is_dir() {
-            if let Ok(rd) = std::fs::read_dir(&vision_dir) {
-                let mut images: Vec<_> = rd.flatten().filter(|e| is_image_file(&e.path())).collect();
-
-                images.sort_by(|a, b| {
-                    let time_a = a.metadata().and_then(|m| m.modified()).ok();
-                    let time_b = b.metadata().and_then(|m| m.modified()).ok();
-                    time_b.cmp(&time_a)
-                });
-
-                for entry in images {
-                    let path = entry.path();
-                    let Some(name) = path.file_name() else {
-                        continue;
-                    };
-                    let archive_name = format!("vision/{}", name.to_string_lossy());
-
-                    if estimated_archive_size > MAX_EXPORT_ARCHIVE_BYTES {
-                        break;
-                    }
-
-                    let image_entry = ExportEntry {
-                        source_path: path,
-                        archive_name,
-                    };
-                    let Some(estimated_delta_upper_bound) =
-                        estimate_entry_upper_bound(&image_entry)
-                    else {
-                        log::warn!("无法获取图片大小，跳过 {:?}", image_entry.source_path);
-                        continue;
-                    };
-
-                    if estimated_archive_size + estimated_delta_upper_bound
-                        > MAX_EXPORT_ARCHIVE_BYTES
-                    {
-                        log::info!(
-                            "vision 图片已截断：当前预计 {} bytes，再加入 {} 后会超过 {} bytes",
-                            estimated_archive_size,
-                            estimated_archive_size + estimated_delta_upper_bound,
-                            MAX_EXPORT_ARCHIVE_BYTES
-                        );
-                        break;
-                    }
-
-                    if !archive_measurer.try_add_entry(&image_entry, options) {
-                        continue;
-                    }
-
-                    estimated_archive_size = archive_measurer.projected_size();
-                    selected_images.push(image_entry);
-                }
-            } else {
-                log::warn!("无法读取 vision 目录");
-            }
-        }
+        collect_debug_images(
+            &debug_dir.join("vision"),
+            "vision",
+            &mut archive_measurer,
+            &mut estimated_archive_size,
+            &mut selected_images,
+            options,
+        );
     }
 
     let file = File::create(&zip_path).map_err(|e| format!("创建压缩文件失败: {}", e))?;

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -525,7 +525,7 @@ export default {
     openLogDir: 'Open Log Dir',
     exportLogs: 'Export Logs',
     exportLogsHint:
-      'Pack logs and config into a zip archive, keeping newest debug images until it reaches about 24.5 MB',
+      'Pack logs and config into a zip archive, keeping newest debug images until it reaches about 24.5 MB; when "Save debug images" is on, vision images are also included',
     exportingLogs: 'Exporting logs...',
     logsExported: 'Logs exported',
     exportLogsFailed: 'Failed to export logs',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -519,7 +519,7 @@ export default {
     openConfigDir: '設定フォルダを開く',
     openLogDir: 'ログフォルダを開く',
     exportLogs: 'ログをエクスポート',
-    exportLogsHint: 'ログと config を zip にまとめ、約 24.5 MB まで最新のデバッグ画像を自動で保持',
+    exportLogsHint: 'ログと config を zip にまとめ、約 24.5 MB まで最新のデバッグ画像を自動で保持；「デバッグ画像を保存」有効時は vision 画像も含める',
     exportingLogs: 'ログをエクスポート中...',
     logsExported: 'ログをエクスポートしました',
     exportLogsFailed: 'ログのエクスポートに失敗しました',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -519,7 +519,7 @@ export default {
     openConfigDir: '設定フォルダを開く',
     openLogDir: 'ログフォルダを開く',
     exportLogs: 'ログをエクスポート',
-    exportLogsHint: 'ログと config を zip にまとめ、約 24.5 MB まで最新のデバッグ画像を自動で保持；「デバッグ画像を保存」有効時は vision 画像も含める',
+    exportLogsHint: 'ログと config を zip にまとめ、約 24.5 MB まで最新のデバッグ画像を自動で保持; 「デバッグ画像を保存」有効時は vision 画像も含める',
     exportingLogs: 'ログをエクスポート中...',
     logsExported: 'ログをエクスポートしました',
     exportLogsFailed: 'ログのエクスポートに失敗しました',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -517,7 +517,7 @@ export default {
     openLogDir: '로그 폴더 열기',
     exportLogs: '로그 내보내기',
     exportLogsHint:
-      '로그와 config를 zip으로 묶고, 약 24.5 MB까지 최신 디버그 이미지를 자동으로 유지',
+      '로그와 config를 zip으로 묶고, 약 24.5 MB까지 최신 디버그 이미지를 자동으로 유지；"디버그 이미지 저장" 활성화 시 vision 이미지도 포함',
     exportingLogs: '로그 내보내는 중...',
     logsExported: '로그를 내보냈습니다',
     exportLogsFailed: '로그 내보내기 실패',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -517,7 +517,7 @@ export default {
     openLogDir: '로그 폴더 열기',
     exportLogs: '로그 내보내기',
     exportLogsHint:
-      '로그와 config를 zip으로 묶고, 약 24.5 MB까지 최신 디버그 이미지를 자동으로 유지；"디버그 이미지 저장" 활성화 시 vision 이미지도 포함',
+      '로그와 config를 zip으로 묶고, 약 24.5 MB까지 최신 디버그 이미지를 자동으로 유지; "디버그 이미지 저장" 활성화 시 vision 이미지도 포함',
     exportingLogs: '로그 내보내는 중...',
     logsExported: '로그를 내보냈습니다',
     exportLogsFailed: '로그 내보내기 실패',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -512,7 +512,7 @@ export default {
     openConfigDir: '打开配置目录',
     openLogDir: '打开日志目录',
     exportLogs: '导出日志',
-    exportLogsHint: '打包日志和 config，并按压缩包 24.5 MB 上限自动保留最近调试图片',
+    exportLogsHint: '打包日志和 config，并按压缩包 24.5 MB 上限自动保留最近调试图片；开启「保存调试图像」时同时打包 vision 图片',
     exportingLogs: '正在导出日志...',
     logsExported: '日志已导出',
     exportLogsFailed: '导出日志失败',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -508,7 +508,7 @@ export default {
     openConfigDir: '開啟設定目錄',
     openLogDir: '開啟日誌目錄',
     exportLogs: '匯出日誌',
-    exportLogsHint: '打包日誌與 config，並依 24.5 MB 上限自動保留最近的除錯圖片',
+    exportLogsHint: '打包日誌與 config，並依 24.5 MB 上限自動保留最近的除錯圖片；開啟「儲存偵錯圖片」時同時打包 vision 圖片',
     exportingLogs: '正在匯出日誌...',
     logsExported: '日誌已匯出',
     exportLogsFailed: '匯出日誌失敗',

--- a/src/utils/useExportLogs.ts
+++ b/src/utils/useExportLogs.ts
@@ -14,6 +14,7 @@ export interface ExportLogsState {
 
 export function useExportLogs() {
   const projectInterface = useAppStore((state) => state.projectInterface);
+  const saveDraw = useAppStore((state) => state.saveDraw);
   const [exportModal, setExportModal] = useState<ExportLogsState>({
     show: false,
     status: 'idle',
@@ -31,6 +32,7 @@ export function useExportLogs() {
       const zipPath = await invoke<string>('export_logs', {
         projectName: projectInterface?.name,
         projectVersion: projectInterface?.version,
+        saveDraw,
       });
       loggers.ui.info('日志已导出:', zipPath);
 
@@ -47,7 +49,7 @@ export function useExportLogs() {
         error: err instanceof Error ? err.message : String(err),
       });
     }
-  }, [projectInterface?.name, projectInterface?.version]);
+  }, [projectInterface?.name, projectInterface?.version, saveDraw]);
 
   const closeExportModal = useCallback(() => {
     setExportModal({ show: false, status: 'idle' });


### PR DESCRIPTION
## Summary by Sourcery

当启用了保存调试图像功能时，在导出的日志归档中包含视觉调试图像，并通过前端界面和本地化的导出日志提示文本对这一行为进行展示。

New Features:
- 在导出的日志归档中可选地加入来自 vision 目录的图像，并受现有归档大小上限的约束。

Enhancements:
- 将前端中的保存绘制（save-draw）开关传递到 `export_logs` 命令中，以控制是否将视觉图像打包进归档。
- 更新各受支持语言环境下的导出日志提示文本，以描述视觉图像的按条件包含行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include vision debug images in exported log archives when saving debug images is enabled, and surface this behavior through the frontend and localized export logs hint text.

New Features:
- Add optional inclusion of images from the vision directory in exported log archives, constrained by the existing archive size limit.

Enhancements:
- Thread the save-draw toggle from the frontend into the export_logs command to control whether vision images are packaged.
- Update export logs hint text across supported locales to describe the conditional inclusion of vision images.

</details>