### PR TITLE
feat: 未运行任务时不再启用预览

### DIFF
--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -104,6 +104,9 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
   // 获取当前实例
   const instance = instances.find((i) => i.id === instanceId);
   const isRunning = instance?.isRunning || false;
+  const isTaskRunning = isRunning || taskStatus === 'Running';
+  // 预览截图可能触发部分 Win32 截图后端抢前台；只在任务运行中启用实时预览。
+  const canPreview = isConnected && isTaskRunning;
   const tasks = instance?.selectedTasks || [];
   const enabledTasks = tasks.filter((t) => t.enabled);
   const canRun = isConnected && isResourceLoaded && enabledTasks.length > 0;
@@ -347,7 +350,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
 
   // 获取最新缓存截图（后端截图循环负责更新缓存，前端无需主动触发 postScreencap）
   const captureFrame = useCallback(async (): Promise<string | null> => {
-    if (!instanceId) return null;
+    if (!instanceId || !canPreview) return null;
 
     try {
       const imageData = await maaService.getCachedImage(instanceId);
@@ -355,7 +358,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
     } catch {
       return null;
     }
-  }, [instanceId]);
+  }, [instanceId, canPreview]);
 
   const loopRunningRef = useRef(false);
 
@@ -363,10 +366,24 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
     if (loopRunningRef.current) return;
     loopRunningRef.current = true;
 
+    const loopInstanceId = instanceId;
+
     try {
       let nextFrameTime = Date.now();
 
       while (streamingRef.current) {
+        const state = useAppStore.getState();
+        const connStatus = state.instanceConnectionStatus[loopInstanceId];
+        if (connStatus !== 'Connected') {
+          break;
+        }
+
+        const currentInstance = state.instances.find((instance) => instance.id === loopInstanceId);
+        const currentTaskStatus = state.instanceTaskStatus[loopInstanceId];
+        if (!currentInstance?.isRunning && currentTaskStatus !== 'Running') {
+          break;
+        }
+
         const now = Date.now();
         const sleepTime = nextFrameTime - now;
         if (sleepTime > 0) {
@@ -395,9 +412,11 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
         }
       }
     } finally {
+      streamingRef.current = false;
+      setInstanceScreenshotStreaming(loopInstanceId, false);
       loopRunningRef.current = false;
     }
-  }, [instanceId, captureFrame]);
+  }, [instanceId, captureFrame, setInstanceScreenshotStreaming]);
 
   // 组件卸载时停止流
   useEffect(() => {
@@ -406,9 +425,9 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
     };
   }, []);
 
-  // 订阅/退订后端截图循环（确保全局只有一份 post_screencap 在运行）
+  // 订阅/退订后端截图循环（仅任务运行中启用，确保全局只有一份 post_screencap 在运行）
   useEffect(() => {
-    if (!instanceId || !isStreaming) return;
+    if (!instanceId || !isStreaming || !canPreview) return;
 
     const intervalMs = getFrameInterval(screenshotFrameRate);
     maaService
@@ -418,49 +437,41 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
     return () => {
       maaService.screenshotUnsubscribe(instanceId, `dashboard-${instanceId}`).catch(() => {});
     };
-  }, [instanceId, isStreaming, screenshotFrameRate]);
+  }, [instanceId, isStreaming, screenshotFrameRate, canPreview]);
 
   // 响应 store 中 isStreaming 状态变化
   useEffect(() => {
     // 同步 ref 与 store 状态
     streamingRef.current = isStreaming;
 
-    // 如果状态变为开启且已连接，启动流
-    if (isStreaming && isConnected) {
+    // 如果状态变为开启且任务正在运行，启动流
+    if (isStreaming && canPreview) {
       streamLoop();
     }
-  }, [isStreaming, isConnected, streamLoop]);
+  }, [isStreaming, canPreview, streamLoop]);
 
