### PR TITLE
perf: 优化日志UI的内存占用和性能表现

### DIFF
--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -23,6 +23,7 @@ use super::types::{AgentConfig, MaaState, TaskConfig};
 use super::utils::{emit_callback_event, get_logs_dir, handle_task_callback, normalize_path};
 use regex::Regex;
 use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
 /// Agent 输出事件载荷
 #[derive(Clone, serde::Serialize)]
@@ -30,6 +31,135 @@ pub struct AgentOutputEvent {
     pub instance_id: String,
     pub stream: String,
     pub line: String,
+}
+
+struct AgentOutputBatchState {
+    lines: Vec<String>,
+    first_stream: Option<String>,
+    has_mixed_streams: bool,
+    flush_deadline: Option<Instant>,
+    flush_running: bool,
+}
+
+struct AgentOutputBatcher {
+    app: tauri::AppHandle,
+    instance_id: String,
+    state: Mutex<AgentOutputBatchState>,
+}
+
+impl AgentOutputBatcher {
+    fn new(app: tauri::AppHandle, instance_id: String) -> Arc<Self> {
+        Arc::new(Self {
+            app,
+            instance_id,
+            state: Mutex::new(AgentOutputBatchState {
+                lines: Vec::new(),
+                first_stream: None,
+                has_mixed_streams: false,
+                flush_deadline: None,
+                flush_running: false,
+            }),
+        })
+    }
+
+    fn enqueue(self: &Arc<Self>, stream: &str, line: &str) {
+        let should_spawn = {
+            let mut state = self.state.lock().unwrap();
+            state.lines.push(line.to_string());
+            match state.first_stream.as_ref() {
+                None => state.first_stream = Some(stream.to_string()),
+                Some(existing) if existing != stream => state.has_mixed_streams = true,
+                _ => {}
+            }
+            state.flush_deadline = Some(Instant::now() + Duration::from_millis(1));
+
+            if state.flush_running {
+                false
+            } else {
+                state.flush_running = true;
+                true
+            }
+        };
+
+        if should_spawn {
+            let batcher = Arc::clone(self);
+            thread::spawn(move || batcher.flush_loop());
+        }
+    }
+
+    fn flush_loop(self: Arc<Self>) {
+        loop {
+            let deadline = {
+                let state = self.state.lock().unwrap();
+                match state.flush_deadline {
+                    Some(deadline) => deadline,
+                    None => {
+                        drop(state);
+                        self.finish_flush_loop();
+                        return;
+                    }
+                }
+            };
+
+            let now = Instant::now();
+            if deadline > now {
+                thread::sleep(deadline.duration_since(now));
+                continue;
+            }
+
+            let payload = {
+                let mut state = self.state.lock().unwrap();
+                match state.flush_deadline {
+                    Some(current_deadline) if Instant::now() >= current_deadline => {
+                        if state.lines.is_empty() {
+                            state.flush_deadline = None;
+                            state.flush_running = false;
+                            None
+                        } else {
+                            let merged_line = state.lines.join("\n");
+                            state.lines.clear();
+                            let stream = if state.has_mixed_streams {
+                                "mixed".to_string()
+                            } else {
+                                state
+                                    .first_stream
+                                    .take()
+                                    .unwrap_or_else(|| "stdout".to_string())
+                            };
+                            state.has_mixed_streams = false;
+                            state.flush_deadline = None;
+                            Some((stream, merged_line))
+                        }
+                    }
+                    Some(_) => continue,
+                    None => {
+                        state.flush_running = false;
+                        None
+                    }
+                }
+            };
+
+            match payload {
+                Some((stream, merged_line)) => {
+                    emit_agent_output(&self.app, &self.instance_id, &stream, &merged_line);
+                }
+                None => {
+                    let should_exit = {
+                        let state = self.state.lock().unwrap();
+                        !state.flush_running
+                    };
+                    if should_exit {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    fn finish_flush_loop(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.flush_running = false;
+    }
 }
 
 /// 发送 Agent 输出事件（Tauri WebView + WebSocket 浏览器客户端）
@@ -251,13 +381,13 @@ async fn start_single_agent(
         let log_filename = format!("mxu-agent-{}-{}.log", agent_index, pid);
         let agent_log_path = Arc::new(get_logs_dir().join(&log_filename));
         let log_file: Arc<Mutex<Option<std::fs::File>>> = Arc::new(Mutex::new(None));
+        let output_batcher = AgentOutputBatcher::new(app.clone(), instance_id.clone());
 
         // 在单独线程中读取 stdout
         if let Some(stdout) = child.stdout.take() {
             let lf = log_file.clone();
             let lf_path = agent_log_path.clone();
-            let app_handle = app.clone();
-            let inst_id = instance_id.clone();
+            let batcher = output_batcher.clone();
             thread::spawn(move || {
                 let mut reader = BufReader::new(stdout);
                 let mut buffer = Vec::new();
@@ -282,7 +412,7 @@ async fn start_single_agent(
                                 }
                             }
                             info!(target: "agent", "[agent#{}][stdout] {}", agent_index, clean_line);
-                            emit_agent_output(&app_handle, &inst_id, "stdout", clean_line);
+                            batcher.enqueue("stdout", clean_line);
                         }
                         Err(_) => break,
                     }
@@ -294,8 +424,7 @@ async fn start_single_agent(
         if let Some(stderr) = child.stderr.take() {
             let lf = log_file.clone();
             let lf_path = agent_log_path.clone();
-            let app_handle = app.clone();
-            let inst_id = instance_id.clone();
+            let batcher = output_batcher.clone();
             thread::spawn(move || {
                 let mut reader = BufReader::new(stderr);
                 let mut buffer = Vec::new();
@@ -320,7 +449,7 @@ async fn start_single_agent(
                                 }
                             }
                             warn!(target: "agent", "[agent#{}][stderr] {}", agent_index, clean_line);
-                            emit_agent_output(&app_handle, &inst_id, "stderr", clean_line);
+                            batcher.enqueue("stderr", clean_line);
                         }
                         Err(_) => break,
                     }

--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -440,6 +440,10 @@ pub fn destroy_instance_impl(state: &Arc<MaaState>, instance_id: &str) -> Result
         }
     }
 
+    if let Ok(mut log_buffer) = state.log_buffer.lock() {
+        log_buffer.clear_instance(instance_id);
+    }
+
     Ok(())
 }
 

--- a/src/components/ConnectionPanel.tsx
+++ b/src/components/ConnectionPanel.tsx
@@ -508,7 +508,7 @@ export function ConnectionPanel() {
     const ctrlId = await maaService.connectController(instanceId, config);
 
     // 注册 ctrl_id 与设备/窗口名及类型的映射，用于日志显示
-    registerCtrlIdName(ctrlId, deviceName || '', targetType);
+    registerCtrlIdName(instanceId, ctrlId, deviceName || '', targetType);
 
     // 等待连接结果（先查缓存，没有则轮询等待）
     const result = await waitForCtrlResult(ctrlId);

--- a/src/components/DeviceSelector.tsx
+++ b/src/components/DeviceSelector.tsx
@@ -286,7 +286,7 @@ export function DeviceSelector({
         deviceName = playcoverAddress;
         targetType = 'device';
       }
-      registerCtrlIdName(ctrlId, deviceName, targetType);
+      registerCtrlIdName(instanceId, ctrlId, deviceName, targetType);
 
       // 记录等待中的 ctrl_id，后续由回调处理完成状态
       setPendingCtrlId(ctrlId);
@@ -356,7 +356,7 @@ export function DeviceSelector({
       const ctrlId = await maaService.connectController(instanceId, config);
 
       // 注册 ctrl_id 与设备名/类型的映射
-      registerCtrlIdName(ctrlId, device.name || device.address, 'device');
+      registerCtrlIdName(instanceId, ctrlId, device.name || device.address, 'device');
 
       // 记录等待中的 ctrl_id，后续由回调处理完成状态
       setPendingCtrlId(ctrlId);
@@ -407,7 +407,7 @@ export function DeviceSelector({
       const ctrlId = await maaService.connectController(instanceId, config);
 
       // 注册 ctrl_id 与窗口名/类型的映射
-      registerCtrlIdName(ctrlId, win.window_name || win.class_name, 'window');
+      registerCtrlIdName(instanceId, ctrlId, win.window_name || win.class_name, 'window');
 
       // 记录等待中的 ctrl_id，后续由回调处理完成状态
       setPendingCtrlId(ctrlId);
@@ -446,7 +446,7 @@ export function DeviceSelector({
       const ctrlId = await maaService.connectController(instanceId, config);
 
       // 注册 ctrl_id 与窗口名/类型的映射
-      registerCtrlIdName(ctrlId, socketPath, 'device');
+      registerCtrlIdName(instanceId, ctrlId, socketPath, 'device');
 
       // 记录等待中的 ctrl_id，后续由回调处理完成状态
       setPendingCtrlId(ctrlId);

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -35,6 +35,7 @@ export function LogsPanel() {
   const isMobile = useIsMobile();
   const logsContainerRef = useRef<HTMLDivElement>(null);
   const isFollowingTailRef = useRef(true);
+  const autoScrollFrameRef = useRef<number | null>(null);
   const [visibleLogLimit, setVisibleLogLimit] = useState(DEFAULT_VISIBLE_LOG_LIMIT);
   const [isAtTop, setIsAtTop] = useState(false);
   const [isExpandingLogs, setIsExpandingLogs] = useState(false);
@@ -63,9 +64,28 @@ export function LogsPanel() {
   }, [activeInstanceId]);
 
   useEffect(() => {
+    if (autoScrollFrameRef.current !== null) {
+      cancelAnimationFrame(autoScrollFrameRef.current);
+      autoScrollFrameRef.current = null;
+    }
+
     const el = logsContainerRef.current;
-    if (el && isFollowingTailRef.current) {
-      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    if (!el || !isFollowingTailRef.current) return;
+
+    autoScrollFrameRef.current = window.requestAnimationFrame(() => {
+      autoScrollFrameRef.current = null;
+      const target = logsContainerRef.current;
+      if (!target || !isFollowingTailRef.current) return;
+
+      // 只在一帧内合并为一次滚动，避免日志洪峰时反复重启动画导致抖动
+      target.scrollTo({ top: target.scrollHeight, behavior: 'smooth' });
+    });
+
+    return () => {
+      if (autoScrollFrameRef.current !== null) {
+        cancelAnimationFrame(autoScrollFrameRef.current);
+        autoScrollFrameRef.current = null;
+      }
     }
   }, [visibleLogs]);
 

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useRef, useEffect, useCallback, useState, useMemo } from 'react';
+import { Fragment, useRef, useEffect, useCallback, useState, useMemo, useLayoutEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Eraser, Copy, ChevronUp, ChevronDown, Archive } from 'lucide-react';
 import clsx from 'clsx';
@@ -20,6 +20,7 @@ import type { LogEntry } from '@/stores/types';
 
 const DEFAULT_VISIBLE_LOG_LIMIT = 500;
 const EXPANDED_LOG_LIMIT = 2000;
+const BOTTOM_FOLLOW_THRESHOLD_PX = 24;
 
 function formatLogTime(date: Date, locale?: string) {
   return date.toLocaleTimeString(locale || undefined, {
@@ -35,9 +36,6 @@ export function LogsPanel() {
   const isMobile = useIsMobile();
   const logsContainerRef = useRef<HTMLDivElement>(null);
   const isFollowingTailRef = useRef(true);
-  const autoScrollFrameRef = useRef<number | null>(null);
-  const autoScrollLockRef = useRef(false);
-  const autoScrollUnlockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [visibleLogLimit, setVisibleLogLimit] = useState(DEFAULT_VISIBLE_LOG_LIMIT);
   const [isAtTop, setIsAtTop] = useState(false);
   const [isExpandingLogs, setIsExpandingLogs] = useState(false);
@@ -63,68 +61,24 @@ export function LogsPanel() {
     setVisibleLogLimit(DEFAULT_VISIBLE_LOG_LIMIT);
     setIsAtTop(false);
     isFollowingTailRef.current = true;
-    autoScrollLockRef.current = false;
-    if (autoScrollUnlockTimerRef.current !== null) {
-      clearTimeout(autoScrollUnlockTimerRef.current);
-      autoScrollUnlockTimerRef.current = null;
-    }
   }, [activeInstanceId]);
 
-  useEffect(() => {
-    if (autoScrollFrameRef.current !== null) {
-      cancelAnimationFrame(autoScrollFrameRef.current);
-      autoScrollFrameRef.current = null;
-    }
-
+  useLayoutEffect(() => {
     const el = logsContainerRef.current;
     if (!el || !isFollowingTailRef.current) return;
 
-    autoScrollFrameRef.current = window.requestAnimationFrame(() => {
-      autoScrollFrameRef.current = null;
-      const target = logsContainerRef.current;
-      if (!target || !isFollowingTailRef.current) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom > BOTTOM_FOLLOW_THRESHOLD_PX) return;
 
-      autoScrollLockRef.current = true;
-      if (autoScrollUnlockTimerRef.current !== null) {
-        clearTimeout(autoScrollUnlockTimerRef.current);
-      }
-      autoScrollUnlockTimerRef.current = window.setTimeout(() => {
-        autoScrollLockRef.current = false;
-        autoScrollUnlockTimerRef.current = null;
-      }, 180);
-
-      // 只在一帧内合并为一次滚动，避免日志洪峰时反复重启动画导致抖动
-      target.scrollTo({ top: target.scrollHeight, behavior: 'smooth' });
-    });
-
-    return () => {
-      if (autoScrollFrameRef.current !== null) {
-        cancelAnimationFrame(autoScrollFrameRef.current);
-        autoScrollFrameRef.current = null;
-      }
-    }
-  }, [visibleLogs]);
-
-  useEffect(() => {
-    return () => {
-      if (autoScrollUnlockTimerRef.current !== null) {
-        clearTimeout(autoScrollUnlockTimerRef.current);
-        autoScrollUnlockTimerRef.current = null;
-      }
-      autoScrollLockRef.current = false;
-    };
-  }, []);
+    el.scrollTop = el.scrollHeight;
+  }, [visibleLogs, visibleLogLimit]);
 
   const handleLogsScroll = useCallback(() => {
-    if (autoScrollLockRef.current) {
-      return;
-    }
-
     const el = logsContainerRef.current;
     if (!el) return;
 
     const top = el.scrollTop <= 4;
-    const bottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 4;
+    const bottom = el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_FOLLOW_THRESHOLD_PX;
 
     setIsAtTop(top);
     isFollowingTailRef.current = bottom;

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Eraser, Copy, ChevronUp, ChevronDown, Archive } from 'lucide-react';
 import clsx from 'clsx';
@@ -11,6 +11,15 @@ import { ExportLogsModal } from './settings/ExportLogsModal';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { getCurrentLogFileName } from '@/utils/logger';
 import { clearPersistedRuntimeLogs } from '@/utils/runtimeLogPersistence';
+import { getAllLogsFromBackend } from '@/utils/logStdout';
+import {
+  loadPersistedRuntimeLogs,
+  mergeRuntimeLogs,
+} from '@/utils/runtimeLogPersistence';
+import type { LogEntry } from '@/stores/types';
+
+const DEFAULT_VISIBLE_LOG_LIMIT = 500;
+const EXPANDED_LOG_LIMIT = 2000;
 
 function formatLogTime(date: Date, locale?: string) {
   return date.toLocaleTimeString(locale || undefined, {
@@ -25,21 +34,51 @@ export function LogsPanel() {
   const { t, i18n } = useTranslation();
   const isMobile = useIsMobile();
   const logsContainerRef = useRef<HTMLDivElement>(null);
+  const isFollowingTailRef = useRef(true);
+  const [visibleLogLimit, setVisibleLogLimit] = useState(DEFAULT_VISIBLE_LOG_LIMIT);
+  const [isAtTop, setIsAtTop] = useState(false);
+  const [isExpandingLogs, setIsExpandingLogs] = useState(false);
 
-  const { sidePanelExpanded, toggleSidePanelExpanded, activeInstanceId, instanceLogs, clearLogs } =
-    useAppStore();
+  const {
+    sidePanelExpanded,
+    toggleSidePanelExpanded,
+    activeInstanceId,
+    instanceLogs,
+    clearLogs,
+    setMaxLogsPerInstance,
+  } = useAppStore();
   const { state: menuState, show: showMenu, hide: hideMenu } = useContextMenu();
   const { exportModal, handleExportLogs, closeExportModal, openExportedFile } = useExportLogs();
 
   // 获取当前实例的日志
   const logs = activeInstanceId ? instanceLogs[activeInstanceId] || [] : [];
+  const visibleLogs = useMemo(() => logs.slice(-visibleLogLimit), [logs, visibleLogLimit]);
+  const canShowMoreLogs =
+    visibleLogLimit === DEFAULT_VISIBLE_LOG_LIMIT && visibleLogs.length === DEFAULT_VISIBLE_LOG_LIMIT;
+
+  useEffect(() => {
+    setVisibleLogLimit(DEFAULT_VISIBLE_LOG_LIMIT);
+    setIsAtTop(false);
+    isFollowingTailRef.current = true;
+  }, [activeInstanceId]);
 
   useEffect(() => {
     const el = logsContainerRef.current;
-    if (el) {
+    if (el && isFollowingTailRef.current) {
       el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
     }
-  }, [logs]);
+  }, [visibleLogs]);
+
+  const handleLogsScroll = useCallback(() => {
+    const el = logsContainerRef.current;
+    if (!el) return;
+
+    const top = el.scrollTop <= 4;
+    const bottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 4;
+
+    setIsAtTop(top);
+    isFollowingTailRef.current = bottom;
+  }, []);
 
   const clearLogFiles = useCallback(async () => {
     if (!isTauri()) return;
@@ -61,11 +100,51 @@ export function LogsPanel() {
   }, [activeInstanceId, clearLogFiles, clearLogs]);
 
   const handleCopyAll = useCallback(() => {
-    const text = logs
+    const text = visibleLogs
       .map((log) => `[${log.timestamp.toLocaleTimeString()}] ${log.message}`)
       .join('\n');
     navigator.clipboard.writeText(text);
-  }, [logs]);
+  }, [visibleLogs]);
+
+  const handleShowMoreLogs = useCallback(() => {
+    if (isExpandingLogs) return;
+
+    const targetLimit = EXPANDED_LOG_LIMIT;
+    setIsExpandingLogs(true);
+
+    void (async () => {
+      try {
+        const backendLogs = await getAllLogsFromBackend();
+        const restoredBackendLogs: Record<string, LogEntry[]> = {};
+        for (const [instanceId, entries] of Object.entries(backendLogs || {})) {
+          restoredBackendLogs[instanceId] = entries.map((entry) => ({
+            id: entry.id,
+            timestamp: new Date(entry.timestamp),
+            type: entry.type as LogType,
+            message: entry.message,
+            html: entry.html,
+          }));
+        }
+
+        const store = useAppStore.getState();
+        const restoredPersistentLogs = loadPersistedRuntimeLogs(targetLimit);
+        const mergedLogs = mergeRuntimeLogs(
+          targetLimit,
+          store.instanceLogs,
+          restoredBackendLogs,
+          restoredPersistentLogs,
+        );
+
+        useAppStore.setState({ instanceLogs: mergedLogs });
+        setMaxLogsPerInstance(targetLimit);
+        setVisibleLogLimit(targetLimit);
+      } catch {
+        // Rehydration failed; keep the 500-line window and allow retry.
+      } finally {
+        setIsExpandingLogs(false);
+      }
+    })();
+  }, [isExpandingLogs, setMaxLogsPerInstance]);
 
   const getLogColor = (type: LogType) => {
     switch (type) {
@@ -223,15 +302,33 @@ export function LogsPanel() {
       <div
         ref={logsContainerRef}
         className="flex-1 min-h-0 overflow-y-auto p-2.5 font-mono text-[12px] leading-5 bg-bg-tertiary"
+        onScroll={handleLogsScroll}
         onContextMenu={handleContextMenu}
       >
-        {logs.length === 0 ? (
+        {visibleLogs.length === 0 ? (
           <div className="h-full flex items-center justify-center text-text-muted">
             {t('logs.noLogs')}
           </div>
         ) : (
           <>
-            {logs.map((log) =>
+            {canShowMoreLogs && isAtTop && (
+              <div className="flex justify-center py-3">
+                <button
+                  type="button"
+                  onClick={handleShowMoreLogs}
+                  disabled={isExpandingLogs}
+                  className={clsx(
+                    'px-4 py-2 rounded-full border border-border',
+                    'bg-bg-secondary text-text-primary shadow-sm',
+                    'hover:bg-bg-hover hover:border-accent/50 transition-colors',
+                    isExpandingLogs && 'opacity-60 cursor-not-allowed',
+                  )}
+                >
+                  {t('logs.showMoreLogs')}
+                </button>
+              </div>
+            )}
+            {visibleLogs.map((log) =>
               log.html ? (
                 // 富文本内容（focus 消息支持 Markdown/HTML）
                 <div

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -36,6 +36,8 @@ export function LogsPanel() {
   const logsContainerRef = useRef<HTMLDivElement>(null);
   const isFollowingTailRef = useRef(true);
   const autoScrollFrameRef = useRef<number | null>(null);
+  const autoScrollLockRef = useRef(false);
+  const autoScrollUnlockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [visibleLogLimit, setVisibleLogLimit] = useState(DEFAULT_VISIBLE_LOG_LIMIT);
   const [isAtTop, setIsAtTop] = useState(false);
   const [isExpandingLogs, setIsExpandingLogs] = useState(false);
@@ -61,6 +63,11 @@ export function LogsPanel() {
     setVisibleLogLimit(DEFAULT_VISIBLE_LOG_LIMIT);
     setIsAtTop(false);
     isFollowingTailRef.current = true;
+    autoScrollLockRef.current = false;
+    if (autoScrollUnlockTimerRef.current !== null) {
+      clearTimeout(autoScrollUnlockTimerRef.current);
+      autoScrollUnlockTimerRef.current = null;
+    }
   }, [activeInstanceId]);
 
   useEffect(() => {
@@ -77,6 +84,15 @@ export function LogsPanel() {
       const target = logsContainerRef.current;
       if (!target || !isFollowingTailRef.current) return;
 
+      autoScrollLockRef.current = true;
+      if (autoScrollUnlockTimerRef.current !== null) {
+        clearTimeout(autoScrollUnlockTimerRef.current);
+      }
+      autoScrollUnlockTimerRef.current = window.setTimeout(() => {
+        autoScrollLockRef.current = false;
+        autoScrollUnlockTimerRef.current = null;
+      }, 180);
+
       // 只在一帧内合并为一次滚动，避免日志洪峰时反复重启动画导致抖动
       target.scrollTo({ top: target.scrollHeight, behavior: 'smooth' });
     });
@@ -89,7 +105,21 @@ export function LogsPanel() {
     }
   }, [visibleLogs]);
 
+  useEffect(() => {
+    return () => {
+      if (autoScrollUnlockTimerRef.current !== null) {
+        clearTimeout(autoScrollUnlockTimerRef.current);
+        autoScrollUnlockTimerRef.current = null;
+      }
+      autoScrollLockRef.current = false;
+    };
+  }, []);
+
   const handleLogsScroll = useCallback(() => {
+    if (autoScrollLockRef.current) {
+      return;
+    }
+
     const el = logsContainerRef.current;
     if (!el) return;
 
@@ -267,7 +297,7 @@ export function LogsPanel() {
         )}
       >
         <span className="text-sm font-medium text-text-primary">{t('logs.title')}</span>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -321,7 +351,7 @@ export function LogsPanel() {
       {/* 日志内容 */}
       <div
         ref={logsContainerRef}
-        className="flex-1 min-h-0 overflow-y-auto p-2.5 font-mono text-[12px] leading-5 bg-bg-tertiary"
+        className="flex-1 min-h-0 overflow-y-auto p-2.5 font-mono text-[12px] leading-4 bg-bg-tertiary"
         onScroll={handleLogsScroll}
         onContextMenu={handleContextMenu}
       >
@@ -358,11 +388,11 @@ export function LogsPanel() {
                       getLogColor(log.type),
                     )}
                   >
-                    <span className="text-text-muted/90 w-[72px] flex-shrink-0 tabular-nums text-[11px] leading-5">
+                    <span className="text-text-muted/90 w-[64px] flex-shrink-0 tabular-nums text-[11px] leading-4">
                       {formatLogTime(log.timestamp, i18n.language)}
                     </span>
                     <span
-                      className="min-w-0 flex-1 break-words leading-5 focus-content"
+                      className="min-w-0 flex-1 break-words leading-4 focus-content"
                       dangerouslySetInnerHTML={{ __html: log.html }}
                     />
                   </div>
@@ -373,10 +403,10 @@ export function LogsPanel() {
                       getLogColor(log.type),
                     )}
                   >
-                    <span className="text-text-muted/90 w-[72px] flex-shrink-0 tabular-nums text-[11px] leading-5">
+                    <span className="text-text-muted/90 w-[64px] flex-shrink-0 tabular-nums text-[11px] leading-4">
                       {formatLogTime(log.timestamp, i18n.language)}
                     </span>
-                    <span className="min-w-0 flex-1 break-words whitespace-pre-wrap leading-5">
+                    <span className="min-w-0 flex-1 break-words whitespace-pre-wrap leading-4">
                       {log.message}
                     </span>
                   </div>

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -35,6 +35,7 @@ export function LogsPanel() {
   const { t, i18n } = useTranslation();
   const isMobile = useIsMobile();
   const logsContainerRef = useRef<HTMLDivElement>(null);
+  const logsEndRef = useRef<HTMLDivElement>(null);
   const isFollowingTailRef = useRef(true);
   const [visibleLogLimit, setVisibleLogLimit] = useState(DEFAULT_VISIBLE_LOG_LIMIT);
   const [isAtTop, setIsAtTop] = useState(false);
@@ -64,21 +65,17 @@ export function LogsPanel() {
   }, [activeInstanceId]);
 
   useLayoutEffect(() => {
-    const el = logsContainerRef.current;
-    if (!el || !isFollowingTailRef.current) return;
+    if (!isFollowingTailRef.current) return;
 
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distanceFromBottom > BOTTOM_FOLLOW_THRESHOLD_PX) return;
-
-    el.scrollTop = el.scrollHeight;
-  }, [visibleLogs, visibleLogLimit]);
+    logsEndRef.current?.scrollIntoView({ block: 'end' });
+  }, [logs.length, visibleLogLimit]);
 
   const handleLogsScroll = useCallback(() => {
     const el = logsContainerRef.current;
     if (!el) return;
 
     const top = el.scrollTop <= 4;
-    const bottom = el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_FOLLOW_THRESHOLD_PX;
+    const bottom = el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_FOLLOW_THRESHOLD_PX * 2;
 
     setIsAtTop(top);
     isFollowingTailRef.current = bottom;
@@ -305,7 +302,7 @@ export function LogsPanel() {
       {/* 日志内容 */}
       <div
         ref={logsContainerRef}
-        className="flex-1 min-h-0 overflow-y-auto p-2.5 font-mono text-[12px] leading-4 bg-bg-secondary"
+        className="flex-1 min-h-0 overflow-y-auto p-2.5 font-mono text-[12px] leading-4 bg-bg-tertiary dark:bg-bg-secondary"
         onScroll={handleLogsScroll}
         onContextMenu={handleContextMenu}
       >
@@ -366,10 +363,11 @@ export function LogsPanel() {
                   </div>
                 )}
                 {index < visibleLogs.length - 1 && (
-                  <div className="mx-4 my-1 h-px bg-border/60" aria-hidden="true" />
+                  <div className="mx-4 my-1 h-px bg-border/50" aria-hidden="true" />
                 )}
               </Fragment>
             ))}
+            <div ref={logsEndRef} aria-hidden="true" />
           </>
         )}
       </div>

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -251,7 +251,7 @@ export function LogsPanel() {
         )}
       >
         <span className="text-sm font-medium text-text-primary">{t('logs.title')}</span>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -305,7 +305,7 @@ export function LogsPanel() {
       {/* 日志内容 */}
       <div
         ref={logsContainerRef}
-        className="flex-1 min-h-0 overflow-y-auto p-2.5 font-mono text-[12px] leading-4 bg-bg-tertiary"
+        className="flex-1 min-h-0 overflow-y-auto p-2.5 font-mono text-[12px] leading-4 bg-bg-secondary"
         onScroll={handleLogsScroll}
         onContextMenu={handleContextMenu}
       >
@@ -366,7 +366,7 @@ export function LogsPanel() {
                   </div>
                 )}
                 {index < visibleLogs.length - 1 && (
-                  <div className="mx-6 my-1 h-px bg-border/40" aria-hidden="true" />
+                  <div className="mx-4 my-1 h-px bg-border/60" aria-hidden="true" />
                 )}
               </Fragment>
             ))}

--- a/src/components/LogsPanel.tsx
+++ b/src/components/LogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useState, useMemo } from 'react';
+import { Fragment, useRef, useEffect, useCallback, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Eraser, Copy, ChevronUp, ChevronDown, Archive } from 'lucide-react';
 import clsx from 'clsx';
@@ -328,43 +328,44 @@ export function LogsPanel() {
                 </button>
               </div>
             )}
-            {visibleLogs.map((log) =>
-              log.html ? (
-                // 富文本内容（focus 消息支持 Markdown/HTML）
-                <div
-                  key={log.id}
-                  className={clsx(
-                    'py-1.5 px-2 rounded-md flex items-start gap-3',
-                    'odd:bg-black/0 even:bg-black/5',
-                    getLogColor(log.type),
-                  )}
-                >
-                  <span className="text-text-muted/90 w-[72px] flex-shrink-0 tabular-nums text-[11px] leading-5">
-                    {formatLogTime(log.timestamp, i18n.language)}
-                  </span>
-                  <span
-                    className="min-w-0 flex-1 break-words leading-5 focus-content"
-                    dangerouslySetInnerHTML={{ __html: log.html }}
-                  />
-                </div>
-              ) : (
-                <div
-                  key={log.id}
-                  className={clsx(
-                    'py-1.5 px-2 rounded-md flex items-start gap-3',
-                    'odd:bg-black/0 even:bg-black/5',
-                    getLogColor(log.type),
-                  )}
-                >
-                  <span className="text-text-muted/90 w-[72px] flex-shrink-0 tabular-nums text-[11px] leading-5">
-                    {formatLogTime(log.timestamp, i18n.language)}
-                  </span>
-                  <span className="min-w-0 flex-1 break-words whitespace-pre-wrap leading-5">
-                    {log.message}
-                  </span>
-                </div>
-              ),
-            )}
+            {visibleLogs.map((log, index) => (
+              <Fragment key={log.id}>
+                {log.html ? (
+                  // 富文本内容（focus 消息支持 Markdown/HTML）
+                  <div
+                    className={clsx(
+                      'py-1.5 px-2 rounded-md flex items-start gap-3',
+                      getLogColor(log.type),
+                    )}
+                  >
+                    <span className="text-text-muted/90 w-[72px] flex-shrink-0 tabular-nums text-[11px] leading-5">
+                      {formatLogTime(log.timestamp, i18n.language)}
+                    </span>
+                    <span
+                      className="min-w-0 flex-1 break-words leading-5 focus-content"
+                      dangerouslySetInnerHTML={{ __html: log.html }}
+                    />
+                  </div>
+                ) : (
+                  <div
+                    className={clsx(
+                      'py-1.5 px-2 rounded-md flex items-start gap-3',
+                      getLogColor(log.type),
+                    )}
+                  >
+                    <span className="text-text-muted/90 w-[72px] flex-shrink-0 tabular-nums text-[11px] leading-5">
+                      {formatLogTime(log.timestamp, i18n.language)}
+                    </span>
+                    <span className="min-w-0 flex-1 break-words whitespace-pre-wrap leading-5">
+                      {log.message}
+                    </span>
+                  </div>
+                )}
+                {index < visibleLogs.length - 1 && (
+                  <div className="mx-6 my-1 h-px bg-border/40" aria-hidden="true" />
+                )}
+              </Fragment>
+            ))}
           </>
         )}
       </div>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -803,7 +803,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
           }
 
           // 注册 ctrl_id 与设备名/类型的映射
-          registerCtrlIdName(ctrlId, deviceName, targetType);
+          registerCtrlIdName(targetId, ctrlId, deviceName, targetType);
 
           // 等待连接完成（同时监听 maa-callback 和 state-changed 两条路径）
           const connectResult = await new Promise<boolean>((resolve) => {

--- a/src/components/connection/useDeviceConnection.ts
+++ b/src/components/connection/useDeviceConnection.ts
@@ -67,7 +67,7 @@ export function useDeviceConnection({
       await startGlobalCallbackListener();
       const ctrlId = await maaService.connectController(instanceId, config);
 
-      registerCtrlIdName(ctrlId, deviceName || '', targetType);
+      registerCtrlIdName(instanceId, ctrlId, deviceName || '', targetType);
 
       const result = await waitForCtrlResult(ctrlId);
 

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -433,7 +433,6 @@ export default {
   logs: {
     title: 'Logs',
     clear: 'Clear',
-    autoClearOnLaunch: 'Auto-clear on launch',
     autoscroll: 'Auto Scroll',
     noLogs: 'No logs',
     copyAll: 'Copy All',
@@ -475,10 +474,10 @@ export default {
       hotkeyDetected: 'Hotkey detected: {{combo}} ({{action}})',
       hotkeyActionStart: 'Start tasks',
       hotkeyActionStop: 'Stop tasks',
-      hotkeyStartSuccess: 'Hotkey start tasks: success',
-      hotkeyStartFailed: 'Hotkey start tasks: failed',
-      hotkeyStopSuccess: 'Hotkey stop tasks: success',
-      hotkeyStopFailed: 'Hotkey stop tasks: failed',
+      hotkeyStartSuccess: 'Started tasks via hotkey:',
+      hotkeyStartFailed: 'Failed to start tasks via hotkey',
+      hotkeyStopSuccess: 'Stopped tasks via hotkey',
+      hotkeyStopFailed: 'Failed to stop tasks via hotkey',
     },
   },
 

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -467,6 +467,9 @@ export default {
       agentConnected: 'Agent connected',
       agentDisconnected: 'Agent disconnected',
       agentFailed: 'Agent start failed',
+      agentLogFloodWarning:
+        'Agent is in a log flood state. To avoid out-of-memory, log reception has been stopped. Please check the local log directory for the mxu-agent-<index>-<pid>.log file pattern.',
+      agentLogFloodRecovered: 'Agent log flood has eased and log reception has been resumed',
       // Hotkeys
       hotkeyDetected: 'Hotkey detected: {{combo}} ({{action}})',
       hotkeyActionStart: 'Start tasks',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -437,6 +437,7 @@ export default {
     autoscroll: 'Auto Scroll',
     noLogs: 'No logs',
     copyAll: 'Copy All',
+    showMoreLogs: 'Show more logs',
     expand: 'Expand panels above',
     collapse: 'Collapse panels above',
     scrollToLogs: 'View logs',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -469,8 +469,8 @@ export default {
       agentDisconnected: 'Agent disconnected',
       agentFailed: 'Agent start failed',
       agentLogFloodWarning:
-        'Agent is in a log flood state. To avoid out-of-memory, log reception has been stopped. Please check the local log directory for the mxu-agent-<index>-<pid>.log file pattern.',
-      agentLogFloodRecovered: 'Agent log flood has eased and log reception has been resumed',
+        'Agent is in a log flood state. To avoid performance issues, log display has been paused. The complete log is available in the local log directory in the mxu-agent file.',
+      agentLogFloodRecovered: 'Agent log flood has eased',
       // Hotkeys
       hotkeyDetected: 'Hotkey detected: {{combo}} ({{action}})',
       hotkeyActionStart: 'Start tasks',

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -468,7 +468,7 @@ export default {
       agentDisconnected: 'Agent disconnected',
       agentFailed: 'Agent start failed',
       agentLogFloodWarning:
-        'Agent is in a log flood state. To avoid performance issues, log display has been paused. The complete log is available in the local log directory in the mxu-agent file.',
+        'Agent is in a log flood state. To avoid performance issues, log display has been paused. The complete log is available in the local log file.',
       agentLogFloodRecovered: 'Agent log flood has eased',
       // Hotkeys
       hotkeyDetected: 'Hotkey detected: {{combo}} ({{action}})',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -463,7 +463,7 @@ export default {
       agentDisconnected: 'Agent が切断しました',
       agentFailed: 'Agent の起動に失敗しました',
       agentLogFloodWarning:
-        'Agent がログスパム状態です。性能問題を避けるためログ表示を一時停止しました。完全なログはローカルのログディレクトリにある mxu-agent ファイルで確認できます。',
+        'Agent がログスパム状態です。性能問題を避けるためログ表示を一時停止しました。完全なログはローカルのログファイルで確認できます。',
       agentLogFloodRecovered: 'Agent のログスパムが緩和されました',
       // ショートカットキー
       hotkeyDetected: 'ショートカットキーを検出: {{combo}}（{{action}}）',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -464,8 +464,8 @@ export default {
       agentDisconnected: 'Agent が切断しました',
       agentFailed: 'Agent の起動に失敗しました',
       agentLogFloodWarning:
-        'Agent がログスパム状態です。メモリ枯渇を防ぐためログ受信を停止しました。詳細はローカルのログディレクトリにある mxu-agent-<index>-<pid>.log のファイルパターンを確認してください。',
-      agentLogFloodRecovered: 'Agent のログスパムが緩和されたため、ログ受信を再開しました',
+        'Agent がログスパム状態です。性能問題を避けるためログ表示を一時停止しました。完全なログはローカルのログディレクトリにある mxu-agent ファイルで確認できます。',
+      agentLogFloodRecovered: 'Agent のログスパムが緩和されました',
       // ショートカットキー
       hotkeyDetected: 'ショートカットキーを検出: {{combo}}（{{action}}）',
       hotkeyActionStart: 'タスク開始',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -462,6 +462,9 @@ export default {
       agentConnected: 'Agent が接続しました',
       agentDisconnected: 'Agent が切断しました',
       agentFailed: 'Agent の起動に失敗しました',
+      agentLogFloodWarning:
+        'Agent がログスパム状態です。メモリ枯渇を防ぐためログ受信を停止しました。詳細はローカルのログディレクトリにある mxu-agent-<index>-<pid>.log のファイルパターンを確認してください。',
+      agentLogFloodRecovered: 'Agent のログスパムが緩和されたため、ログ受信を再開しました',
       // ショートカットキー
       hotkeyDetected: 'ショートカットキーを検出: {{combo}}（{{action}}）',
       hotkeyActionStart: 'タスク開始',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -429,7 +429,6 @@ export default {
   logs: {
     title: '実行ログ',
     clear: 'クリア',
-    autoClearOnLaunch: '起動時に自動クリア',
     autoscroll: '自動スクロール',
     noLogs: 'ログがありません',
     copyAll: 'すべてコピー',
@@ -470,10 +469,10 @@ export default {
       hotkeyDetected: 'ショートカットキーを検出: {{combo}}（{{action}}）',
       hotkeyActionStart: 'タスク開始',
       hotkeyActionStop: 'タスク停止',
-      hotkeyStartSuccess: 'ショートカットキーでタスク開始：成功',
-      hotkeyStartFailed: 'ショートカットキーでタスク開始：失敗',
-      hotkeyStopSuccess: 'ショートカットキーでタスク停止：成功',
-      hotkeyStopFailed: 'ショートカットキーでタスク停止：失敗',
+      hotkeyStartSuccess: 'ショートカットキーでタスクを開始しました：',
+      hotkeyStartFailed: 'ショートカットキーでタスクを開始できませんでした',
+      hotkeyStopSuccess: 'ショートカットキーでタスクを停止しました',
+      hotkeyStopFailed: 'ショートカットキーでタスクを停止できませんでした',
     },
   },
 

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -433,6 +433,7 @@ export default {
     autoscroll: '自動スクロール',
     noLogs: 'ログがありません',
     copyAll: 'すべてコピー',
+    showMoreLogs: 'さらにログを表示',
     expand: '上部パネルを展開',
     collapse: '上部パネルを折りたたむ',
     scrollToLogs: 'ログを表示',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -460,7 +460,7 @@ export default {
       agentDisconnected: 'Agent 연결이 끊어졌습니다',
       agentFailed: 'Agent 시작에 실패했습니다',
       agentLogFloodWarning:
-        'Agent가 로그 폭주 상태입니다. 성능 문제를 방지하기 위해 로그 표시를 일시 중지했습니다. 전체 로그는 로컬 로그 디렉터리의 mxu-agent 파일에서 확인할 수 있습니다.',
+        'Agent가 로그 폭주 상태입니다. 성능 문제를 방지하기 위해 로그 표시를 일시 중지했습니다. 전체 로그는 로컬 로그 파일에서 확인할 수 있습니다.',
       agentLogFloodRecovered: 'Agent 로그 폭주가 완화되었습니다',
       // 단축키
       hotkeyDetected: '단축키 감지: {{combo}} ({{action}})',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -430,6 +430,7 @@ export default {
     autoscroll: '자동 스크롤',
     noLogs: '로그가 없습니다',
     copyAll: '모두 복사',
+    showMoreLogs: '로그 더 보기',
     expand: '상단 패널 펼치기',
     collapse: '상단 패널 접기',
     scrollToLogs: '로그 보기',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -426,7 +426,6 @@ export default {
   logs: {
     title: '실행 로그',
     clear: '지우기',
-    autoClearOnLaunch: '시작 시 자동 지우기',
     autoscroll: '자동 스크롤',
     noLogs: '로그가 없습니다',
     copyAll: '모두 복사',
@@ -467,10 +466,10 @@ export default {
       hotkeyDetected: '단축키 감지: {{combo}} ({{action}})',
       hotkeyActionStart: '작업 시작',
       hotkeyActionStop: '작업 중지',
-      hotkeyStartSuccess: '단축키로 작업 시작: 성공',
-      hotkeyStartFailed: '단축키로 작업 시작: 실패',
-      hotkeyStopSuccess: '단축키로 작업 중지: 성공',
-      hotkeyStopFailed: '단축키로 작업 중지: 실패',
+      hotkeyStartSuccess: '단축키로 작업을 시작했습니다:',
+      hotkeyStartFailed: '단축키로 작업을 시작하지 못했습니다',
+      hotkeyStopSuccess: '단축키로 작업을 중지했습니다',
+      hotkeyStopFailed: '단축키로 작업을 중지하지 못했습니다',
     },
   },
 

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -461,8 +461,8 @@ export default {
       agentDisconnected: 'Agent 연결이 끊어졌습니다',
       agentFailed: 'Agent 시작에 실패했습니다',
       agentLogFloodWarning:
-        'Agent가 로그 폭주 상태입니다. 메모리 오버플로를 방지하기 위해 로그 수신을 중지했습니다. 자세한 내용은 로컬 로그 디렉터리의 mxu-agent-<index>-<pid>.log 파일 패턴을 확인하세요.',
-      agentLogFloodRecovered: 'Agent 로그 폭주가 완화되어 로그 수신을 다시 시작했습니다',
+        'Agent가 로그 폭주 상태입니다. 성능 문제를 방지하기 위해 로그 표시를 일시 중지했습니다. 전체 로그는 로컬 로그 디렉터리의 mxu-agent 파일에서 확인할 수 있습니다.',
+      agentLogFloodRecovered: 'Agent 로그 폭주가 완화되었습니다',
       // 단축키
       hotkeyDetected: '단축키 감지: {{combo}} ({{action}})',
       hotkeyActionStart: '작업 시작',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -459,6 +459,9 @@ export default {
       agentConnected: 'Agent가 연결되었습니다',
       agentDisconnected: 'Agent 연결이 끊어졌습니다',
       agentFailed: 'Agent 시작에 실패했습니다',
+      agentLogFloodWarning:
+        'Agent가 로그 폭주 상태입니다. 메모리 오버플로를 방지하기 위해 로그 수신을 중지했습니다. 자세한 내용은 로컬 로그 디렉터리의 mxu-agent-<index>-<pid>.log 파일 패턴을 확인하세요.',
+      agentLogFloodRecovered: 'Agent 로그 폭주가 완화되어 로그 수신을 다시 시작했습니다',
       // 단축키
       hotkeyDetected: '단축키 감지: {{combo}} ({{action}})',
       hotkeyActionStart: '작업 시작',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -456,7 +456,7 @@ export default {
       agentDisconnected: 'Agent 已断开',
       agentFailed: 'Agent 启动失败',
       agentLogFloodWarning:
-        'Agent 处于日志风暴状态，为避免性能问题已暂停显示日志，完整日志可在本地日志目录中的 mxu-agent 文件中查看',
+        'Agent 处于日志风暴状态，为避免性能问题已暂停显示日志，完整日志可在本地日志文件中查看',
       agentLogFloodRecovered: 'Agent 日志风暴状态已缓解',
       // 快捷键
       hotkeyDetected: '检测到快捷键: {{combo}}（{{action}}）',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -455,6 +455,9 @@ export default {
       agentConnected: 'Agent 已连接',
       agentDisconnected: 'Agent 已断开',
       agentFailed: 'Agent 启动失败',
+      agentLogFloodWarning:
+        'Agent 处于日志风暴状态，为避免内存溢出已停止接收日志，请检查本地日志目录中的 mxu-agent-<index>-<pid>.log 文件模式以了解详情',
+      agentLogFloodRecovered: 'Agent 日志风暴状态已缓解，已恢复接收日志',
       // 快捷键
       hotkeyDetected: '检测到快捷键：{{combo}}（{{action}}）',
       hotkeyActionStart: '开始任务',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -426,6 +426,7 @@ export default {
     autoscroll: '自动滚动',
     noLogs: '暂无日志',
     copyAll: '复制全部',
+    showMoreLogs: '展示更多日志',
     expand: '展开上方面板',
     collapse: '折叠上方面板',
     scrollToLogs: '查看日志',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -57,8 +57,8 @@ export default {
     theme: '主题',
     themeLight: '浅色',
     themeDark: '深色',
-    accentColor: '强调色',
     themeSystem: '系统',
+    accentColor: '强调色',
     showOptionPreview: '显示选项预览',
     showOptionPreviewHint: '在任务列表中显示选项的快捷预览信息',
     openLogDir: '打开日志目录',
@@ -138,7 +138,7 @@ export default {
       argsLabel: '附加参数',
       argsPlaceholder: '输入附加参数（可选）',
       waitLabel: '等待退出',
-      waitDescription: '禁用时启动进程后立即继续；启用时等待进程退出后再继续作',
+      waitDescription: '禁用时启动进程后立即继续；启用时等待进程退出后再继续工作',
       waitYes: '等待程序退出后继续',
       waitNo: '启动后立即继续',
       skipLabel: '已运行时跳过',
@@ -422,7 +422,6 @@ export default {
   logs: {
     title: '运行日志',
     clear: '清空',
-    autoClearOnLaunch: '启动时自动清理',
     autoscroll: '自动滚动',
     noLogs: '暂无日志',
     copyAll: '复制全部',
@@ -433,7 +432,7 @@ export default {
     // 日志消息
     messages: {
       // 连接消息
-      connecting: '正在连接{{target}} ...',
+      connecting: '正在连接{{target}}...',
       connected: '{{target}}连接成功:',
       connectFailed: '{{target}}连接失败:',
       targetDevice: '设备',
@@ -460,13 +459,13 @@ export default {
         'Agent 处于日志风暴状态，为避免性能问题已暂停显示日志，完整日志可在本地日志目录中的 mxu-agent 文件中查看',
       agentLogFloodRecovered: 'Agent 日志风暴状态已缓解',
       // 快捷键
-      hotkeyDetected: '检测到快捷键：{{combo}}（{{action}}）',
+      hotkeyDetected: '检测到快捷键: {{combo}}（{{action}}）',
       hotkeyActionStart: '开始任务',
       hotkeyActionStop: '停止任务',
-      hotkeyStartSuccess: '快捷键开始任务：成功',
-      hotkeyStartFailed: '快捷键开始任务：失败',
-      hotkeyStopSuccess: '快捷键停止任务：成功',
-      hotkeyStopFailed: '快捷键停止任务：失败',
+      hotkeyStartSuccess: '已通过快捷键开始任务：',
+      hotkeyStartFailed: '未能通过快捷键开始任务',
+      hotkeyStopSuccess: '已通过快捷键停止任务',
+      hotkeyStopFailed: '未能通过快捷键停止任务',
     },
   },
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -457,8 +457,8 @@ export default {
       agentDisconnected: 'Agent 已断开',
       agentFailed: 'Agent 启动失败',
       agentLogFloodWarning:
-        'Agent 处于日志风暴状态，为避免内存溢出已停止接收日志，请检查本地日志目录中的 mxu-agent-<index>-<pid>.log 文件模式以了解详情',
-      agentLogFloodRecovered: 'Agent 日志风暴状态已缓解，已恢复接收日志',
+        'Agent 处于日志风暴状态，为避免性能问题已暂停显示日志，完整日志可在本地日志目录中的 mxu-agent 文件中查看',
+      agentLogFloodRecovered: 'Agent 日志风暴状态已缓解',
       // 快捷键
       hotkeyDetected: '检测到快捷键：{{combo}}（{{action}}）',
       hotkeyActionStart: '开始任务',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -453,8 +453,8 @@ export default {
       agentDisconnected: 'Agent 已中斷',
       agentFailed: 'Agent 啟動失敗',
       agentLogFloodWarning:
-        'Agent 處於日誌風暴狀態，為避免記憶體溢出已停止接收日誌，請檢查本機日誌目錄中的 mxu-agent-<index>-<pid>.log 檔案模式以了解詳情',
-      agentLogFloodRecovered: 'Agent 日誌風暴狀態已緩解，已恢復接收日誌',
+        'Agent 處於日誌風暴狀態，為避免效能問題已暫停顯示日誌，完整日誌可在本機日誌目錄中的 mxu-agent 檔案中查看',
+      agentLogFloodRecovered: 'Agent 日誌風暴狀態已緩解',
       // 快捷鍵
       hotkeyDetected: '偵測到快捷鍵：{{combo}}（{{action}}）',
       hotkeyActionStart: '開始任務',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -451,6 +451,9 @@ export default {
       agentConnected: 'Agent 已連接',
       agentDisconnected: 'Agent 已中斷',
       agentFailed: 'Agent 啟動失敗',
+      agentLogFloodWarning:
+        'Agent 處於日誌風暴狀態，為避免記憶體溢出已停止接收日誌，請檢查本機日誌目錄中的 mxu-agent-<index>-<pid>.log 檔案模式以了解詳情',
+      agentLogFloodRecovered: 'Agent 日誌風暴狀態已緩解，已恢復接收日誌',
       // 快捷鍵
       hotkeyDetected: '偵測到快捷鍵：{{combo}}（{{action}}）',
       hotkeyActionStart: '開始任務',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -422,6 +422,7 @@ export default {
     autoscroll: '自動捲動',
     noLogs: '暫無日誌',
     copyAll: '複製全部',
+    showMoreLogs: '顯示更多日誌',
     expand: '展開上方面板',
     collapse: '摺疊上方面板',
     scrollToLogs: '查看日誌',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -452,7 +452,7 @@ export default {
       agentDisconnected: 'Agent 已中斷',
       agentFailed: 'Agent 啟動失敗',
       agentLogFloodWarning:
-        'Agent 處於日誌風暴狀態，為避免效能問題已暫停顯示日誌，完整日誌可在本機日誌目錄中的 mxu-agent 檔案中查看',
+        'Agent 處於日誌風暴狀態，為避免效能問題已暫停顯示日誌，完整日誌可在本機日誌檔案中查看',
       agentLogFloodRecovered: 'Agent 日誌風暴狀態已緩解',
       // 快捷鍵
       hotkeyDetected: '偵測到快捷鍵: {{combo}}（{{action}}）',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -418,7 +418,6 @@ export default {
   logs: {
     title: '執行日誌',
     clear: '清空',
-    autoClearOnLaunch: '啟動時自動清理',
     autoscroll: '自動捲動',
     noLogs: '暫無日誌',
     copyAll: '複製全部',
@@ -429,7 +428,7 @@ export default {
     // 日誌訊息
     messages: {
       // 連接訊息
-      connecting: '正在連接{{target}} ...',
+      connecting: '正在連接{{target}}...',
       connected: '{{target}}連接成功:',
       connectFailed: '{{target}}連接失敗:',
       targetDevice: '裝置',
@@ -456,13 +455,13 @@ export default {
         'Agent 處於日誌風暴狀態，為避免效能問題已暫停顯示日誌，完整日誌可在本機日誌目錄中的 mxu-agent 檔案中查看',
       agentLogFloodRecovered: 'Agent 日誌風暴狀態已緩解',
       // 快捷鍵
-      hotkeyDetected: '偵測到快捷鍵：{{combo}}（{{action}}）',
+      hotkeyDetected: '偵測到快捷鍵: {{combo}}（{{action}}）',
       hotkeyActionStart: '開始任務',
       hotkeyActionStop: '停止任務',
-      hotkeyStartSuccess: '快捷鍵開始任務：成功',
-      hotkeyStartFailed: '快捷鍵開始任務：失敗',
-      hotkeyStopSuccess: '快捷鍵停止任務：成功',
-      hotkeyStopFailed: '快捷鍵停止任務：失敗',
+      hotkeyStartSuccess: '透過快捷鍵開始任務：',
+      hotkeyStartFailed: '無法透過快捷鍵開始任務',
+      hotkeyStopSuccess: '透過快捷鍵停止任務',
+      hotkeyStopFailed: '無法透過快捷鍵停止任務',
     },
   },
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -361,7 +361,9 @@ export const useAppStore = create<AppState>()(
       return id;
     },
 
-    removeInstance: (id) =>
+    removeInstance: (id) => {
+      get().clearControllerRuntimeState(id);
+
       set((state) => {
         const instanceToClose = state.instances.find((i) => i.id === id);
         const newInstances = state.instances.filter((i) => i.id !== id);
@@ -411,7 +413,8 @@ export const useAppStore = create<AppState>()(
           recentlyClosed: newRecentlyClosed,
           ...autoStartUpdate,
         };
-      }),
+      });
+    },
 
     setActiveInstance: (id) => set({ activeInstanceId: id }),
 
@@ -1273,13 +1276,19 @@ export const useAppStore = create<AppState>()(
     instanceCurrentTaskId: {},
     instanceTaskStatus: {},
 
-    setInstanceConnectionStatus: (instanceId, status) =>
+    setInstanceConnectionStatus: (instanceId, status) => {
+      const previousStatus = get().instanceConnectionStatus[instanceId];
+      if (previousStatus === 'Connected' && status === 'Disconnected') {
+        get().clearControllerRuntimeState(instanceId);
+      }
+
       set((state) => ({
         instanceConnectionStatus: {
           ...state.instanceConnectionStatus,
           [instanceId]: status,
         },
-      })),
+      }));
+    },
 
     setInstanceResourceLoaded: (instanceId, loaded) =>
       set((state) => ({
@@ -1850,23 +1859,60 @@ export const useAppStore = create<AppState>()(
 
     clearTaskRunStatus: (instanceId) => {
       set((state) => ({
-        instanceTaskRunStatus: {
-          ...state.instanceTaskRunStatus,
-          [instanceId]: {},
-        },
-        maaTaskIdMapping: {
-          ...state.maaTaskIdMapping,
-          [instanceId]: {},
-        },
-        instancePendingTaskIds: {
-          ...state.instancePendingTaskIds,
-          [instanceId]: [],
-        },
-        instanceCurrentTaskIndex: {
-          ...state.instanceCurrentTaskIndex,
-          [instanceId]: 0,
-        },
+        instanceTaskRunStatus: Object.fromEntries(
+          Object.entries(state.instanceTaskRunStatus).filter(([id]) => id !== instanceId),
+        ),
+        maaTaskIdMapping: Object.fromEntries(
+          Object.entries(state.maaTaskIdMapping).filter(([id]) => id !== instanceId),
+        ),
+        instancePendingTaskIds: Object.fromEntries(
+          Object.entries(state.instancePendingTaskIds).filter(([id]) => id !== instanceId),
+        ),
+        instanceCurrentTaskIndex: Object.fromEntries(
+          Object.entries(state.instanceCurrentTaskIndex).filter(([id]) => id !== instanceId),
+        ),
       }));
+    },
+
+    clearControllerRuntimeState: (instanceId) => {
+      get().clearLogs(instanceId);
+      get().clearTaskRunStatus(instanceId);
+
+      set((state) => {
+        const trackedCtrlIds = state.instanceCtrlIds[instanceId] ?? [];
+        const nextCtrlIdToName = { ...state.ctrlIdToName };
+        const nextCtrlIdToType = { ...state.ctrlIdToType };
+
+        for (const ctrlId of trackedCtrlIds) {
+          delete nextCtrlIdToName[ctrlId];
+          delete nextCtrlIdToType[ctrlId];
+        }
+
+        const { [instanceId]: _removedCtrlIds, ...restInstanceCtrlIds } = state.instanceCtrlIds;
+        const { [instanceId]: _removedConnectionStatus, ...restConnectionStatus } =
+          state.instanceConnectionStatus;
+        const { [instanceId]: _removedResourceLoaded, ...restResourceLoaded } =
+          state.instanceResourceLoaded;
+        const { [instanceId]: _removedCurrentTaskId, ...restCurrentTaskId } =
+          state.instanceCurrentTaskId;
+        const { [instanceId]: _removedTaskStatus, ...restTaskStatus } = state.instanceTaskStatus;
+
+        return {
+          ctrlIdToName: nextCtrlIdToName,
+          ctrlIdToType: nextCtrlIdToType,
+          instanceCtrlIds: restInstanceCtrlIds,
+          instanceConnectionStatus: restConnectionStatus,
+          instanceResourceLoaded: restResourceLoaded,
+          instanceCurrentTaskId: restCurrentTaskId,
+          instanceTaskStatus: restTaskStatus,
+          instanceScreenshotStreaming: Object.fromEntries(
+            Object.entries(state.instanceScreenshotStreaming).filter(([id]) => id !== instanceId),
+          ),
+          scheduleExecutions: Object.fromEntries(
+            Object.entries(state.scheduleExecutions).filter(([id]) => id !== instanceId),
+          ),
+        };
+      });
     },
 
     // 定时执行状态
@@ -1943,15 +1989,20 @@ export const useAppStore = create<AppState>()(
     // 回调 ID 与名称的映射
     ctrlIdToName: {},
     ctrlIdToType: {},
+    instanceCtrlIds: {},
     resIdToName: {},
     resBatchInfo: {},
     taskIdToName: {},
     entryToTaskName: {},
 
-    registerCtrlIdName: (ctrlId, name, type) =>
+    registerCtrlIdName: (instanceId, ctrlId, name, type) =>
       set((state) => ({
         ctrlIdToName: { ...state.ctrlIdToName, [ctrlId]: name },
         ctrlIdToType: { ...state.ctrlIdToType, [ctrlId]: type },
+        instanceCtrlIds: {
+          ...state.instanceCtrlIds,
+          [instanceId]: Array.from(new Set([...(state.instanceCtrlIds[instanceId] ?? []), ctrlId])),
+        },
       })),
 
     registerResIdName: (resId, name) =>

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -462,15 +462,22 @@ export interface AppState {
   instanceLogs: Record<string, LogEntry[]>;
   addLog: (instanceId: string, log: Omit<LogEntry, 'id' | 'timestamp'>) => void;
   clearLogs: (instanceId: string) => void;
+  clearControllerRuntimeState: (instanceId: string) => void;
 
   // 回调 ID 与名称的映射
   ctrlIdToName: Record<number, string>;
   ctrlIdToType: Record<number, 'device' | 'window'>;
+  instanceCtrlIds: Record<string, number[]>;
   resIdToName: Record<number, string>;
   resBatchInfo: Record<number, { isFirst: boolean; isLast: boolean }>;
   taskIdToName: Record<number, string>;
   entryToTaskName: Record<string, string>;
-  registerCtrlIdName: (ctrlId: number, name: string, type: 'device' | 'window') => void;
+  registerCtrlIdName: (
+    instanceId: string,
+    ctrlId: number,
+    name: string,
+    type: 'device' | 'window',
+  ) => void;
   registerResIdName: (resId: number, name: string) => void;
   registerResBatch: (resIds: number[]) => void;
   registerTaskIdName: (taskId: number, name: string) => void;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,7 +3,7 @@
 import type { OptionValue, ActionConfig } from './interface';
 import type { AccentColor, CustomAccent } from '@/themes/types';
 
-export const DEFAULT_MAX_LOGS_PER_INSTANCE = 2000;
+export const DEFAULT_MAX_LOGS_PER_INSTANCE = 500;
 
 // 定时执行策略
 export interface SchedulePolicy {

--- a/src/utils/useMaaCallbackLogger.ts
+++ b/src/utils/useMaaCallbackLogger.ts
@@ -22,8 +22,8 @@ import type { FocusTemplate, FocusDisplayChannel } from '@/types/interface';
 
 const log = loggers.app;
 
-const AGENT_LOG_FLOOD_WINDOW_MS = 1000;
-const AGENT_LOG_FLOOD_THRESHOLD = 10;
+const AGENT_LOG_FLOOD_WINDOW_MS = 2000;
+const AGENT_LOG_FLOOD_THRESHOLD = 15;
 
 // 每次会话只请求一次通知权限，避免多条 focus 消息重复弹权限弹窗
 let focusNotificationPermissionRequested = false;

--- a/src/utils/useMaaCallbackLogger.ts
+++ b/src/utils/useMaaCallbackLogger.ts
@@ -22,6 +22,10 @@ import type { FocusTemplate, FocusDisplayChannel } from '@/types/interface';
 
 const log = loggers.app;
 
+const AGENT_LOG_FLOOD_WINDOW_MS = 1000;
+const AGENT_LOG_FLOOD_THRESHOLD = 10;
+const AGENT_LOG_BATCH_WINDOW_MS = 10;
+
 // 每次会话只请求一次通知权限，避免多条 focus 消息重复弹权限弹窗
 let focusNotificationPermissionRequested = false;
 
@@ -548,6 +552,7 @@ function handleCallback(
  * 监听 Agent 输出事件
  */
 export function useMaaAgentLogger() {
+  const { t } = useTranslation();
   const { addLog } = useAppStore();
   const unlistenRef = useRef<(() => void) | null>(null);
   const pendingAgentLogsRef = useRef<
@@ -556,24 +561,70 @@ export function useMaaAgentLogger() {
       {
         lines: string[];
         timer: ReturnType<typeof setTimeout> | null;
+        recentFlushTimestamps: number[];
+        floodSuppressed: boolean;
+        recoveryTimer: ReturnType<typeof setTimeout> | null;
+        warningEmitted: boolean;
       }
     >
   >(new Map());
 
-  const flushAgentLogBatch = (instanceId: string) => {
+  const pruneAgentFloodWindow = (timestamps: number[], now: number): number[] =>
+    timestamps.filter((timestamp) => now - timestamp < AGENT_LOG_FLOOD_WINDOW_MS);
+
+  const ensureAgentBatchState = (instanceId: string) => {
+    const existing = pendingAgentLogsRef.current.get(instanceId);
+    if (existing) return existing;
+
+    const created = {
+      lines: [] as string[],
+      timer: null as ReturnType<typeof setTimeout> | null,
+      recentFlushTimestamps: [] as number[],
+      floodSuppressed: false,
+      recoveryTimer: null as ReturnType<typeof setTimeout> | null,
+      warningEmitted: false,
+    };
+    pendingAgentLogsRef.current.set(instanceId, created);
+    return created;
+  };
+
+  const clearAgentRecoveryTimer = (batch: {
+    recoveryTimer: ReturnType<typeof setTimeout> | null;
+  }) => {
+    if (batch.recoveryTimer !== null) {
+      clearTimeout(batch.recoveryTimer);
+      batch.recoveryTimer = null;
+    }
+  };
+
+  const scheduleAgentRecoveryCheck = (instanceId: string) => {
     const batch = pendingAgentLogsRef.current.get(instanceId);
     if (!batch) return;
 
-    if (batch.timer !== null) {
-      clearTimeout(batch.timer);
-      batch.timer = null;
-    }
+    clearAgentRecoveryTimer(batch);
+    batch.recoveryTimer = setTimeout(() => {
+      const currentBatch = pendingAgentLogsRef.current.get(instanceId);
+      if (!currentBatch) return;
 
-    pendingAgentLogsRef.current.delete(instanceId);
+      const now = Date.now();
+      currentBatch.recentFlushTimestamps = pruneAgentFloodWindow(currentBatch.recentFlushTimestamps, now);
 
-    const mergedLine = batch.lines.join('\n');
-    if (!mergedLine) return;
+      if (currentBatch.recentFlushTimestamps.length < AGENT_LOG_FLOOD_THRESHOLD) {
+        if (currentBatch.floodSuppressed) {
+          currentBatch.floodSuppressed = false;
+          currentBatch.warningEmitted = false;
+          addLog(instanceId, {
+            type: 'warning',
+            message: t('logs.messages.agentLogFloodRecovered'),
+          });
+        }
+      } else {
+        scheduleAgentRecoveryCheck(instanceId);
+      }
+    }, AGENT_LOG_FLOOD_WINDOW_MS);
+  };
 
+  const emitAgentLog = (instanceId: string, mergedLine: string) => {
     resolveFocusContent(mergedLine, {} as MaaCallbackDetails & Record<string, unknown>, instanceId)
       .then((resolved) => {
         addLog(instanceId, {
@@ -588,17 +639,52 @@ export function useMaaAgentLogger() {
       });
   };
 
-  const enqueueAgentLogLine = (instanceId: string, line: string) => {
-    const existing = pendingAgentLogsRef.current.get(instanceId);
-    if (!existing) {
-      const timer = setTimeout(() => {
-        flushAgentLogBatch(instanceId);
-      }, 1);
+  const flushAgentLogBatch = (instanceId: string) => {
+    const batch = pendingAgentLogsRef.current.get(instanceId);
+    if (!batch) return;
 
-      pendingAgentLogsRef.current.set(instanceId, {
-        lines: [line],
-        timer,
-      });
+    if (batch.timer !== null) {
+      clearTimeout(batch.timer);
+      batch.timer = null;
+    }
+
+    const mergedLine = batch.lines.join('\n');
+    if (!mergedLine) return;
+
+    batch.lines = [];
+
+    const now = Date.now();
+    batch.recentFlushTimestamps = pruneAgentFloodWindow(batch.recentFlushTimestamps, now);
+    batch.recentFlushTimestamps.push(now);
+
+    if (batch.floodSuppressed) {
+      scheduleAgentRecoveryCheck(instanceId);
+      return;
+    }
+
+    if (batch.recentFlushTimestamps.length >= AGENT_LOG_FLOOD_THRESHOLD) {
+      batch.floodSuppressed = true;
+      if (!batch.warningEmitted) {
+        batch.warningEmitted = true;
+        addLog(instanceId, {
+          type: 'warning',
+          message: t('logs.messages.agentLogFloodWarning'),
+        });
+      }
+      scheduleAgentRecoveryCheck(instanceId);
+      return;
+    }
+
+    emitAgentLog(instanceId, mergedLine);
+
+    if (batch.recentFlushTimestamps.length > 0) {
+      scheduleAgentRecoveryCheck(instanceId);
+    }
+  };
+
+  const enqueueAgentLogLine = (instanceId: string, line: string) => {
+    const existing = ensureAgentBatchState(instanceId);
+    if (!existing) {
       return;
     }
 
@@ -608,7 +694,11 @@ export function useMaaAgentLogger() {
     }
     existing.timer = setTimeout(() => {
       flushAgentLogBatch(instanceId);
-    }, 1);
+    }, AGENT_LOG_BATCH_WINDOW_MS);
+
+    if (existing.floodSuppressed) {
+      scheduleAgentRecoveryCheck(instanceId);
+    }
   };
 
   useEffect(() => {
@@ -660,10 +750,17 @@ export function useMaaAgentLogger() {
         unlistenRef.current = null;
       }
 
-      for (const instanceId of pendingAgentLogsRef.current.keys()) {
-        flushAgentLogBatch(instanceId);
+      for (const [instanceId, batch] of pendingAgentLogsRef.current.entries()) {
+        if (batch.timer !== null) {
+          clearTimeout(batch.timer);
+          batch.timer = null;
+        }
+        clearAgentRecoveryTimer(batch);
+        if (!batch.floodSuppressed) {
+          flushAgentLogBatch(instanceId);
+        }
       }
       pendingAgentLogsRef.current.clear();
     };
-  }, [addLog]);
+  }, [addLog, t]);
 }

--- a/src/utils/useMaaCallbackLogger.ts
+++ b/src/utils/useMaaCallbackLogger.ts
@@ -24,7 +24,6 @@ const log = loggers.app;
 
 const AGENT_LOG_FLOOD_WINDOW_MS = 1000;
 const AGENT_LOG_FLOOD_THRESHOLD = 10;
-const AGENT_LOG_BATCH_WINDOW_MS = 10;
 
 // 每次会话只请求一次通知权限，避免多条 focus 消息重复弹权限弹窗
 let focusNotificationPermissionRequested = false;
@@ -555,13 +554,11 @@ export function useMaaAgentLogger() {
   const { t } = useTranslation();
   const { addLog } = useAppStore();
   const unlistenRef = useRef<(() => void) | null>(null);
-  const pendingAgentLogsRef = useRef<
+  const agentFloodStateRef = useRef<
     Map<
       string,
       {
-        lines: string[];
-        timer: ReturnType<typeof setTimeout> | null;
-        recentFlushTimestamps: number[];
+        recentTimestamps: number[];
         floodSuppressed: boolean;
         recoveryTimer: ReturnType<typeof setTimeout> | null;
         warningEmitted: boolean;
@@ -572,19 +569,17 @@ export function useMaaAgentLogger() {
   const pruneAgentFloodWindow = (timestamps: number[], now: number): number[] =>
     timestamps.filter((timestamp) => now - timestamp < AGENT_LOG_FLOOD_WINDOW_MS);
 
-  const ensureAgentBatchState = (instanceId: string) => {
-    const existing = pendingAgentLogsRef.current.get(instanceId);
+  const ensureAgentFloodState = (instanceId: string) => {
+    const existing = agentFloodStateRef.current.get(instanceId);
     if (existing) return existing;
 
     const created = {
-      lines: [] as string[],
-      timer: null as ReturnType<typeof setTimeout> | null,
-      recentFlushTimestamps: [] as number[],
+      recentTimestamps: [] as number[],
       floodSuppressed: false,
       recoveryTimer: null as ReturnType<typeof setTimeout> | null,
       warningEmitted: false,
     };
-    pendingAgentLogsRef.current.set(instanceId, created);
+    agentFloodStateRef.current.set(instanceId, created);
     return created;
   };
 
@@ -598,18 +593,18 @@ export function useMaaAgentLogger() {
   };
 
   const scheduleAgentRecoveryCheck = (instanceId: string) => {
-    const batch = pendingAgentLogsRef.current.get(instanceId);
+    const batch = agentFloodStateRef.current.get(instanceId);
     if (!batch) return;
 
     clearAgentRecoveryTimer(batch);
     batch.recoveryTimer = setTimeout(() => {
-      const currentBatch = pendingAgentLogsRef.current.get(instanceId);
+      const currentBatch = agentFloodStateRef.current.get(instanceId);
       if (!currentBatch) return;
 
       const now = Date.now();
-      currentBatch.recentFlushTimestamps = pruneAgentFloodWindow(currentBatch.recentFlushTimestamps, now);
+      currentBatch.recentTimestamps = pruneAgentFloodWindow(currentBatch.recentTimestamps, now);
 
-      if (currentBatch.recentFlushTimestamps.length < AGENT_LOG_FLOOD_THRESHOLD) {
+      if (currentBatch.recentTimestamps.length < AGENT_LOG_FLOOD_THRESHOLD) {
         if (currentBatch.floodSuppressed) {
           currentBatch.floodSuppressed = false;
           currentBatch.warningEmitted = false;
@@ -639,80 +634,45 @@ export function useMaaAgentLogger() {
       });
   };
 
-  const flushAgentLogBatch = (instanceId: string) => {
-    const batch = pendingAgentLogsRef.current.get(instanceId);
-    if (!batch) return;
-
-    if (batch.timer !== null) {
-      clearTimeout(batch.timer);
-      batch.timer = null;
-    }
-
-    const mergedLine = batch.lines.join('\n');
-    if (!mergedLine) return;
-
-    batch.lines = [];
-
-    const now = Date.now();
-    batch.recentFlushTimestamps = pruneAgentFloodWindow(batch.recentFlushTimestamps, now);
-    batch.recentFlushTimestamps.push(now);
-
-    if (batch.floodSuppressed) {
-      scheduleAgentRecoveryCheck(instanceId);
-      return;
-    }
-
-    if (batch.recentFlushTimestamps.length >= AGENT_LOG_FLOOD_THRESHOLD) {
-      batch.floodSuppressed = true;
-      if (!batch.warningEmitted) {
-        batch.warningEmitted = true;
-        addLog(instanceId, {
-          type: 'warning',
-          message: t('logs.messages.agentLogFloodWarning'),
-        });
-      }
-      scheduleAgentRecoveryCheck(instanceId);
-      return;
-    }
-
-    emitAgentLog(instanceId, mergedLine);
-
-    if (batch.recentFlushTimestamps.length > 0) {
-      scheduleAgentRecoveryCheck(instanceId);
-    }
-  };
-
-  const enqueueAgentLogLine = (instanceId: string, line: string) => {
-    const existing = ensureAgentBatchState(instanceId);
-    if (!existing) {
-      return;
-    }
-
-    existing.lines.push(line);
-    if (existing.timer !== null) {
-      clearTimeout(existing.timer);
-    }
-    existing.timer = setTimeout(() => {
-      flushAgentLogBatch(instanceId);
-    }, AGENT_LOG_BATCH_WINDOW_MS);
-
-    if (existing.floodSuppressed) {
-      scheduleAgentRecoveryCheck(instanceId);
-    }
-  };
-
   useEffect(() => {
     let cancelled = false;
 
-    const handleAgentOutput = (instance_id: string, _stream: string, line: string) => {
+    const handleAgentOutput = (instanceId: string, _stream: string, line: string) => {
       if (cancelled) return;
-      enqueueAgentLogLine(instance_id, line);
+
+      const state = ensureAgentFloodState(instanceId);
+      const now = Date.now();
+      state.recentTimestamps = pruneAgentFloodWindow(state.recentTimestamps, now);
+
+      if (state.floodSuppressed) {
+        scheduleAgentRecoveryCheck(instanceId);
+        return;
+      }
+
+      state.recentTimestamps.push(now);
+      if (state.recentTimestamps.length >= AGENT_LOG_FLOOD_THRESHOLD) {
+        state.floodSuppressed = true;
+        if (!state.warningEmitted) {
+          state.warningEmitted = true;
+          addLog(instanceId, {
+            type: 'warning',
+            message: t('logs.messages.agentLogFloodWarning'),
+          });
+        }
+        scheduleAgentRecoveryCheck(instanceId);
+        return;
+      }
+
+      emitAgentLog(instanceId, line);
+
+      if (state.recentTimestamps.length > 0) {
+        scheduleAgentRecoveryCheck(instanceId);
+      }
     };
 
     const setupListener = async () => {
       try {
         if (isTauri()) {
-          // Tauri WebView：监听 Tauri 事件
           const { listen } = await import('@tauri-apps/api/event');
           const unlisten = await listen<{ instance_id: string; stream: string; line: string }>(
             'maa-agent-output',
@@ -728,7 +688,6 @@ export function useMaaAgentLogger() {
             unlistenRef.current = unlisten;
           }
         } else {
-          // 浏览器：通过 WebSocket 接收
           const unlisten = wsService.onAgentOutput(handleAgentOutput);
           if (cancelled) {
             unlisten();
@@ -750,17 +709,10 @@ export function useMaaAgentLogger() {
         unlistenRef.current = null;
       }
 
-      for (const [instanceId, batch] of pendingAgentLogsRef.current.entries()) {
-        if (batch.timer !== null) {
-          clearTimeout(batch.timer);
-          batch.timer = null;
-        }
+      for (const batch of agentFloodStateRef.current.values()) {
         clearAgentRecoveryTimer(batch);
-        if (!batch.floodSuppressed) {
-          flushAgentLogBatch(instanceId);
-        }
       }
-      pendingAgentLogsRef.current.clear();
+      agentFloodStateRef.current.clear();
     };
   }, [addLog, t]);
 }

--- a/src/utils/useMaaCallbackLogger.ts
+++ b/src/utils/useMaaCallbackLogger.ts
@@ -550,27 +550,73 @@ function handleCallback(
 export function useMaaAgentLogger() {
   const { addLog } = useAppStore();
   const unlistenRef = useRef<(() => void) | null>(null);
+  const pendingAgentLogsRef = useRef<
+    Map<
+      string,
+      {
+        lines: string[];
+        timer: ReturnType<typeof setTimeout> | null;
+      }
+    >
+  >(new Map());
+
+  const flushAgentLogBatch = (instanceId: string) => {
+    const batch = pendingAgentLogsRef.current.get(instanceId);
+    if (!batch) return;
+
+    if (batch.timer !== null) {
+      clearTimeout(batch.timer);
+      batch.timer = null;
+    }
+
+    pendingAgentLogsRef.current.delete(instanceId);
+
+    const mergedLine = batch.lines.join('\n');
+    if (!mergedLine) return;
+
+    resolveFocusContent(mergedLine, {} as MaaCallbackDetails & Record<string, unknown>, instanceId)
+      .then((resolved) => {
+        addLog(instanceId, {
+          type: 'agent',
+          message: resolved.message,
+          html: resolved.html,
+        });
+      })
+      .catch((err) => {
+        log.warn('Failed to resolve agent content:', err);
+        addLog(instanceId, { type: 'agent', message: mergedLine });
+      });
+  };
+
+  const enqueueAgentLogLine = (instanceId: string, line: string) => {
+    const existing = pendingAgentLogsRef.current.get(instanceId);
+    if (!existing) {
+      const timer = setTimeout(() => {
+        flushAgentLogBatch(instanceId);
+      }, 1);
+
+      pendingAgentLogsRef.current.set(instanceId, {
+        lines: [line],
+        timer,
+      });
+      return;
+    }
+
+    existing.lines.push(line);
+    if (existing.timer !== null) {
+      clearTimeout(existing.timer);
+    }
+    existing.timer = setTimeout(() => {
+      flushAgentLogBatch(instanceId);
+    }, 1);
+  };
 
   useEffect(() => {
     let cancelled = false;
 
     const handleAgentOutput = (instance_id: string, _stream: string, line: string) => {
       if (cancelled) return;
-
-      resolveFocusContent(line, {} as MaaCallbackDetails & Record<string, unknown>, instance_id)
-        .then((resolved) => {
-          if (cancelled) return;
-          addLog(instance_id, {
-            type: 'agent',
-            message: resolved.message,
-            html: resolved.html,
-          });
-        })
-        .catch((err) => {
-          log.warn('Failed to resolve agent content:', err);
-          if (cancelled) return;
-          addLog(instance_id, { type: 'agent', message: line });
-        });
+      enqueueAgentLogLine(instance_id, line);
     };
 
     const setupListener = async () => {
@@ -613,6 +659,11 @@ export function useMaaAgentLogger() {
         unlistenRef.current();
         unlistenRef.current = null;
       }
+
+      for (const instanceId of pendingAgentLogsRef.current.keys()) {
+        flushAgentLogBatch(instanceId);
+      }
+      pendingAgentLogsRef.current.clear();
     };
   }, [addLog]);
 }


### PR DESCRIPTION
## 概要

此 PR 针对运行日志及其 UI 进行了如下优化：

1. 新增了对 Agent 短时间内输出的日志的缓冲合并功能。
2. 新增了对 Agent 日志风暴的识别功能，检测到日志风暴时不会显示在前端中。
3. 新增了前端日志条数上限的分级显示功能，默认情况下展示 500 条日志，可以手动展开到 2000 条（先前值）。
4. 移除了斑马纹日志样式，因为与分级条数上限功能不兼容。
5. 修复了实例被移除或断开时，日志状态未清理的问题。
6. 其他日志 UI 优化和国际化文案优化。

## 关联

此 PR 启发自 https://github.com/MaaEnd/MaaEnd/issues/2986 。

## Summary by Sourcery

通过限制可见日志数量、对代理输出进行批量处理、抑制日志洪泛，并强化对已关闭或断开实例的运行时清理，改进日志 UI 性能和内存使用。

New Features:
- 为每个实例增加可见日志上限，支持可扩展的限制，并在视图中提供控件，从持久化存储和后端加载更多日志。
- 在后端对代理的 stdout/stderr 行进行批量处理后再发送到前端，以减少事件量。
- 在前端检测代理日志洪泛情况，临时阻止渲染，并在所有支持的语言中展示本地化的警告和恢复消息。

Enhancements:
- 优化日志面板的滚动行为、布局和分隔线，同时简化行样式，以提升可读性和性能。
- 确保在实例被移除或断开时，控制器和任务运行时状态被完全清理，包括相关的控制器 ID 映射和日志缓冲区。
- 按实例跟踪控制器 ID，以便在实例清理时能够精确清除，并改进相关日志标签。
- 将每个实例的默认最大日志条数从 2000 调整为 500，从而降低内存占用并提升响应速度。

Documentation:
- 更新所有支持语言中的本地化日志和快捷键文案，以提高清晰度，并描述新的日志洪泛处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve logging UI performance and memory usage by limiting visible logs, batching agent output, and suppressing log floods while tightening runtime cleanup for closed or disconnected instances.

New Features:
- Add a per-instance visible log cap with an expandable limit and in-view control to load more logs from persisted and backend sources.
- Introduce backend batching of agent stdout/stderr lines before emitting them to the frontend to reduce event volume.
- Detect agent log flood situations on the frontend, temporarily suppress rendering, and surface localized warning and recovery messages in all supported languages.

Enhancements:
- Refine log panel scrolling behavior, layout, and separators while simplifying row styling for better readability and performance.
- Ensure controller and task runtime state is fully cleared when instances are removed or disconnected, including associated controller ID mappings and log buffers.
- Track controller IDs per instance so they can be cleaned up precisely with the instance and improve related logging labels.
- Adjust default maximum logs per instance from 2000 to 500 to reduce memory footprint and improve responsiveness.

Documentation:
- Update localized log and hotkey messages across all supported languages for clarity and to describe new log flood handling behavior.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过限制可见日志数量、对代理输出进行批量处理、抑制日志洪泛，并强化对已关闭或断开实例的运行时清理，改进日志 UI 性能和内存使用。

New Features:
- 为每个实例增加可见日志上限，支持可扩展的限制，并在视图中提供控件，从持久化存储和后端加载更多日志。
- 在后端对代理的 stdout/stderr 行进行批量处理后再发送到前端，以减少事件量。
- 在前端检测代理日志洪泛情况，临时阻止渲染，并在所有支持的语言中展示本地化的警告和恢复消息。

Enhancements:
- 优化日志面板的滚动行为、布局和分隔线，同时简化行样式，以提升可读性和性能。
- 确保在实例被移除或断开时，控制器和任务运行时状态被完全清理，包括相关的控制器 ID 映射和日志缓冲区。
- 按实例跟踪控制器 ID，以便在实例清理时能够精确清除，并改进相关日志标签。
- 将每个实例的默认最大日志条数从 2000 调整为 500，从而降低内存占用并提升响应速度。

Documentation:
- 更新所有支持语言中的本地化日志和快捷键文案，以提高清晰度，并描述新的日志洪泛处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve logging UI performance and memory usage by limiting visible logs, batching agent output, and suppressing log floods while tightening runtime cleanup for closed or disconnected instances.

New Features:
- Add a per-instance visible log cap with an expandable limit and in-view control to load more logs from persisted and backend sources.
- Introduce backend batching of agent stdout/stderr lines before emitting them to the frontend to reduce event volume.
- Detect agent log flood situations on the frontend, temporarily suppress rendering, and surface localized warning and recovery messages in all supported languages.

Enhancements:
- Refine log panel scrolling behavior, layout, and separators while simplifying row styling for better readability and performance.
- Ensure controller and task runtime state is fully cleared when instances are removed or disconnected, including associated controller ID mappings and log buffers.
- Track controller IDs per instance so they can be cleaned up precisely with the instance and improve related logging labels.
- Adjust default maximum logs per instance from 2000 to 500 to reduce memory footprint and improve responsiveness.

Documentation:
- Update localized log and hotkey messages across all supported languages for clarity and to describe new log flood handling behavior.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过限制可见日志数量、对代理输出进行批量处理、抑制日志洪泛，并强化对已关闭或断开实例的运行时清理，改进日志 UI 性能和内存使用。

New Features:
- 为每个实例增加可见日志上限，支持可扩展的限制，并在视图中提供控件，从持久化存储和后端加载更多日志。
- 在后端对代理的 stdout/stderr 行进行批量处理后再发送到前端，以减少事件量。
- 在前端检测代理日志洪泛情况，临时阻止渲染，并在所有支持的语言中展示本地化的警告和恢复消息。

Enhancements:
- 优化日志面板的滚动行为、布局和分隔线，同时简化行样式，以提升可读性和性能。
- 确保在实例被移除或断开时，控制器和任务运行时状态被完全清理，包括相关的控制器 ID 映射和日志缓冲区。
- 按实例跟踪控制器 ID，以便在实例清理时能够精确清除，并改进相关日志标签。
- 将每个实例的默认最大日志条数从 2000 调整为 500，从而降低内存占用并提升响应速度。

Documentation:
- 更新所有支持语言中的本地化日志和快捷键文案，以提高清晰度，并描述新的日志洪泛处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve logging UI performance and memory usage by limiting visible logs, batching agent output, and suppressing log floods while tightening runtime cleanup for closed or disconnected instances.

New Features:
- Add a per-instance visible log cap with an expandable limit and in-view control to load more logs from persisted and backend sources.
- Introduce backend batching of agent stdout/stderr lines before emitting them to the frontend to reduce event volume.
- Detect agent log flood situations on the frontend, temporarily suppress rendering, and surface localized warning and recovery messages in all supported languages.

Enhancements:
- Refine log panel scrolling behavior, layout, and separators while simplifying row styling for better readability and performance.
- Ensure controller and task runtime state is fully cleared when instances are removed or disconnected, including associated controller ID mappings and log buffers.
- Track controller IDs per instance so they can be cleaned up precisely with the instance and improve related logging labels.
- Adjust default maximum logs per instance from 2000 to 500 to reduce memory footprint and improve responsiveness.

Documentation:
- Update localized log and hotkey messages across all supported languages for clarity and to describe new log flood handling behavior.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过限制可见日志数量、对代理输出进行批量处理、抑制日志洪泛，并强化对已关闭或断开实例的运行时清理，改进日志 UI 性能和内存使用。

New Features:
- 为每个实例增加可见日志上限，支持可扩展的限制，并在视图中提供控件，从持久化存储和后端加载更多日志。
- 在后端对代理的 stdout/stderr 行进行批量处理后再发送到前端，以减少事件量。
- 在前端检测代理日志洪泛情况，临时阻止渲染，并在所有支持的语言中展示本地化的警告和恢复消息。

Enhancements:
- 优化日志面板的滚动行为、布局和分隔线，同时简化行样式，以提升可读性和性能。
- 确保在实例被移除或断开时，控制器和任务运行时状态被完全清理，包括相关的控制器 ID 映射和日志缓冲区。
- 按实例跟踪控制器 ID，以便在实例清理时能够精确清除，并改进相关日志标签。
- 将每个实例的默认最大日志条数从 2000 调整为 500，从而降低内存占用并提升响应速度。

Documentation:
- 更新所有支持语言中的本地化日志和快捷键文案，以提高清晰度，并描述新的日志洪泛处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve logging UI performance and memory usage by limiting visible logs, batching agent output, and suppressing log floods while tightening runtime cleanup for closed or disconnected instances.

New Features:
- Add a per-instance visible log cap with an expandable limit and in-view control to load more logs from persisted and backend sources.
- Introduce backend batching of agent stdout/stderr lines before emitting them to the frontend to reduce event volume.
- Detect agent log flood situations on the frontend, temporarily suppress rendering, and surface localized warning and recovery messages in all supported languages.

Enhancements:
- Refine log panel scrolling behavior, layout, and separators while simplifying row styling for better readability and performance.
- Ensure controller and task runtime state is fully cleared when instances are removed or disconnected, including associated controller ID mappings and log buffers.
- Track controller IDs per instance so they can be cleaned up precisely with the instance and improve related logging labels.
- Adjust default maximum logs per instance from 2000 to 500 to reduce memory footprint and improve responsiveness.

Documentation:
- Update localized log and hotkey messages across all supported languages for clarity and to describe new log flood handling behavior.

</details>

</details>

</details>