### PR TITLE
fix: 修复自动更新偶现损坏配置文件问题

### DIFF
--- a/src-tauri/src/commands/app_config.rs
+++ b/src-tauri/src/commands/app_config.rs
@@ -163,7 +163,21 @@ impl AppConfigState {
         let content =
             serde_json::to_string_pretty(&config).map_err(|e| format!("序列化配置失败: {}", e))?;
 
-        std::fs::write(&config_path, content).map_err(|e| format!("写入配置文件失败: {}", e))?;
+        // 原子写：先写到 .tmp，再 rename 覆盖正式文件。
+        // 与前端 configService.ts 保持一致，避免进程在写入中途被杀
+        // （如自动更新触发的 Tauri relaunch）时把配置文件截断为 0 字节。
+        // std::fs::rename 在 Windows 上走 MoveFileExW(MOVEFILE_REPLACE_EXISTING)，
+        // 在 Unix 上是原子的 rename(2)，同文件系统内可保证原子替换。
+        let tmp_path = config_path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, content).map_err(|e| {
+            // 清理半成品 .tmp，避免遗留
+            let _ = std::fs::remove_file(&tmp_path);
+            format!("写入临时配置文件失败: {}", e)
+        })?;
+        if let Err(e) = std::fs::rename(&tmp_path, &config_path) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!("重命名配置文件失败: {}", e));
+        }
 
         *self.config.lock().unwrap() = config;
         log::debug!("AppConfigState: config saved to {:?}", config_path);

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -146,7 +146,9 @@ export async function saveConfig(
   log.debug('保存配置, 路径:', configPath);
 
   try {
-    const { writeTextFile, mkdir, exists, readTextFile } = await import('@tauri-apps/plugin-fs');
+    const { writeTextFile, mkdir, exists, readTextFile, rename, remove } = await import(
+      '@tauri-apps/plugin-fs'
+    );
 
     // 确保 config 目录存在
     if (!(await exists(configDir))) {
@@ -174,7 +176,26 @@ export async function saveConfig(
     }
 
     const content = JSON.stringify(config, null, 2);
-    await writeTextFile(configPath, content);
+    // 原子写：先写到 .tmp，再 rename 覆盖正式文件。
+    // 这样即使进程在写入中途被杀（典型场景：自动更新后 Tauri relaunch
+    // 触发 beforeunload，writeTextFile 已经把目标文件截断为 0 字节但内容还没
+    // 落盘），目标文件也只会停留在上一份完整内容，不会出现空 / 损坏的
+    // mxu-{projectName}.json。
+    const tempPath = configPath + '.tmp';
+    try {
+      await writeTextFile(tempPath, content);
+      await rename(tempPath, configPath);
+    } catch (err) {
+      // 写入或重命名失败时清理半成品 .tmp，避免遗留垃圾
+      try {
+        if (await exists(tempPath)) {
+          await remove(tempPath);
+        }
+      } catch (cleanupErr) {
+        log.debug('清理临时配置文件失败（忽略）:', cleanupErr);
+      }
+      throw err;
+    }
     log.info('配置保存成功');
 
     // 通知 Rust 后端更新内存缓存并广播 config-changed 给所有其他客户端


### PR DESCRIPTION
close https://github.com/MaaEnd/MaaEnd/issues/2788
<img width="951" height="1130" alt="image" src="https://github.com/user-attachments/assets/8df415d0-cd17-4d02-8f80-f21cf86a805b" />
<img width="935" height="391" alt="image" src="https://github.com/user-attachments/assets/78a099b1-e035-4483-8a3e-82f5e01ee655" />

## Summary by Sourcery

确保配置文件以原子方式保存，以避免在写入中断时发生损坏。

错误修复：
- 防止在保存过程中（例如自动更新时）应用被终止或重新启动时，配置 JSON 文件变为空或损坏。

改进：
- 统一前端和 Rust 后端的配置保存逻辑，采用“临时文件 + 原子重命名”的模式，并在失败时清理临时文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure configuration files are saved atomically to avoid corruption during interrupted writes.

Bug Fixes:
- Prevent configuration JSON files from becoming empty or corrupted when the app is killed or relaunched during a save (e.g., during auto-update).

Enhancements:
- Align frontend and Rust backend config saving logic to use a temporary file plus atomic rename pattern, with cleanup of temporary files on failure.

</details>