### PR TITLE
update notification task

### DIFF
--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -307,6 +307,37 @@ fn mxu_launch_action_fn(
     }
 }
 
+fn get_instance_status(
+    app_handle: Option<&AppHandle>,
+    instance_id: Option<&str>
+) -> Vec<HashMap<String, String>> {
+    let run_state = app_handle.and_then(|app| {
+        let maa_state = app.try_state::<Arc<crate::commands::MaaState>>()?;
+        let instance_id = instance_id?;
+        let instances = maa_state.instances.lock().ok()?;
+        let instance = instances.get(instance_id)?;
+        Some(instance.taskRunState?)
+    });
+    return Vec<HashMap<String, String>> = run_state.pending_task_ids
+        .iter()
+        .filter_map(|&maa_task_id| {
+            if let Some(selected_task_id) = state.mappings.get(&maa_task_id) {
+                if let Some(status) = state.statuses.get(selected_task_id) {
+                    let mut map = HashMap::new();
+                    map.insert(selected_task_id.clone(), status.clone());
+                    Some(map)
+                } else {
+                    warn!("[MXU] instance status: selected_task_id '{}' -> statuses 'None'", selected_task_id);
+                    None
+                }
+            } else {
+                warn!("[MXU] instance status: maa_task_id '{}' -> mappings 'None'", maa_task_id);
+                None
+            }
+        })
+        .collect();
+}
+
 // ============================================================================
 // MXU_WEBHOOK Custom Action
 // ============================================================================
@@ -319,7 +350,26 @@ const MXU_WEBHOOK_ACTION: &str = "MXU_WEBHOOK_ACTION";
 fn mxu_webhook_action_fn(
     _ctx: &maa_framework::context::Context,
     args: &maa_framework::custom::ActionArgs,
+    app_handle: Option<&AppHandle>,
+    instance_id: Option<&str>,
 ) -> bool {
+    let status = get_instance_status(app_handle, instance_id)
+    let minimized = match serde_json::to_string(&status) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("[MXU_WEBHOOK] Failed to parse param JSON: {}", e);
+            return "[]";
+        }
+    }
+    let pretty = match serde_json::to_string_pretty(&status) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("[MXU_WEBHOOK] Failed to parse param JSON: {}", e);
+            return "[]";
+        }
+    }
+    info!("[MXU_WEBHOOK] Received instance status: {}", minimized);
+
     let param_str = args.param;
     info!("[MXU_WEBHOOK] Received param: {}", param_str);
 
@@ -338,8 +388,13 @@ fn mxu_webhook_action_fn(
             return false;
         }
     };
+    let body = match json.get("body").and_then(|v| v.as_str()) {
+        Some(u) if !u.trim().is_empty() => u.to_string(),
+        _ => { return "" }
+    };
+    body = body.replace("{{STATUS}}", &pretty)
 
-    info!("[MXU_WEBHOOK] Sending GET request to: {}", url);
+    info!("[MXU_WEBHOOK] Sending request to: {}", url);
 
     let client = match reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
@@ -352,7 +407,8 @@ fn mxu_webhook_action_fn(
         }
     };
 
