### PR TITLE
fix(update):  自动运行模式下更新弹窗不阻塞任务

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -895,7 +895,7 @@ function App() {
             } else {
               showUpdateCompletedUI();
               if (isAutoRunOnLaunchMode) {
-                pendingAutoTasksRef.current = true;
+                dispatchPendingAutoStartTasks();
               }
               return;
             }
@@ -911,7 +911,7 @@ function App() {
           } else {
             showUpdateCompletedUI();
             if (isAutoRunOnLaunchMode) {
-              pendingAutoTasksRef.current = true;
+              dispatchPendingAutoStartTasks();
             }
             return;
           }


### PR DESCRIPTION
## 问题

PR #141 引入了新的判断逻辑，允许自动模式跳过更新弹窗，但代码行为和意图不完全一致。

当前实际表现是：
- 开机自启动模式会跳过更新完成弹窗
- 普通手动启动不会自动执行任务
- 有且只有“手动启动但勾选了 AutoRunOnLaunch”的用户，会在更新完成后的启动阶段被更新完成弹窗阻塞。

原因是更新完成分支里将自动执行任务挂到了 `pendingAutoTasksRef`，需要等弹窗关闭后才会继续派发任务。此时更新其实已经完成，弹窗只是提示，不应该阻塞启动后的自动执行流程。

## 改了啥

在更新完成后的启动分支中，`AutoRunOnLaunch` 场景不再进入 pending 状态，而是在展示更新完成弹窗后直接 dispatch 

## 验证

- 编译通过
- 本地测试通过

## Summary by Sourcery

Bug Fixes:
- 修复自动启动流程被更新完成对话框阻塞的问题：在显示该对话框后立即派发待处理的自动启动任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix auto-run-on-launch flow being blocked by the update completion dialog by dispatching pending auto-start tasks immediately after showing the dialog.

</details>