-  // 连接后自动开始截图流
-  const prevConnectedRef = useRef(false);
-  const hasAutoStartedRef = useRef(false);
+  // 任务开始后自动开始截图流
+  const prevCanPreviewRef = useRef(false);
 
-  // 组件挂载或状态恢复后，如果已连接，自动启动截图流
+  // 未运行任务时禁用实时预览，并确保后台截图订阅被关闭
   useEffect(() => {
-    // 避免重复启动
-    if (hasAutoStartedRef.current) return;
+    const couldPreview = prevCanPreviewRef.current;
+    prevCanPreviewRef.current = canPreview;
 
-    if (isConnected && !isStreaming) {
-      hasAutoStartedRef.current = true;
+    if (!canPreview) {
+      if (isStreaming) {
+        streamingRef.current = false;
+        setInstanceScreenshotStreaming(instanceId, false);
+      }
+      return;
+    }
+
+    // 从不可预览变为可预览时，自动启动截图流
+    if (!couldPreview && !isStreaming) {
       streamingRef.current = true;
       setInstanceScreenshotStreaming(instanceId, true);
-      streamLoop();
     }
-  }, [isConnected, isStreaming, instanceId, setInstanceScreenshotStreaming, streamLoop]);
-
-  // 连接状态变化时的处理（从未连接变为已连接时重新启动）
-  useEffect(() => {
-    const wasConnected = prevConnectedRef.current;
-    prevConnectedRef.current = isConnected;
-
-    // 从未连接变为已连接时，重置自动启动标记并启动
-    if (isConnected && !wasConnected && !isStreaming) {
-      hasAutoStartedRef.current = true;
-      streamingRef.current = true;
-      setInstanceScreenshotStreaming(instanceId, true);
-      streamLoop();
-    }
-  }, [isConnected, isStreaming, instanceId, setInstanceScreenshotStreaming, streamLoop]);
+  }, [canPreview, isStreaming, instanceId, setInstanceScreenshotStreaming]);
 
   // 全屏模式切换
   const toggleFullscreen = useCallback(
@@ -531,11 +542,13 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
 
   // 强制刷新
   const forceRefresh = useCallback(async () => {
+    if (!canPreview) return;
+
     const imageData = await captureFrame();
     if (imageData) {
       setScreenshotUrl(imageData);
     }
-  }, [captureFrame]);
+  }, [canPreview, captureFrame]);
 
   // 右键菜单（复用首页截图面板的菜单结构）
   const handleContextMenu = useCallback(
@@ -548,9 +561,9 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
           id: 'stream',
           label: isStreaming ? t('contextMenu.stopStream') : t('contextMenu.startStream'),
           icon: isStreaming ? Pause : Play,
-          disabled: !isConnected,
+          disabled: !canPreview,
           onClick: () => {
-            if (!instanceId || !isConnected) return;
+            if (!instanceId || !canPreview) return;
             if (isStreaming) {
               streamingRef.current = false;
               setInstanceScreenshotStreaming(instanceId, false);
@@ -565,7 +578,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
           id: 'refresh',
           label: t('contextMenu.forceRefresh'),
           icon: RefreshCw,
-          disabled: !isConnected,
+          disabled: !canPreview,
           onClick: forceRefresh,
         },
         { id: 'divider-1', label: '', divider: true },
@@ -608,6 +621,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
       t,
       instanceId,
       isConnected,
+      canPreview,
       isStreaming,
       screenshotUrl,
       setInstanceScreenshotStreaming,
@@ -646,7 +660,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
           <div className="absolute inset-0 flex flex-col items-center justify-center text-text-muted">
             <Monitor className="w-8 h-8 opacity-30 mb-1" />
             <span className="text-xs">
-              {isConnected ? t('screenshot.noScreenshot') : t('screenshot.connectFirst')}
+              {isConnected ? t('screenshot.startTaskFirst') : t('screenshot.connectFirst')}
             </span>
           </div>
         )}