-    match client.get(&url).send() {
+    let req = if body == "" { client.get(&url) } else { client.post(&url).body(&body) };
+    match req.send() {
         Ok(resp) => {
             let status = resp.status();
             info!("[MXU_WEBHOOK] Response status: {}", status);
@@ -879,9 +935,56 @@ pub fn register_all_mxu_actions(
     reg_action!(MXU_SLEEP_ACTION, mxu_sleep_action_fn);
     reg_action!(MXU_WAITUNTIL_ACTION, mxu_waituntil_action_fn);
     reg_action!(MXU_LAUNCH_ACTION, mxu_launch_action_fn);
-    reg_action!(MXU_WEBHOOK_ACTION, mxu_webhook_action_fn);
     reg_action!(MXU_NOTIFY_ACTION, mxu_notify_action_fn);
     reg_action!(MXU_POWER_ACTION, mxu_power_action_fn);
+
+    // webhook
+
+    let webhook_app_handle = app_handle.clone();
+    let webhook_instance_id = instance_id.to_string();
+    let webhook_wrapper = move |ctx: &maa_framework::context::Context,
+                                args: &maa_framework::custom::ActionArgs|
+        -> bool {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            mxu_webhook_action_fn(
+                ctx,
+                args,
+                Some(&webhook_app_handle),
+                Some(&webhook_instance_id),
+            )
+        }))
+        .unwrap_or_else(|e| {
+            let msg = if let Some(s) = e.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic payload".to_string()
+            };
+            log::error!("[MXU] Custom action {} panicked: {}", MXU_WEBHOOK_ACTION, msg);
+            false
+        })
+    };
+
+    resource.register_custom_action(
+        MXU_WEBHOOK_ACTION,
+        Box::new(FnAction::new(webhook_wrapper)),
+    )?;
+
+    if let Err(e) = resource.register_custom_action(
+        MXU_WEBHOOK_ACTION,
+        Box::new(FnAction::new(webhook_wrapper)),
+    ) {
+        warn!("[MXU] Failed to register {}: {:?}", MXU_WEBHOOK_ACTION, e);
+        failed_count += 1;
+    } else {
+        info!(
+            "[MXU] Custom action {} registered successfully",
+            MXU_WEBHOOK_ACTION
+        );
+    }
+
+    // kill process
 
     let killproc_app_handle = app_handle.clone();
     let killproc_instance_id = instance_id.to_string();

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -170,6 +170,8 @@ export default {
       optionLabel: 'Request Settings',
       urlLabel: 'Request URL',
       urlPlaceholder: 'Enter full URL (e.g. https://example.com/webhook?key=xxx)',
+      bodyLabel: 'Request Body',
+      bodyPlaceholder: 'If empty, use GET. If not empty, use POST + text/plain. You can use the template variable {{STATUS}} to embed the execution status (JSON array).'
     },
     killProc: {
       label: '⛔ Kill Process',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -168,6 +168,8 @@ export default {
       optionLabel: 'リクエスト設定',
       urlLabel: 'リクエストURL',
       urlPlaceholder: '完全なURLを入力（例：https://example.com/webhook?key=xxx）',
+      bodyLabel: 'リクエストボディ',
+      bodyPlaceholder: '空の場合は GET です。空でない場合は POST + text/plain です。テンプレート変数 {{STATUS}} を使用して、実行ステータス（JSON 配列）を埋め込むことができます。'
     },
     killProc: {
       label: '⛔ プロセス終了',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -167,6 +167,8 @@ export default {
       optionLabel: '요청 설정',
       urlLabel: '요청 URL',
       urlPlaceholder: '전체 URL을 입력하세요 (예: https://example.com/webhook?key=xxx)',
+      bodyLabel: '요청 본문',
+      bodyPlaceholder: '비어 있으면 GET입니다. 비어 있지 않으면 POST + text/plain입니다. 템플릿 변수 {{STATUS}}를 사용하여 실행 상태(JSON 배열)를 삽입할 수 있습니다.'
     },
     killProc: {
       label: '⛔ 프로세스 종료',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -164,6 +164,8 @@ export default {
       optionLabel: '请求设置',
       urlLabel: '请求地址',
       urlPlaceholder: '输入完整的 URL（如 https://example.com/webhook?key=xxx）',
+      bodyLabel: '请求体',
+      bodyPlaceholder: '若为空，则 GET 。若非空，则 POST + text/plain。可以使用模板变量 {{STATUS}} 嵌入执行状态（JSON 数组）。'
     },
     killProc: {
       label: '⛔ 结束进程',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -164,6 +164,8 @@ export default {
       optionLabel: '請求設定',
       urlLabel: '請求地址',
       urlPlaceholder: '輸入完整的 URL（如 https://example.com/webhook?key=xxx）',
+      bodyLabel: '請求本體',
+      bodyPlaceholder: '若為空，則 GET。若非空，則 POST + text/plain。可以使用模板變數 {{STATUS}} 嵌入執行狀態（JSON 陣列）。'
     },
     killProc: {
       label: '⛔ 結束程序',

--- a/src/types/specialTasks.ts
+++ b/src/types/specialTasks.ts
@@ -326,11 +326,19 @@ const MXU_WEBHOOK_OPTION_DEF_INTERNAL: InputOption = {
       pipeline_type: 'string',
       placeholder: 'specialTask.webhook.urlPlaceholder',
     },
+    {
+      name: 'body',
+      label: 'specialTask.webhook.bodyLabel',
+      default: '',
+      pipeline_type: 'string',
+      placeholder: 'specialTask.webhook.bodyPlaceholder',
+    },
   ],
   pipeline_override: {
     [MXU_WEBHOOK_ENTRY]: {
       custom_action_param: {
         url: '{url}',
+        body: '{body}',
       },
     },
   },


### PR DESCRIPTION
## Summary by Sourcery

添加对发送 MXU webhook 请求的支持，可选携带 POST 请求体，其中可以包含已序列化的实例状态，并使用 app handle 和实例 ID 注册 webhook 自定义动作。

新功能：
- 允许 MXU webhook 特殊任务定义一个可选的请求体字段，用于控制将 webhook 作为 GET 还是 POST 发送，并且可以包含模板化的状态负载。

增强：
- 将实例执行状态暴露给 MXU webhook 动作，使其可以被序列化为 JSON 并注入到 webhook 请求体中。
- 在 app handle 和实例 ID 上下文中包装 MXU webhook 自定义动作注册过程，包括 panic 安全处理和注册日志记录。

文档：
- 扩展所有受支持语言中的 webhook 任务本地化字符串，以记录新的请求体选项以及 {{STATUS}} 模板的用法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for sending MXU webhook requests with optional POST bodies that can include serialized instance status, and register the webhook custom action using the app handle and instance ID.

New Features:
- Allow MXU webhook special tasks to define an optional request body field that controls whether the webhook is sent as GET or POST and can include a templated status payload.

Enhancements:
- Expose instance execution status to the MXU webhook action so it can be serialized to JSON and injected into the webhook request body.
- Wrap MXU webhook custom action registration with app handle and instance ID context, including panic safety and registration logging.

Documentation:
- Extend webhook task localization strings in all supported languages to document the new request body option and {{STATUS}} template usage.

</details>