### PR TITLE
feat: 适配 PI v2.7 协议

### DIFF
--- a/src/components/AddTaskPanel.tsx
+++ b/src/components/AddTaskPanel.tsx
@@ -23,14 +23,24 @@ import {
   addTaskPanelResizeStep,
 } from '@/types/config';
 import { Tooltip } from './ui/Tooltip';
-import type { TaskItem, ActionConfig, GroupItem } from '@/types/interface';
+import type {
+  TaskItem,
+  ActionConfig,
+  GroupItem,
+  PreTaskConfig,
+  OptionDefinition,
+  OptionValue,
+  CaseItem,
+} from '@/types/interface';
+import { normalizePreTaskConfigs } from '@/types/interface';
 import type { MxuSpecialTaskDefinition } from '@/types/specialTasks';
 import {
   getAllMxuSpecialTasks,
   MXU_LAUNCH_TASK_NAME,
   MXU_KILLPROC_TASK_NAME,
 } from '@/types/specialTasks';
-import { generateId } from '@/stores/helpers';
+import { generateId, initializeAllOptionValues } from '@/stores/helpers';
+import { findSwitchCase } from '@/utils/optionHelpers';
 import { getProcessNameFromPath } from '@/utils/paths';
 import clsx from 'clsx';
 
@@ -158,6 +168,145 @@ function createDefaultAction(defaultProgram?: string): ActionConfig {
     skipIfRunning: true,
     useCmd: false,
   };