--- a/src/components/ScreenshotPanel.tsx
+++ b/src/components/ScreenshotPanel.tsx
@@ -39,8 +39,10 @@ export function ScreenshotPanel() {
   const isMobile = useIsMobile();
   const {
     activeInstanceId,
+    instances,
     instanceConnectionStatus,
     instanceResourceLoaded,
+    instanceTaskStatus,
     sidePanelExpanded,
     instanceScreenshotStreaming,
     setInstanceScreenshotStreaming,
@@ -70,6 +72,13 @@ export function ScreenshotPanel() {
   }, [screenshotFrameRate]);
 
   const instanceId = activeInstanceId || '';
+  const connectionStatus = instanceId ? instanceConnectionStatus[instanceId] : undefined;
+  const isResourceLoaded = instanceId ? instanceResourceLoaded[instanceId] : false;
+  const activeInstance = instances.find((instance) => instance.id === instanceId);
+  const taskStatus = instanceId ? instanceTaskStatus[instanceId] : undefined;
+  const isTaskRunning = Boolean(activeInstance?.isRunning) || taskStatus === 'Running';
+  // 预览截图可能触发部分 Win32 截图后端抢前台；只在任务运行中启用实时预览。
+  const canPreview = connectionStatus === 'Connected' && isTaskRunning;
 
   // 从 store 获取当前实例的截图流状态
   const isStreaming = instanceId ? (instanceScreenshotStreaming[instanceId] ?? false) : false;
@@ -86,7 +95,7 @@ export function ScreenshotPanel() {
 
   // 获取最新缓存截图（后端截图循环负责更新缓存，前端无需主动触发 postScreencap）
   const captureFrame = useCallback(async (): Promise<string | null> => {
-    if (!instanceId) return null;
+    if (!instanceId || !canPreview) return null;
 
     try {
       const imageData = await withTimeout(maaService.getCachedImage(instanceId), API_TIMEOUT);
@@ -95,7 +104,7 @@ export function ScreenshotPanel() {
       log.warn('获取截图失败:', err);
       throw err;
     }
-  }, [instanceId]);
+  }, [instanceId, canPreview]);
 
   // 全屏模式切换
   const toggleFullscreen = (e?: React.MouseEvent) => {
@@ -110,9 +119,9 @@ export function ScreenshotPanel() {
     };
   }, []);
 
