### PR TITLE
fix: 前置程序后所有控制器类型统一等待设备就绪并重试连接

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -334,12 +334,12 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
 
       try {
         let needsReconnect = false;
+        let shouldDelayAfterAdbConnected = false;
 
         // 收集所有启用且有程序路径的前置程序，按列表顺序执行
         const allPreActions = (targetInstance.preActions ?? []).filter(
           (a) => a.enabled && a.program.trim(),
         );
-        let hasNonWaitForExit = false;
         let preActionControlStarted = false;
 
         if (allPreActions.length > 0) {
@@ -393,13 +393,11 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                 });
               }
 
-              if (!(preAction.waitForExit ?? true)) {
-                hasNonWaitForExit = true;
-              }
             }
 
-            // 所有前置程序执行完毕后，如果有任何非等待退出的动作，则等待设备/窗口就绪
-            if (hasNonWaitForExit && controller) {
+            // 所有前置程序执行完毕后，等待设备/窗口就绪再连接
+            const shouldWaitAfterPreActions = !!controller;
+            if (shouldWaitAfterPreActions && controller) {
               const controllerType = controller.type;
               const isWindowType = controllerType === 'Win32' || controllerType === 'Gamepad';
               log.info(`实例 ${targetInstance.name}: 等待${isWindowType ? '窗口' : '设备'}就绪...`);
@@ -519,17 +517,17 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
                   }
                 }
 
-                const delaySec = useAppStore.getState().preActionConnectDelaySec ?? 5;
-                if (delaySec > 0) {
-                  log.info(`实例 ${targetInstance.name}: 等待 ${delaySec} 秒后再连接...`);
-                  addLog(targetId, {
-                    type: 'info',
-                    message: t('action.preActionConnectDelay', { seconds: delaySec }),
-                  });
-                  await waitWithStopCheck(delaySec * 1000, targetId);
-                }
-
                 needsReconnect = true;