+}
+
+/**
+ * 以兼容 shell_words crate（POSIX 解析）的方式对单个参数做引号转义。
+ * 字母/数字/常用安全符号原样输出，其他字符使用单引号包裹。
+ */
+function shellQuote(arg: string): string {
+  if (arg === '') return "''";
+  if (/^[a-zA-Z0-9._/\-+=:@%]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/** 将参数数组以 shell 安全形式 join 为字符串，便于回写 ActionConfig.args */
+function joinArgsShell(args: string[] | undefined): string {
+  if (!args || args.length === 0) return '';
+  return args.map(shellQuote).join(' ');
+}
+
+/** 将 OptionValue 转换为协议要求的「原始 JSON 取值」（select/switch -> case.name 字符串等） */
+function rawValueFromOptionValue(value: OptionValue, optionDef: OptionDefinition): unknown {
+  if (value.type === 'select') return value.caseName;
+  if (value.type === 'checkbox') return value.caseNames;
+  if (value.type === 'input') return value.values;
+  if (value.type === 'switch') {
+    const cases = (optionDef as { cases?: CaseItem[] }).cases;
+    const matched = findSwitchCase(cases, value.value);
+    return matched?.name ?? (value.value ? 'Yes' : 'No');
+  }
+  return null;
+}
+
+/**
+ * 按 PI v2.7.0 规范，构造 pretask option 的「单行紧凑 JSON」字符串。
+ * 仅快照默认值，不在此处做控制器/资源过滤（pretask 顶层即生效）。
+ * 若无 option 或 allOptions 为空，则返回 null。
+ */
+function buildPretaskOptionJson(
+  optionKeys: string[] | undefined,
+  allOptions: Record<string, OptionDefinition> | undefined,
+): string | null {
+  if (!optionKeys || optionKeys.length === 0 || !allOptions) return null;
+  const valuesMap = initializeAllOptionValues(optionKeys, allOptions);
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(valuesMap)) {
+    const def = allOptions[key];
+    if (!def) continue;
+    result[key] = rawValueFromOptionValue(value, def);
+  }
+  return JSON.stringify(result);
+}
+
+/** 以 pretask 配置生成新的 ActionConfig，args 末尾按需追加 option 取值 JSON */
+function createActionFromPretask(
+  pretask: PreTaskConfig,
+  allOptions: Record<string, OptionDefinition> | undefined,
+  resolvedLabel?: string,
+): ActionConfig {
+  const args = [...(pretask.args ?? [])];
+  const optionJson = buildPretaskOptionJson(pretask.option, allOptions);
+  if (optionJson !== null) {
+    args.push(optionJson);
+  }
+  return {
+    id: generateId(),
+    enabled: true,
+    program: pretask.exec,
+    args: joinArgsShell(args),
+    // PI 协议要求 Client 等待每个 pretask 结束并在失败时中止启动；这里以 ActionConfig 形式承载，
+    // 通过保留 waitForExit=true 来贴近协议语义（用户仍可在 UI 中调整）。
+    waitForExit: true,
+    skipIfRunning: false,
+    useCmd: false,
+    customName: resolvedLabel,
+  };
+}
+
+/** pretask 按钮：与 TaskButton 风格保持一致，但不依赖 controller/resource 兼容性 */
+function PreTaskButton({
+  pretask,
+  count,
+  label,
+  langKey,
+  basePath,
+  onClick,
+}: {
+  pretask: PreTaskConfig;
+  count: number;
+  label: string;
+  langKey: string;
+  basePath: string;
+  onClick: () => void;
+}) {
+  const { t } = useTranslation();
+  const { resolveI18nText, interfaceTranslations } = useAppStore();
+
+  const translations = interfaceTranslations[langKey];
+  const resolvedDescription = useResolvedContent(
+    pretask.description ? resolveI18nText(pretask.description, langKey) : undefined,
+    basePath,
+    translations,
+  );
+
+  const hasDescription = !!resolvedDescription.html || resolvedDescription.loading;
+
+  const tooltipContent = hasDescription ? (
+    <div className="space-y-2">
+      {resolvedDescription.loading ? (
+        <div className="flex items-center gap-1.5 text-text-muted">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          <span>{t('taskItem.loadingDescription')}</span>
+        </div>
+      ) : resolvedDescription.html ? (
+        <div
+          className="text-text-secondary [&_p]:my-0.5 [&_a]:text-accent [&_a]:hover:underline"
+          dangerouslySetInnerHTML={{ __html: resolvedDescription.html }}
+        />
+      ) : null}
+    </div>
+  ) : null;
+
+  return (
+    <Tooltip content={tooltipContent} side="top" align="center" maxWidth="max-w-xs">
+      <button
+        onClick={onClick}
+        className={clsx(
+          'relative flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors text-left',
+          'bg-bg-secondary hover:bg-bg-hover text-text-primary border border-border hover:border-accent',
+        )}
+      >
+        <Plus className="w-4 h-4 shrink-0 text-accent" />
+        <span className="flex-1 truncate">{label}</span>
+        {count > 0 && (
+          <span className="shrink-0 px-1.5 py-0.5 text-xs rounded-full font-medium bg-accent/10 text-accent">
+            {count}
+          </span>
+        )}
+      </button>
+    </Tooltip>
+  );
 }
 
 export function AddTaskPanel() {
@@ -402,6 +551,56 @@ export function AddTaskPanel() {
   });
   const [ungroupedExpanded, setUngroupedExpanded] = useState(true);
   const [specialExpanded, setSpecialExpanded] = useState(true);
+  const [pretaskExpanded, setPretaskExpanded] = useState(true);
+
+  // v2.7.0: 收集合并后的 pretask 列表（loader 已合并主文件 + import）
+  const allPretasks = useMemo(
+    () => normalizePreTaskConfigs(projectInterface?.pretask),
+    [projectInterface?.pretask],
+  );
+
+  // 按搜索关键词过滤 pretask（与 task 一致：匹配 name 或解析后的 label）
+  const filteredPretasks = useMemo(() => {
+    if (allPretasks.length === 0) return [];
+    const searchLower = searchQuery.toLowerCase();
+    return allPretasks.filter((p) => {
+      const label = resolveI18nText(p.label, langKey) || p.name || p.exec;
+      return (
+        (p.name?.toLowerCase().includes(searchLower) ?? false) ||
+        p.exec.toLowerCase().includes(searchLower) ||
+        label.toLowerCase().includes(searchLower)
+      );
+    });
+  }, [allPretasks, searchQuery, resolveI18nText, langKey]);
+
+  // 统计每个 pretask 已被加入 preActions 的次数（按 program 路径匹配）
+  const pretaskCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    const preActions = instance?.preActions ?? [];
+    for (const p of allPretasks) {
+      counts[p.exec] = preActions.filter((a) => a.program === p.exec).length;
+    }
+    return counts;
+  }, [allPretasks, instance?.preActions]);
+
+  /** 点击 pretask 按钮：基于 pretask 配置生成 ActionConfig，加入 preActions */
+  const handleAddPretask = useCallback(
+    (pretask: PreTaskConfig) => {
+      if (!instance) return;
+      const resolvedLabel = resolveI18nText(pretask.label, langKey) || pretask.name || undefined;
+      const action = createActionFromPretask(pretask, projectInterface?.option, resolvedLabel);
+      addPreAction(instance.id, action);
+      setShowAddTaskPanel(false);
+    },
+    [
+      instance,
+      projectInterface?.option,
+      resolveI18nText,
+      langKey,
+      addPreAction,
+      setShowAddTaskPanel,
+    ],
+  );
 
   // 当分组定义变化时，移除已失效 key，并为新分组注入 default_expand 默认值
   useEffect(() => {
@@ -518,6 +717,45 @@ export function AddTaskPanel() {
         {count !== undefined && <span className="text-[10px] text-text-muted">({count})</span>}
         <div className="flex-1 h-px bg-border/30 ml-2" />
       </button>
+    );
+  };
+
+  /** 渲染 pretask 分组（与普通 task 分组风格一致） */
+  const renderPretaskSection = () => {
+    if (filteredPretasks.length === 0) return null;
+    const contentId = 'add-task-panel-section-pretask';
+    return (
+      <div>
+        {renderSectionHeader(
+          t('addTaskPanel.pretasks'),
+          pretaskExpanded,
+          () => setPretaskExpanded((prev) => !prev),
+          filteredPretasks.length,
+          contentId,
+        )}
+        {pretaskExpanded && (
+          <div id={contentId} className="mt-1">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-2">
+              {filteredPretasks.map((pretask) => {
+                const label =
+                  resolveI18nText(pretask.label, langKey) || pretask.name || pretask.exec;
+                const key = pretask.name || pretask.exec;
+                return (
+                  <PreTaskButton
+                    key={key}
+                    pretask={pretask}
+                    count={pretaskCounts[pretask.exec] || 0}
+                    label={label}
+                    langKey={langKey}
+                    basePath={basePath}
+                    onClick={() => handleAddPretask(pretask)}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
     );
   };
 
@@ -723,6 +961,9 @@ export function AddTaskPanel() {
               /* 无分组：保持原有平铺网格 */
               filteredTasks.length > 0 && renderTaskGrid(filteredTasks)
             )}
+
+            {/* 前置任务（pretask）：放在普通任务与特殊任务之间，仅当存在配置且有活动实例时渲染 */}
+            {instance && renderPretaskSection()}
 
             {instance && (
               <div>

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -488,6 +488,7 @@ export default {
     specialTasks: 'Special Tasks',
     allSpecialTasksAdded: 'All added',
     ungroupedTasks: 'Others',
+    pretasks: 'Pre-tasks',
     resizeHandleAriaLabel: 'Resize add task panel height',
   },
 

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -483,6 +483,7 @@ export default {
     allSpecialTasksAdded: 'すべて追加済み',
     collapse: 'パネルを閉じる',
     ungroupedTasks: 'その他',
+    pretasks: '事前タスク',
     resizeHandleAriaLabel: 'タスク追加パネルの高さを調整',
   },
 

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -480,6 +480,7 @@ export default {
     specialTasks: '특수 작업',
     allSpecialTasksAdded: '모두 추가됨',
     ungroupedTasks: '기타',
+    pretasks: '사전 작업',
     resizeHandleAriaLabel: '작업 추가 패널 높이 조정',
   },
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -476,6 +476,7 @@ export default {
     allSpecialTasksAdded: '已全部添加',
     collapse: '收起面板',
     ungroupedTasks: '其他',
+    pretasks: '前置任务',
     resizeHandleAriaLabel: '调整添加任务面板高度',
   },
 

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -472,6 +472,7 @@ export default {
     allSpecialTasksAdded: '已全部新增',
     collapse: '收起面板',
     ungroupedTasks: '其他',
+    pretasks: '前置任務',
     resizeHandleAriaLabel: '調整新增任務面板高度',
   },
 

--- a/src/services/interfaceLoader.ts
+++ b/src/services/interfaceLoader.ts
@@ -6,7 +6,9 @@ import type {
   ControllerType,
   PresetItem,
   GroupItem,
+  PreTaskConfig,
 } from '@/types/interface';
+import { normalizePreTaskConfigs } from '@/types/interface';
 import { loggers } from '@/utils/logger';
 import { parseJsonc } from '@/utils/jsonc';
 import { isTauri } from '@/utils/paths';
@@ -15,7 +17,7 @@ import { setBackendPort } from '@/utils/backendApi';
 const log = loggers.app;
 
 /**
- * 可导入的 PI 文件结构（支持 task、option、preset 和 group 字段）
+ * 可导入的 PI 文件结构（支持 task、option、preset、group 和 pretask 字段）
  */
 interface ImportableInterface {
   task?: TaskItem[];
@@ -24,6 +26,8 @@ interface ImportableInterface {
   preset?: PresetItem[];
   /** v2.4.0: 支持导入 group */
   group?: GroupItem[];
+  /** v2.7.1: 支持导入 pretask */
+  pretask?: PreTaskConfig | PreTaskConfig[];
 }
 
 export interface LoadResult {
@@ -231,6 +235,14 @@ function mergeImported(pi: ProjectInterface, imported: ImportableInterface): voi
   if (imported.preset && imported.preset.length > 0) {
     pi.preset = [...(pi.preset || []), ...imported.preset];
     log.info(`合并了 ${imported.preset.length} 个导入的 preset`);
+  }
+
+  // v2.7.1: 合并 pretask（主文件已在 normalizePretask 处理；此处把导入文件的条目按数组顺序追加）
+  const importedPretasks = normalizePreTaskConfigs(imported.pretask);
+  if (importedPretasks.length > 0) {
+    const existing = normalizePreTaskConfigs(pi.pretask);
+    pi.pretask = [...existing, ...importedPretasks];
+    log.info(`合并了 ${importedPretasks.length} 个导入的 pretask`);
   }
 
   // v2.4.0: 合并 group 数组（按 name 去重，保持先定义优先）

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -28,6 +28,41 @@ export interface ProjectInterface {
   import?: string[];
   /** v2.3.0: 预设配置 */
   preset?: PresetItem[];
+  /** v2.7.0: Controller 启动前执行的预任务配置，可为单对象或对象数组 */
+  pretask?: PreTaskConfig | PreTaskConfig[];
+}
+
+/** v2.7.0: 预任务配置 */
+export interface PreTaskConfig {
+  /** 必须。要执行的程序路径，可以是系统 PATH 中的可执行文件 */
+  exec: string;
+  /** 可选。固定参数数组，按顺序传递给 exec */
+  args?: string[];
+  /** v2.7.2: 可选。预任务唯一标识，用于 Client UI/日志区分；缺省时 Client 可回退到 exec */
+  name?: string;
+  /** v2.7.2: 可选。预任务显示名称，支持 i18n */
+  label?: string;
+  /** v2.7.2: 可选。预任务详细描述，支持 i18n / 文件路径 / URL，内容支持 Markdown */
+  description?: string;
+  /** v2.7.2: 可选。预任务图标路径，相对于 interface.json 所在目录，支持 i18n */
+  icon?: string;
+  /**
+   * 可选。需要让用户选择的 option 键名列表，元素应与外层 option 配置中的键名对应。
+   * 若设置，Client 应将这些 option 的当前取值序列化为单行紧凑 JSON 字符串并追加为最后一个参数。
+   * 该字段仅用于生成传给预任务进程的参数，不参与 pipeline_override 合并。
+   */
+  option?: string[];
+}
+
+/**
+ * 将 PI 协议中的 pretask 字段（单对象或数组）标准化为数组。
+ * 如果 pretask 未定义则返回空数组。
+ */
+export function normalizePreTaskConfigs(
+  pretask: PreTaskConfig | PreTaskConfig[] | undefined,
+): PreTaskConfig[] {
+  if (!pretask) return [];
+  return Array.isArray(pretask) ? pretask : [pretask];
 }
 
 /** v2.4.0: 任务分组声明 */


### PR DESCRIPTION
## Summary by Sourcery

将客户端适配到 PI v2.7 的预任务（pretask）定义，通过把预任务配置接入接口模型、加载器以及 AddTaskPanel UI，包括参数和选项处理。

New Features:
- 在 ProjectInterface 模式（schema）和接口加载器中新增对 PI v2.7 预任务配置的支持。
- 在 AddTaskPanel 中暴露预任务，添加专门的预任务区域，以及基于预任务定义添加预操作的按钮。
- 将所选选项值序列化为精简的 JSON 参数，并附加到预任务命令后，同时使用对 shell 安全的参数拼接方式。

Enhancements:
- 引入用于规范化预任务配置以及安全地对参数进行 shell 引号包裹/拼接的实用工具。
- 扩展 i18n 资源，在受支持语言中增加新的预任务区域标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt the client to PI v2.7 pretask definitions by wiring pretask configs into the interface model, loader, and AddTaskPanel UI, including argument and option handling.

New Features:
- Add support for PI v2.7 pretask configurations in the ProjectInterface schema and interface loader.
- Expose pretasks in the AddTaskPanel with a dedicated pretask section and buttons for adding pre-actions based on pretask definitions.
- Serialize selected option values into a compact JSON argument appended to pretask commands, with shell-safe argument joining.

Enhancements:
- Introduce utilities for normalizing pretask configs and safely shell-quoting/joining arguments.
- Extend i18n resources with labels for the new pretask section across supported languages.

</details>