-  // 订阅/退订后端截图循环（确保全局只有一份 post_screencap 在运行）
+  // 订阅/退订后端截图循环（仅任务运行中启用，确保全局只有一份 post_screencap 在运行）
   useEffect(() => {
-    if (!instanceId || !isStreaming) return;
+    if (!instanceId || !isStreaming || !canPreview) return;
 
     const intervalMs = getFrameInterval(screenshotFrameRate);
     maaService
@@ -122,7 +131,7 @@ export function ScreenshotPanel() {
     return () => {
       maaService.screenshotUnsubscribe(instanceId, `panel-${instanceId}`).catch(() => {});
     };
-  }, [instanceId, isStreaming, screenshotFrameRate]);
+  }, [instanceId, isStreaming, screenshotFrameRate, canPreview]);
 
   // ESC 键退出全屏
   useEffect(() => {
@@ -163,6 +172,13 @@ export function ScreenshotPanel() {
         const connStatus = useAppStore.getState().instanceConnectionStatus[loopInstanceId];
         if (connStatus !== 'Connected') {
           setError('连接已断开');
+          break;
+        }
+
+        const state = useAppStore.getState();
+        const currentInstance = state.instances.find((instance) => instance.id === loopInstanceId);
+        const currentTaskStatus = state.instanceTaskStatus[loopInstanceId];
+        if (!currentInstance?.isRunning && currentTaskStatus !== 'Running') {
           break;
         }
 
@@ -224,7 +240,7 @@ export function ScreenshotPanel() {
     (e?: React.MouseEvent) => {
       e?.stopPropagation();
 
-      if (!instanceId) return;
+      if (!instanceId || !canPreview) return;
 
       if (isStreaming) {
         // 停止流
@@ -248,6 +264,7 @@ export function ScreenshotPanel() {
       streamLoop,
       screenshotPanelExpanded,
       setScreenshotPanelExpanded,
+      canPreview,
     ],
   );
 
@@ -264,14 +281,10 @@ export function ScreenshotPanel() {
     streamingRef.current = newInstanceStreaming;
 
     // 如果新实例的截图流是开启的，启动流循环
-    if (newInstanceStreaming && instanceId) {
+    if (newInstanceStreaming && instanceId && canPreview) {
       streamLoop();
     }
-  }, [instanceId]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // 连接成功后自动开始实时截图（仅当面板可见且未开启时）
-  const connectionStatus = instanceId ? instanceConnectionStatus[instanceId] : undefined;
-  const isResourceLoaded = instanceId ? instanceResourceLoaded[instanceId] : false;
+  }, [instanceId, canPreview]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // 当设备已连接且资源已加载时自动折叠（与连接设置面板行为一致）
   useEffect(() => {
@@ -280,45 +293,36 @@ export function ScreenshotPanel() {
     }
   }, [connectionStatus, isResourceLoaded, setScreenshotPanelExpanded]);
 
-  // 面板折叠时暂停截图，展开时自动开始（如果已连接）
+  const prevConnectionStatusRef = useRef<typeof connectionStatus>(undefined);
+  const prevCanPreviewRef = useRef(false);
+  const hasAutoStartedRef = useRef(false);
+
+  // 未运行任务时禁用实时预览，并确保后台截图订阅被关闭
+  useEffect(() => {
+    if (!canPreview) {
+      hasAutoStartedRef.current = false;
+    }
+
+    if (!canPreview && isStreaming) {
+      streamingRef.current = false;
+      setIsStreaming(false);
+    }
+  }, [canPreview, isStreaming, setIsStreaming]);
+
+  // 面板折叠时暂停截图，展开时仅在任务运行中自动开始
   useEffect(() => {
     if (!screenshotPanelExpanded || !isPanelVisible) {
       // 折叠时暂停截图流，同步更新状态和图标
       streamingRef.current = false;
       setIsStreaming(false);
-    } else if (connectionStatus === 'Connected' && instanceId) {
-      // 展开且已连接时，自动开始截图
+    } else if (canPreview && instanceId) {
+      // 展开且任务运行中，自动开始截图
       streamingRef.current = true;
       setIsStreaming(true);
       setError(null);
       streamLoop();
     }
-  }, [screenshotPanelExpanded, isPanelVisible]); // eslint-disable-line react-hooks/exhaustive-deps
-  const prevConnectionStatusRef = useRef<typeof connectionStatus>(undefined);
-  const hasAutoStartedRef = useRef(false);
-
-  // 组件挂载或状态恢复后，如果已连接且面板可见，自动启动截图流
-  useEffect(() => {
-    // 避免重复启动（仅在首次检测到已连接时启动）
-    if (hasAutoStartedRef.current) return;
-
-    const isConnected = connectionStatus === 'Connected';
-    if (isConnected && !isStreaming && screenshotPanelExpanded && isPanelVisible && instanceId) {
-      hasAutoStartedRef.current = true;
-      streamingRef.current = true;
-      setIsStreaming(true);
-      setError(null);
-      streamLoop();
-    }
-  }, [
-    connectionStatus,
-    instanceId,
-    screenshotPanelExpanded,
-    isPanelVisible,
-    isStreaming,
-    setIsStreaming,
-    streamLoop,
-  ]);
+  }, [screenshotPanelExpanded, isPanelVisible, canPreview]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // 实例切换时重置自动启动标记
   useEffect(() => {
@@ -357,7 +361,7 @@ export function ScreenshotPanel() {
 
   // 强制刷新截图
   const forceRefresh = useCallback(async () => {
-    if (!instanceId) return;
+    if (!instanceId || !canPreview) return;
 
     try {
       const imageData = await captureFrame();
@@ -368,7 +372,7 @@ export function ScreenshotPanel() {
     } catch (err) {
       log.warn('强制刷新失败:', err);
     }
-  }, [instanceId, captureFrame]);
+  }, [instanceId, canPreview, captureFrame]);
 
   // 断开连接（销毁实例）
   const disconnect = useCallback(async () => {
@@ -420,21 +424,19 @@ export function ScreenshotPanel() {
       e.preventDefault();
       e.stopPropagation();
 
-      const isConnected = connectionStatus === 'Connected';
-
       const menuItems: MenuItem[] = [
         {
           id: 'stream',
           label: isStreaming ? t('contextMenu.stopStream') : t('contextMenu.startStream'),
           icon: isStreaming ? Pause : Play,
-          disabled: !instanceId || !isConnected,
+          disabled: !instanceId || !canPreview,
           onClick: () => toggleStreaming(),
         },
         {
           id: 'refresh',
           label: t('contextMenu.forceRefresh'),
           icon: RefreshCw,
-          disabled: !instanceId || !isConnected,
+          disabled: !instanceId || !canPreview,
           onClick: forceRefresh,
         },
         { id: 'divider-1', label: '', divider: true },
@@ -465,7 +467,7 @@ export function ScreenshotPanel() {
           id: 'disconnect',
           label: t('contextMenu.disconnect'),
           icon: Unplug,
-          disabled: !isConnected,
+          disabled: connectionStatus !== 'Connected',
           danger: true,
           onClick: disconnect,
         },
@@ -477,6 +479,7 @@ export function ScreenshotPanel() {
       t,
       instanceId,
       connectionStatus,
+      canPreview,
       isStreaming,
       screenshotUrl,
       toggleStreaming,
@@ -489,10 +492,12 @@ export function ScreenshotPanel() {
   );
 
   useEffect(() => {
-    // 检测连接状态从非 Connected 变为 Connected
+    // 检测连接状态变化，用于断开时清理截图状态
     const wasConnected = prevConnectionStatusRef.current === 'Connected';
     const isConnected = connectionStatus === 'Connected';
     prevConnectionStatusRef.current = connectionStatus;
+    const couldPreview = prevCanPreviewRef.current;
+    prevCanPreviewRef.current = canPreview;
 
     // 连接断开时清空截图（如切换控制器、断开连接等场景）
     if (wasConnected && !isConnected) {
@@ -502,13 +507,17 @@ export function ScreenshotPanel() {
     }
 
     if (
-      isConnected &&
-      !wasConnected &&
+      canPreview &&
+      !couldPreview &&
       !isStreaming &&
       screenshotPanelExpanded &&
       isPanelVisible &&
       instanceId
     ) {
+      if (hasAutoStartedRef.current) return;
+
+      // 从不可预览变为可预览时，自动启动截图流。
+      hasAutoStartedRef.current = true;
       streamingRef.current = true;
       setIsStreaming(true);
       setError(null);
@@ -516,6 +525,7 @@ export function ScreenshotPanel() {
     }
   }, [
     connectionStatus,
+    canPreview,
     instanceId,
     screenshotPanelExpanded,
     isPanelVisible,
@@ -556,16 +566,22 @@ export function ScreenshotPanel() {
               e.stopPropagation();
               toggleStreaming();
             }}
-            disabled={!instanceId}
+            disabled={!instanceId || !canPreview}
             className={clsx(
               'p-1 rounded-md transition-colors',
-              !instanceId
+              !instanceId || !canPreview
                 ? 'text-text-muted cursor-not-allowed'
                 : isStreaming
                   ? 'text-success hover:bg-bg-tertiary'
                   : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
             )}
-            title={isStreaming ? t('screenshot.stopStream') : t('screenshot.startStream')}
+            title={
+              !canPreview
+                ? t('screenshot.startTaskFirst')
+                : isStreaming
+                  ? t('screenshot.stopStream')
+                  : t('screenshot.startStream')
+            }
           >
             {isStreaming ? <Pause className="w-3.5 h-3.5" /> : <Play className="w-3.5 h-3.5" />}
           </button>
@@ -634,7 +650,11 @@ export function ScreenshotPanel() {
                     <>
                       <span className="text-xs">{t('screenshot.noScreenshot')}</span>
                       <span className="text-xs text-text-muted">
-                        {t('screenshot.connectFirst')}
+                        {t(
+                          connectionStatus !== 'Connected'
+                            ? 'screenshot.connectFirst'
+                            : 'screenshot.startTaskFirst',
+                        )}
                       </span>
                     </>
                   )}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -415,6 +415,7 @@ export default {
     startStream: 'Start Live Stream',
     stopStream: 'Stop Live Stream',
     connectFirst: 'Please connect a device first',
+    startTaskFirst: 'Please start a task first',
     fullscreen: 'Fullscreen',
     exitFullscreen: 'Exit Fullscreen',
     clickHint: 'Click on the image to send a tap to the device',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -411,6 +411,7 @@ export default {
     startStream: 'ライブストリームを開始',
     stopStream: 'ライブストリームを停止',
     connectFirst: '先にデバイスを接続してください',
+    startTaskFirst: '先にタスクを開始してください',
     fullscreen: '全画面表示',
     exitFullscreen: '全画面を終了',
     clickHint: '画面をクリックするとデバイスにタップを送信します',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -408,6 +408,7 @@ export default {
     startStream: '라이브 스트림 시작',
     stopStream: '라이브 스트림 중지',
     connectFirst: '먼저 기기를 연결하세요',
+    startTaskFirst: '먼저 작업을 시작하세요',
     fullscreen: '전체 화면',
     exitFullscreen: '전체 화면 종료',
     clickHint: '화면을 클릭하면 기기에 탭을 전송합니다',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -404,6 +404,7 @@ export default {
     startStream: '开始实时流',
     stopStream: '停止实时流',
     connectFirst: '请先连接设备',
+    startTaskFirst: '请先开始任务',
     fullscreen: '全屏显示',
     exitFullscreen: '退出全屏',
     clickHint: '点击画面可向设备发送点击',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -400,6 +400,7 @@ export default {
     startStream: '開始即時流',
     stopStream: '停止即時流',
     connectFirst: '請先連接裝置',
+    startTaskFirst: '請先開始任務',
     fullscreen: '全螢幕顯示',
     exitFullscreen: '退出全螢幕',
     clickHint: '點擊畫面可向裝置發送點擊',


### PR DESCRIPTION
Fixes https://github.com/MaaEnd/MaaEnd/issues/3262
头疼砍头这一块

在未开始任务时禁用Preivew以防止意料之外的由于截图引发的窗口前置

## Summary by Sourcery

在运行中的任务前提下才启用截图实时预览，以避免意外的窗口聚焦，并调整相关的自动开始/停止行为。

新功能：
- 只有在存在正在运行的任务时，才在截图面板和仪表盘实例卡片中启用截图实时预览。

错误修复：
- 当没有任务运行时，防止实时预览导致前台窗口被意外激活。

增强改进：
- 将截图流的自动开始/停止逻辑与任务运行状态和连接状态对齐，确保在预览被禁用时清理订阅。
- 改进空状态和控制提示，以区分“需要连接设备”和“需要启动任务”这两种情形，从而明确在什么情况下可以使用预览。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate screenshot live preview behind running tasks to avoid unintended window focus and adjust related auto-start/stop behavior.

New Features:
- Require an active running task before enabling screenshot live preview in both the screenshot panel and dashboard instance cards.

Bug Fixes:
- Prevent live preview from triggering unintended foreground window activation when no task is running.

Enhancements:
- Align auto-start/stop logic of screenshot streams with task running state and connection status, ensuring subscriptions are cleaned up when preview is disabled.
- Improve empty-state and control hints to distinguish between needing to connect a device and needing to start a task before preview is available.

</details>