### PR TITLE
fix: 修复 Windows GUI 构建下 --help 无法输出

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -6,7 +6,9 @@ use super::types::MaaState;
 use super::types::SystemInfo;
 use super::types::WebView2DirInfo;
 use super::utils::get_maafw_dir;
-use log::{info, warn};
+use log::info;
+#[cfg(windows)]
+use log::warn;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -530,6 +532,46 @@ pub fn check_vcredist_missing() -> bool {
 #[tauri::command]
 pub fn is_autostart() -> bool {
     std::env::args().any(|arg| arg == "--autostart")
+}
+
+/// 打印命令行帮助文本。
+pub fn print_cli_help_text() {
+    #[cfg(windows)]
+    let attached_console = attach_parent_console_for_cli();
+
+    print!("{}", get_cli_help_text());
+
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    #[cfg(windows)]
+    if attached_console {
+        detach_parent_console_for_cli();
+    }
+}
+
+#[cfg(windows)]
+fn attach_parent_console_for_cli() -> bool {
+    extern "system" {
+        fn AttachConsole(dw_process_id: u32) -> i32;
+    }
+
+    const ATTACH_PARENT_PROCESS: u32 = 0xFFFF_FFFF;
+
+    // GUI subsystem builds do not auto-attach to the invoking terminal.
+    // Ignore failure: redirected stdout or double-click launches should still fall through.
+    unsafe { AttachConsole(ATTACH_PARENT_PROCESS) != 0 }
+}
+
+#[cfg(windows)]
+fn detach_parent_console_for_cli() {
+    extern "system" {
+        fn FreeConsole() -> i32;
+    }
+
+    unsafe {
+        FreeConsole();
+    }
 }
 
 /// 检查命令行是否包含 -h/--help 参数

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,8 +6,8 @@ mod webview2;
 
 fn main() {
     if mxu_lib::commands::system::has_help_flag() {
-        print!("{}", mxu_lib::commands::system::get_cli_help_text());
-        return;
+        mxu_lib::commands::system::print_cli_help_text();
+        std::process::exit(0);
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## 概要
Windows下的启动参数-h不会如描述一样，被正确的输出到控制台。
仅在Windows下: 
- 在正常 Tauri 启动前处理 `-h/--help`。
- Windows GUI 子系统构建下，打印帮助文本前临时附加到调用方控制台。

## 说明

Windows GUI 子系统进程不会被 PowerShell/CMD 当作普通控制台子进程等待，因此该修复不能完全恢复原生 CLI 的提示符刷新行为。它只是在不把 MXU 主程序改成控制台程序的前提下，让 `mxu.exe --help` 尽可能可靠地输出帮助文本。

## 测试

正常编译通过，pwsh（chcp=65001) 下正确显示 -h内容