### PR TITLE
ci: update actions version and remove sccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,9 +77,6 @@ jobs:
         with:
           targets: ${{ matrix.arch == 'x86_64' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -103,10 +100,6 @@ jobs:
           echo "Updated version to $VERSION"
 
       - name: Build Tauri app
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
         run: pnpm tauri build --no-bundle --target ${{ matrix.arch == 'x86_64' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}
 
       - name: Prepare artifacts
@@ -155,9 +148,6 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -180,10 +170,6 @@ jobs:
           echo "Updated version to $VERSION"
 
       - name: Build Tauri app
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
         run: pnpm tauri build --no-bundle
 
       - name: Prepare artifacts
@@ -227,9 +213,6 @@ jobs:
         with:
           targets: ${{ matrix.arch == 'x86_64' && 'x86_64-apple-darwin' || 'aarch64-apple-darwin' }}
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -252,10 +235,6 @@ jobs:
           echo "Updated version to $VERSION"
 
       - name: Build Tauri app
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
         run: pnpm tauri build --no-bundle --target ${{ matrix.arch == 'x86_64' && 'x86_64-apple-darwin' || 'aarch64-apple-darwin' }}
 
       - name: Prepare artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       is-release: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get version
         id: version
@@ -61,13 +61,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "pnpm"
@@ -120,7 +120,7 @@ jobs:
           ls -la install/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: MXU-win-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Linux dependencies
         run: |
@@ -144,10 +144,10 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "pnpm"
@@ -195,7 +195,7 @@ jobs:
           tar -czvf MXU-linux-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}.tar.gz -C install .
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: MXU-linux-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}
@@ -211,13 +211,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "pnpm"
@@ -228,7 +228,7 @@ jobs:
           targets: ${{ matrix.arch == 'x86_64' && 'x86_64-apple-darwin' || 'aarch64-apple-darwin' }}
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -267,7 +267,7 @@ jobs:
           tar -czvf MXU-macos-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}.tar.gz -C install .
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: MXU-macos-${{ matrix.arch }}-${{ needs.meta.outputs.tag }}
@@ -281,7 +281,7 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -304,7 +304,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           submodules: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "pnpm"


### PR DESCRIPTION
## 概要

此 PR 对 CI 进行了调整：

1. 更新部分 v4 Actions 到 v6，因为 2026 年 6 月份 GitHub 官方将弃用对应的环境。
2. 删除 sccache 步骤，因为该缓存从未被命中过，属于无效缓存步。

## Summary by Sourcery

更新 CI 工作流，以使用更新版本的 GitHub Actions，并简化构建流水线。

Build:
- 在构建工作流中，将 `checkout`、`setup-node`、`pnpm`、`upload-artifact` 和 `download-artifact` actions 从 v4 提升到 v6。
- 从 Windows、Linux 和 macOS 的构建任务中移除与 sccache 相关的步骤和环境变量，改为依赖现有的 Rust 缓存。

CI:
- 刷新 CI 配置，使其与最新的 GitHub Actions 生态保持一致，并移除未使用的编译器缓存集成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflows to use newer GitHub Actions versions and simplify the build pipeline.

Build:
- Bump checkout, setup-node, pnpm, upload-artifact, and download-artifact actions from v4 to v6 in the build workflow.
- Remove sccache-related steps and environment variables from Windows, Linux, and macOS build jobs, relying on the existing Rust cache instead.

CI:
- Refresh CI configuration to align with the latest GitHub Actions ecosystem and drop unused compiler cache integration.

</details>