+                // 设备/窗口已就绪，先等待稳定再连接
+                const settleSec = useAppStore.getState().preActionConnectDelaySec ?? 5;
+                if (settleSec > 0) {
+                  log.info(
+                    `实例 ${targetInstance.name}: ${isWindowType ? '窗口' : '设备'}已就绪，等待 ${settleSec} 秒稳定后连接...`,
+                  );
+                  await waitWithStopCheck(settleSec * 1000, targetId);
+                }
+                // 连接成功后再等待，避免”连接前固定等待”导致时序不稳定
+                shouldDelayAfterAdbConnected = true;
               } else {
                 log.warn(`实例 ${targetInstance.name}: 等待${isWindowType ? '窗口' : '设备'}超时`);
                 addLog(targetId, {
@@ -783,128 +781,155 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
 
           onPhaseChange?.('connecting');
 
-          // 提前注册回调收集器，await 完成后再发起连接，避免竞态
-          const collectedCallbacks: Array<{ message: string; details: { ctrl_id?: number } }> = [];
-          const unsubscribe = await maaService.onCallback((message, details) => {
-            if (
-              message === 'Controller.Action.Succeeded' ||
-              message === 'Controller.Action.Failed'
-            ) {
-              collectedCallbacks.push({ message, details });
-            }
-          });
+          const maxRetries = 3;
+          let connectResult = false;
 
-          let ctrlId: number;
-          try {
-            ctrlId = await maaService.connectController(targetId, config);
-          } catch (err) {
-            unsubscribe();
-            throw err;
-          }
-
-          // 注册 ctrl_id 与设备名/类型的映射
-          registerCtrlIdName(ctrlId, deviceName, targetType);
-
-          // 等待连接完成（同时监听 maa-callback 和 state-changed 两条路径）
-          const connectResult = await new Promise<boolean>((resolve) => {
-            let resolved = false;
-
-            const handleSuccess = () => {
-              if (resolved) return;
-              resolved = true;
-              clearTimeout(timeout);
-              unsubscribe();
-              unlistenCb?.();
-              unlistenState?.();
-              setInstanceConnectionStatus(targetId, 'Connected');
-              resolve(true);
-            };
-
-            const handleFailure = () => {
-              if (resolved) return;
-              resolved = true;
-              clearTimeout(timeout);
-              unsubscribe();
-              unlistenCb?.();
-              unlistenState?.();
-              resolve(false);
-            };
-
-            const timeout = setTimeout(() => {
-              if (!resolved) {
-                log.warn(`实例 ${targetInstance.name}: 连接超时`);
-                handleFailure();
-              }
-            }, 30000);
-
-            // 路径 1：继续监听新的 maa-callback（Controller.Action.Succeeded/Failed）
-            let unlistenCb: (() => void) | undefined;
-            // 路径 2：监听 state-changed（兜底：后端已广播 connected 但 Action.Succeeded 可能因竞态丢失）
-            // Tauri 桌面端走 app.emit() → listen()，WebSocket 端走 wsService
-            let unlistenState: (() => void) | undefined;
-
-            // 检查已收集的回调（注册监听器在 connectController 之前已完成）
-            const match = collectedCallbacks.find((cb) => cb.details.ctrl_id === ctrlId);
-            if (match) {
-              if (match.message === 'Controller.Action.Succeeded') {
-                handleSuccess();
-              } else {
-                handleFailure();
-              }
-              return;
+          for (let retry = 0; retry < maxRetries && !connectResult; retry++) {
+            if (retry > 0) {
+              throwIfPreActionStopped(targetId);
+              log.info(`实例 ${targetInstance.name}: 连接失败，第 ${retry} 次重试...`);
+              addLog(targetId, {
+                type: 'info',
+                message: t('taskList.autoConnect.retryConnect', { attempt: retry + 1 }),
+              });
+              await waitWithStopCheck(2000, targetId);
             }
 
-            maaService
-              .onCallback((message, details) => {
+            // 提前注册回调收集器，await 完成后再发起连接，避免竞态
+            const collectedCallbacks: Array<{ message: string; details: { ctrl_id?: number } }> = [];
+            const unsubscribe = await maaService.onCallback((message, details) => {
+              if (
+                message === 'Controller.Action.Succeeded' ||
+                message === 'Controller.Action.Failed'
+              ) {
+                collectedCallbacks.push({ message, details });
+              }
+            });
+
+            let ctrlId: number;
+            try {
+              ctrlId = await maaService.connectController(targetId, config);
+            } catch (err) {
+              unsubscribe();
+              throw err;
+            }
+
+            // 注册 ctrl_id 与设备名/类型的映射
+            registerCtrlIdName(ctrlId, deviceName, targetType);
+
+            // 等待连接完成（同时监听 maa-callback 和 state-changed 两条路径）
+            connectResult = await new Promise<boolean>((resolve) => {
+              let resolved = false;
+
+              const handleSuccess = () => {
                 if (resolved) return;
-                if (details.ctrl_id !== ctrlId) return;
-                if (message === 'Controller.Action.Succeeded') {
-                  handleSuccess();
-                } else if (message === 'Controller.Action.Failed') {
+                resolved = true;
+                clearTimeout(timeout);
+                unsubscribe();
+                unlistenCb?.();
+                unlistenState?.();
+                setInstanceConnectionStatus(targetId, 'Connected');
+                resolve(true);
+              };
+
+              const handleFailure = () => {
+                if (resolved) return;
+                resolved = true;
+                clearTimeout(timeout);
+                unsubscribe();
+                unlistenCb?.();
+                unlistenState?.();
+                resolve(false);
+              };
+
+              const timeout = setTimeout(() => {
+                if (!resolved) {
+                  log.warn(`实例 ${targetInstance.name}: 连接超时`);
                   handleFailure();
                 }
-              })
-              .then((cb) => {
-                if (!resolved) {
-                  unlistenCb = cb;
-                } else {
-                  cb();
-                }
-              })
-              .catch((err) => {
-                log.error(`实例 ${targetInstance.name}: 注册 maa-callback 监听失败:`, err);
-                handleFailure();
-              });
-            const handleStateChanged = (instanceId: string, kind: string) => {
-              if (resolved) return;
-              if (instanceId === targetId && kind === 'connected') {
-                log.info(`实例 ${targetInstance.name}: 通过 state-changed 兜底判定连接成功`);
-                handleSuccess();
-              }
-            };
+              }, 30000);
 
-            if (isTauri()) {
-              import('@tauri-apps/api/event')
-                .then(({ listen }) =>
-                  listen<{ instance_id: string; kind: string }>('state-changed', (event) =>
-                    handleStateChanged(event.payload.instance_id, event.payload.kind),
-                  ),
-                )
-                .then((dispose) => {
-                  if (resolved) dispose();
-                  else unlistenState = dispose;
+              // 路径 1：继续监听新的 maa-callback（Controller.Action.Succeeded/Failed）
+              let unlistenCb: (() => void) | undefined;
+              // 路径 2：监听 state-changed（兜底：后端已广播 connected 但 Action.Succeeded 可能因竞态丢失）
+              // Tauri 桌面端走 app.emit() → listen()，WebSocket 端走 wsService
+              let unlistenState: (() => void) | undefined;
+
+              // 检查已收集的回调（注册监听器在 connectController 之前已完成）
+              const match = collectedCallbacks.find((cb) => cb.details.ctrl_id === ctrlId);
+              if (match) {
+                if (match.message === 'Controller.Action.Succeeded') {
+                  handleSuccess();
+                } else {
+                  handleFailure();
+                }
+                return;
+              }
+
+              maaService
+                .onCallback((message, details) => {
+                  if (resolved) return;
+                  if (details.ctrl_id !== ctrlId) return;
+                  if (message === 'Controller.Action.Succeeded') {
+                    handleSuccess();
+                  } else if (message === 'Controller.Action.Failed') {
+                    handleFailure();
+                  }
+                })
+                .then((cb) => {
+                  if (!resolved) {
+                    unlistenCb = cb;
+                  } else {
+                    cb();
+                  }
                 })
                 .catch((err) => {
-                  log.warn('注册 state-changed 监听失败:', err);
+                  log.error(`实例 ${targetInstance.name}: 注册 maa-callback 监听失败:`, err);
+                  handleFailure();
                 });
-            } else {
-              unlistenState = onStateChanged(handleStateChanged);
-            }
-          });
+              const handleStateChanged = (instanceId: string, kind: string) => {
+                if (resolved) return;
+                if (instanceId === targetId && kind === 'connected') {
+                  log.info(`实例 ${targetInstance.name}: 通过 state-changed 兜底判定连接成功`);
+                  handleSuccess();
+                }
+              };
+
+              if (isTauri()) {
+                import('@tauri-apps/api/event')
+                  .then(({ listen }) =>
+                    listen<{ instance_id: string; kind: string }>('state-changed', (event) =>
+                      handleStateChanged(event.payload.instance_id, event.payload.kind),
+                    ),
+                  )
+                  .then((dispose) => {
+                    if (resolved) dispose();
+                    else unlistenState = dispose;
+                  })
+                  .catch((err) => {
+                    log.warn('注册 state-changed 监听失败:', err);
+                  });
+              } else {
+                unlistenState = onStateChanged(handleStateChanged);
+              }
+            });
+          }
 
           if (!connectResult) {
-            log.warn(`实例 ${targetInstance.name}: 连接设备失败`);
+            log.warn(`实例 ${targetInstance.name}: 连接设备失败（已重试 ${maxRetries} 次）`);
             return false;
+          }
+
+          if (shouldDelayAfterAdbConnected) {
+            const delaySec = useAppStore.getState().preActionConnectDelaySec ?? 5;
+            if (delaySec > 0) {
+              log.info(`实例 ${targetInstance.name}: 连接成功，等待 ${delaySec} 秒后继续...`);
+              addLog(targetId, {
+                type: 'info',
+                message: t('action.preActionConnectDelay', { seconds: delaySec }),
+              });
+              await waitWithStopCheck(delaySec * 1000, targetId);
+            }
           }
         }
 

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -223,6 +223,7 @@ export default {
       noDeviceFound: 'No devices found',
       noWindowFound: 'No windows found',
       connectFailed: 'Auto connect failed',
+      retryConnect: 'Connection failed, retry {{attempt}}...',
       autoSelectedDevice:
         'No device was previously selected. Automatically matched "{{name}}". To change, select manually in Connection Settings — your choice will be remembered next time.',
       autoSelectedWindow:

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -217,6 +217,7 @@ export default {
       noDeviceFound: 'デバイスが見つかりませんでした',
       noWindowFound: 'ウィンドウが見つかりませんでした',
       connectFailed: '自動接続に失敗しました',
+      retryConnect: '接続失敗、リトライ {{attempt}}...',
       autoSelectedDevice:
         'デバイスが未設定のため、「{{name}}」を自動的に選択しました。変更する場合は接続設定で手動選択してください。次回以降は選択内容が保存されます。',
       autoSelectedWindow:

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -216,6 +216,7 @@ export default {
       noDeviceFound: '기기를 찾을 수 없습니다',
       noWindowFound: '창을 찾을 수 없습니다',
       connectFailed: '자동 연결에 실패했습니다',
+      retryConnect: '연결 실패, {{attempt}}번째 재시도...',
       autoSelectedDevice:
         '기기가 설정되지 않아 「{{name}}」을(를) 자동으로 선택했습니다. 변경하려면 연결 설정에서 수동으로 선택하세요. 다음 번에는 선택 내용이 저장됩니다.',
       autoSelectedWindow:

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -216,6 +216,7 @@ export default {
       noDeviceFound: '未搜索到任何设备',
       noWindowFound: '未搜索到任何窗口',
       connectFailed: '自动连接失败',
+      retryConnect: '连接失败，第 {{attempt}} 次重试...',
       autoSelectedDevice:
         '尚未手动选择过设备，已自动匹配到「{{name}}」。如需更换，请在连接设置中手动选择，下次将记住您的选择。',
       autoSelectedWindow:

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -212,6 +212,7 @@ export default {
       noDeviceFound: '未搜尋到任何裝置',
       noWindowFound: '未搜尋到任何視窗',
       connectFailed: '自動連接失敗',
+      retryConnect: '連接失敗，第 {{attempt}} 次重試...',
       autoSelectedDevice:
         '尚未手動選擇過裝置，已自動匹配到「{{name}}」。如需更換，請在連接設定中手動選擇，下次將記住您的選擇。',
       autoSelectedWindow:


### PR DESCRIPTION
fix https://github.com/MistEO/MXU/issues/218

- 所有控制器类型（Adb/Win32/WlRoots/Gamepad/PlayCover）前置程序后均等待设备/窗口就绪
- 设备就绪后先稳定等待再发起连接，避免模拟器未完全启动
- 连接失败时自动重试（最多 3 次，间隔 2 秒）
- 连接成功后再等待 preActionConnectDelaySec 秒，让应用完成启动

## Summary by Sourcery

确保控制器在连接之前等待设备或窗口就绪，引入控制器连接的重试逻辑，并调整连接延迟以实现更稳定的启动顺序。

New Features:
- 引入带有限定尝试次数和延迟的控制器连接自动重试机制。
- 添加本地化的用户可见消息，用于提示控制器重新连接尝试。

Enhancements:
- 在建立控制器连接之前，始终等待设备或窗口就绪，并在预操作之后加入稳定延迟。
- 将现有的预操作连接延迟在需要时延后至成功连接之后执行，以改善时序稳定性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure controllers wait for devices or windows to become ready before connecting, add retry logic for controller connections, and adjust connection delays for more stable startup sequencing.

New Features:
- Introduce automatic retry for controller connections with limited attempts and delays.
- Add localized user-facing messages indicating controller reconnection attempts.

Enhancements:
- Always wait for device or window readiness and a stabilization delay after pre-actions before establishing controller connections.
- Defer the existing pre-action connection delay to run after a successful connection when needed to improve timing stability.

</details>