### PR TITLE
fix: 清理失效的 PI 选项 case

### DIFF
--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -593,7 +593,10 @@ export function TaskItem({ instanceId, task }: TaskItemProps) {
           optionValue?.type === 'select'
             ? optionValue.caseName
             : optionDef.default_case || optionDef.cases?.[0]?.name || '';
-        const selectedCase = optionDef.cases?.find((c) => c.name === caseName);
+        const selectedCase =
+          optionDef.cases?.find((c) => c.name === caseName) ||
+          optionDef.cases?.find((c) => c.name === optionDef.default_case) ||
+          optionDef.cases?.[0];
         // MXU 特殊任务的 case label 也需要用 t() 翻译
         const caseLabel = selectedCase
           ? isMxuOption

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -31,6 +31,7 @@ import { useAppStore } from '@/stores/appStore';
 import { TaskItem } from './TaskItem';
 import { ActionItem } from './ActionItem';
 import { ContextMenu, useContextMenu, type MenuItem } from './ContextMenu';
+import type { SavedTask } from '@/types/config';
 import type { PresetItem } from '@/types/interface';
 import { getInterfaceLangKey } from '@/i18n';
 import { useResolvedContent } from '@/services/contentResolver';
@@ -40,6 +41,7 @@ import {
   getImportErrorType,
 } from '@/utils/tabExportImport';
 import { generateId, initializeAllOptionValues, sanitizeOptionValues } from '@/stores/helpers';
+import { loggers } from '@/utils/logger';
 import { toast } from 'sonner';
 import clsx from 'clsx';
 
@@ -111,7 +113,12 @@ function ImportConfigButton({ instanceId }: { instanceId: string }) {
       const importedTasks = payload.selectedTasks
         .map((task) => {
           const taskDef = projectInterface.task.find((t) => t.name === task.taskName);
-          if (!taskDef) return null;
+          if (!taskDef) {
+            loggers.config.warn(
+              `导入标签页配置时，任务 "${task.taskName}" 在当前 Project Interface 中不存在，已跳过`,
+            );
+            return null;
+          }
 
           const defaultValues =
             taskDef.option && projectInterface.option
@@ -131,7 +138,7 @@ function ImportConfigButton({ instanceId }: { instanceId: string }) {
             expanded: true,
           };
         })
-        .filter((task) => task !== null);
+        .filter((task): task is SavedTask & { expanded: boolean } => task !== null);
 
       // 任务写入后 PresetSelector 自动消失，无需调用 skipPreset（避免触发 showAddTaskPanel）
       updateInstance(instanceId, {

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -39,7 +39,7 @@ import {
   importTabConfigFromClipboard,
   getImportErrorType,
 } from '@/utils/tabExportImport';
-import { generateId } from '@/stores/helpers';
+import { generateId, initializeAllOptionValues, sanitizeOptionValues } from '@/stores/helpers';
 import { toast } from 'sonner';
 import clsx from 'clsx';
 
@@ -108,11 +108,30 @@ function ImportConfigButton({ instanceId }: { instanceId: string }) {
     try {
       const { tabName, payload } = await importTabConfigFromClipboard(projectName);
 
-      const importedTasks = payload.selectedTasks.map((task) => ({
-        ...task,
-        id: generateId(),
-        expanded: true,
-      }));
+      const importedTasks = payload.selectedTasks
+        .map((task) => {
+          const taskDef = projectInterface.task.find((t) => t.name === task.taskName);
+          if (!taskDef) return null;
+
+          const defaultValues =
+            taskDef.option && projectInterface.option
+              ? initializeAllOptionValues(taskDef.option, projectInterface.option)
+              : {};
+          const cleanedValues = projectInterface.option
+            ? sanitizeOptionValues(task.optionValues, projectInterface.option)
+            : {};
+
+          return {
+            ...task,
+            id: generateId(),
+            optionValues: {
+              ...defaultValues,
+              ...cleanedValues,
+            },
+            expanded: true,
+          };
+        })
+        .filter((task) => task !== null);
 
       // 任务写入后 PresetSelector 自动消失，无需调用 skipPreset（避免触发 showAddTaskPanel）
       updateInstance(instanceId, {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -54,6 +54,7 @@ import {
   convertPresetOptionValue,
   getCurrentControllerAndResource,
   isTaskCompatible,
+  sanitizeOptionValues,
 } from './helpers';
 import { persistRuntimeLogs } from '@/utils/runtimeLogPersistence';
 // 从独立模块导入类型和辅助函数
@@ -77,25 +78,8 @@ function cleanOptionValues(
   optionValues: Record<string, OptionValue>,
   pi: ProjectInterface | null,
 ): Record<string, OptionValue> {
-  const validOptionNames = new Set(pi?.option ? Object.keys(pi.option) : []);
-  const cleaned: Record<string, OptionValue> = {};
-  for (const [key, value] of Object.entries(optionValues)) {
-    if (!validOptionNames.has(key)) continue;
-
-    const optionDef = pi?.option?.[key];
-    if (optionDef) {
-      const expectedType = optionDef.type || 'select';
-      if (value.type !== expectedType) {
-        loggers.config.warn(
-          `选项 "${key}" 的类型已从 "${value.type}" 变更为 "${expectedType}"，已重置为默认值`,
-        );
-        continue;
-      }
-    }
-
-    cleaned[key] = value;
-  }
-  return cleaned;
+  if (!pi?.option) return {};
+  return sanitizeOptionValues(optionValues, pi.option, (message) => loggers.config.warn(message));
 }
 
 function forwardLogToStdout(message: string) {

--- a/src/stores/helpers.ts
+++ b/src/stores/helpers.ts
@@ -31,6 +31,66 @@ export const createDefaultOptionValue = (optionDef: OptionDefinition): OptionVal
   return { type: 'select', caseName: defaultCase };
 };
 
+export type OptionValueSanitizeLogger = (message: string) => void;
+
+/**
+ * 校验保存的选项值是否仍符合当前 Project Interface 定义。
+ * 返回 null 表示应丢弃保存值并回退到当前默认值。
+ */
+export const sanitizeOptionValue = (
+  optionKey: string,
+  value: OptionValue,
+  allOptions: Record<string, OptionDefinition>,
+  warn?: OptionValueSanitizeLogger,
+): OptionValue | null => {
+  const optionDef = allOptions[optionKey];
+  if (!optionDef) return null;
+
+  const expectedType = optionDef.type || 'select';
+  if (value.type !== expectedType) {
+    warn?.(
+      `选项 "${optionKey}" 的类型已从 "${value.type}" 变更为 "${expectedType}"，已重置为默认值`,
+    );
+    return null;
+  }
+
+  if ((!optionDef.type || optionDef.type === 'select') && value.type === 'select') {
+    const caseExists = optionDef.cases.some((caseDef) => caseDef.name === value.caseName);
+    if (!caseExists) {
+      warn?.(`选项 "${optionKey}" 的 case "${value.caseName}" 已不存在，已重置为默认值`);
+      return null;
+    }
+    return value;
+  }
+
+  if (optionDef.type === 'checkbox' && value.type === 'checkbox') {
+    const validNames = new Set(optionDef.cases.map((caseDef) => caseDef.name));
+    const caseNames = value.caseNames.filter((caseName) => validNames.has(caseName));
+    if (caseNames.length !== value.caseNames.length) {
+      const removedNames = value.caseNames.filter((caseName) => !validNames.has(caseName));
+      warn?.(`选项 "${optionKey}" 包含已不存在的 case "${removedNames.join(', ')}"，已过滤`);
+    }
+    return { type: 'checkbox', caseNames };
+  }
+
+  return value;
+};
+
+export const sanitizeOptionValues = (
+  optionValues: Record<string, OptionValue>,
+  allOptions: Record<string, OptionDefinition>,
+  warn?: OptionValueSanitizeLogger,
+): Record<string, OptionValue> => {
+  const cleaned: Record<string, OptionValue> = {};
+  for (const [optionKey, value] of Object.entries(optionValues)) {
+    const sanitized = sanitizeOptionValue(optionKey, value, allOptions, warn);
+    if (sanitized) {
+      cleaned[optionKey] = sanitized;
+    }
+  }
+  return cleaned;
+};
+
 /**
  * 递归初始化所有选项（包括嵌套选项）的默认值
  * @param optionKeys 顶层选项键列表

--- a/src/stores/helpers.ts
+++ b/src/stores/helpers.ts
@@ -44,7 +44,10 @@ export const sanitizeOptionValue = (
   warn?: OptionValueSanitizeLogger,
 ): OptionValue | null => {
   const optionDef = allOptions[optionKey];
-  if (!optionDef) return null;
+  if (!optionDef) {
+    warn?.(`选项 "${optionKey}" 已不存在，已丢弃保存值`);
+    return null;
+  }
 
   const expectedType = optionDef.type || 'select';
   if (value.type !== expectedType) {
@@ -69,6 +72,10 @@ export const sanitizeOptionValue = (
     if (caseNames.length !== value.caseNames.length) {
       const removedNames = value.caseNames.filter((caseName) => !validNames.has(caseName));
       warn?.(`选项 "${optionKey}" 包含已不存在的 case "${removedNames.join(', ')}"，已过滤`);
+    }
+    if (value.caseNames.length > 0 && caseNames.length === 0) {
+      warn?.(`选项 "${optionKey}" 保存的 case 已全部失效，已重置为默认值`);
+      return null;
     }
     return { type: 'checkbox', caseNames };
   }

--- a/src/utils/pipelineOverride.ts
+++ b/src/utils/pipelineOverride.ts
@@ -13,7 +13,7 @@ import type {
 import { isMxuSpecialTask, getMxuSpecialTask } from '@/types/specialTasks';
 import { loggers } from './logger';
 import { findSwitchCase } from './optionHelpers';
-import { createDefaultOptionValue } from '@/stores/helpers';
+import { createDefaultOptionValue, sanitizeOptionValue } from '@/stores/helpers';
 
 /**
  * 检查选项是否与当前控制器/资源不兼容
@@ -59,11 +59,12 @@ const collectOptionOverrides = (
   }
 
   const savedValue = optionValues[optionKey];
-  const expectedType = optionDef.type || 'select';
-  const optionValue =
-    savedValue && savedValue.type === expectedType
-      ? savedValue
-      : createDefaultOptionValue(optionDef);
+  const sanitizedValue = savedValue
+    ? sanitizeOptionValue(optionKey, savedValue, allOptions, (message) =>
+        loggers.task.warn(message),
+      )
+    : null;
+  const optionValue = sanitizedValue || createDefaultOptionValue(optionDef);
 
   if (optionValue.type === 'checkbox' && optionDef.type === 'checkbox') {
     // v2.3.0: checkbox 多选类型，按 cases 定义顺序合并所有选中的 case


### PR DESCRIPTION
Project Interface 更新后，已有配置中保存的 select/checkbox case 可能已经不再存在。 此前 MXU 只校验 option 名称和类型，失效的 select case 会继续覆盖当前默认值， 导致生成 pipeline_override 时找不到 caseDef 并静默跳过对应覆盖。
这会造成已有任务配置与重新添加的同名任务行为不一致。

本次修复：
- 增加 option value 清理工具，校验 select case 并过滤 checkbox 中的失效 case
- 配置导入时丢弃失效保存值，让当前 Project Interface 默认值生效
- pipeline_override 生成时增加运行时兜底，避免失效 select case 静默丢失 override
- 标签页/剪贴板导入复用默认值初始化和清理流程，防止导入旧配置再次带入失效 case
- 任务预览遇到失效 select case 时回退显示当前默认/首个有效 case

验证：
- pnpm exec prettier --check 变更文件
- pnpm build

## Summary by Sourcery

根据当前的 Project Interface 清理已存储的任务选项值，防止无效配置影响任务行为和 pipeline overrides。

Bug 修复：
- 丢弃或过滤其类型或取值集合已不再符合当前 Project Interface 的选项值，并在必要时回退到默认值。
- 确保从标签页或剪贴板导入的任务配置，会使用当前默认值重新初始化选项值并移除已废弃的取值。
- 防止在生成 `pipeline_override` 时，当已保存的下拉选项引用已移除的取值时静默丢弃 overrides；改为记录日志并回退到默认值。
- 当已保存的下拉选项取值不再可用时，使任务预览回退到当前默认值或首个有效取值。

增强功能：
- 将选项值清理逻辑集中到共享的 helper 中，以便在配置加载、导入以及 pipeline override 生成过程中复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize stored task option values against the current Project Interface to prevent invalid cases from affecting task behavior and pipeline overrides.

Bug Fixes:
- Discard or filter option values whose type or cases no longer match the current Project Interface, falling back to defaults where necessary.
- Ensure imported task configurations from tabs or clipboard reinitialize option values with current defaults and remove obsolete cases.
- Prevent pipeline_override generation from silently dropping overrides when saved select options reference removed cases, logging and reverting to defaults instead.
- Make task preview fall back to the current default or first valid case when a saved select case is no longer available.

Enhancements:
- Centralize option value sanitation in shared helpers for reuse across config loading, imports, and pipeline override generation.

</details>