### PR TITLE
Improve WebView2 bootstrap recovery

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,18 @@ use tauri::Manager;
 use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
 use ws_broadcast::WsBroadcast;
 
+#[cfg(target_os = "windows")]
+fn clear_webview_boot_marker() {
+    let Some(exe_dir) = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|dir| dir.to_path_buf()))
+    else {
+        return;
+    };
+    let marker = exe_dir.join("cache").join("webview_boot_pending");
+    let _ = std::fs::remove_file(marker);
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // 日志目录：exe 目录/debug/logs（与前端日志同目录）
@@ -56,6 +68,9 @@ pub fn run() {
                 .build(),
         )
         .setup(|app| {
+            #[cfg(target_os = "windows")]
+            clear_webview_boot_marker();
+
             // 创建 MaaState 并注册为 Tauri 管理状态
             let maa_state = Arc::new(MaaState::default());
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,34 +4,128 @@
 #[cfg(target_os = "windows")]
 mod webview2;
 
+#[cfg(target_os = "windows")]
+fn exe_dir() -> Option<std::path::PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|dir| dir.to_path_buf()))
+}
+
+#[cfg(target_os = "windows")]
+fn bootstrap_log(message: &str) {
+    use std::io::Write;
+
+    let Some(exe_dir) = exe_dir() else {
+        return;
+    };
+    let debug_dir = exe_dir.join("debug");
+    let _ = std::fs::create_dir_all(&debug_dir);
+    let log_path = debug_dir.join("bootstrap.log");
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+    {
+        let _ = writeln!(file, "{}", message);
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn webview_boot_marker_path() -> Option<std::path::PathBuf> {
+    exe_dir().map(|dir| dir.join("cache").join("webview_boot_pending"))
+}
+
+#[cfg(target_os = "windows")]
+fn mark_webview_boot_pending() {
+    let Some(marker) = webview_boot_marker_path() else {
+        return;
+    };
+    if let Some(parent) = marker.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(marker, b"pending");
+}
+
+#[cfg(target_os = "windows")]
+fn repair_webview_data_after_previous_failure() {
+    let Some(marker) = webview_boot_marker_path() else {
+        return;
+    };
+    if !marker.exists() {
+        return;
+    }
+
+    bootstrap_log("previous WebView boot did not reach Tauri setup; rotating webview_data");
+    let _ = std::fs::remove_file(&marker);
+
+    let Some(exe_dir) = exe_dir() else {
+        return;
+    };
+    let webview_data_dir = exe_dir.join("cache").join("webview_data");
+    if !webview_data_dir.exists() {
+        return;
+    }
+
+    let backup_name = format!(
+        "webview_data.bak-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    );
+    let backup_dir = exe_dir.join("cache").join(backup_name);
+    match std::fs::rename(&webview_data_dir, &backup_dir) {
+        Ok(()) => bootstrap_log("rotated webview_data successfully"),
+        Err(e) => bootstrap_log(&format!("failed to rotate webview_data: {}", e)),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn is_fixed_webview2_runtime_usable(runtime_dir: &std::path::Path) -> bool {
+    runtime_dir.is_dir()
+        && runtime_dir.join("msedgewebview2.exe").is_file()
+        && runtime_dir.join("EBWebView").is_dir()
+}
+
 fn main() {
+    #[cfg(target_os = "windows")]
+    bootstrap_log("mxu bootstrap start");
+
     if mxu_lib::commands::system::has_help_flag() {
+        #[cfg(target_os = "windows")]
+        bootstrap_log("help flag detected; exiting");
         mxu_lib::commands::system::print_cli_help_text();
         std::process::exit(0);
     }
 
     #[cfg(target_os = "windows")]
     {
+        repair_webview_data_after_previous_failure();
+
         // 设置 WebView2 数据目录为程序所在目录下的 webview_data 文件夹
         // 这样可以避免用户名包含特殊字符（如中文）导致 WebView2 无法创建数据目录的问题
-        if let Ok(exe_path) = std::env::current_exe() {
-            if let Some(exe_dir) = exe_path.parent() {
-                let webview_data_dir = exe_dir.join("cache").join("webview_data");
-                // 确保目录存在
-                let _ = std::fs::create_dir_all(&webview_data_dir);
-                std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", &webview_data_dir);
+        if let Some(exe_dir) = exe_dir() {
+            let webview_data_dir = exe_dir.join("cache").join("webview_data");
+            // 确保目录存在
+            match std::fs::create_dir_all(&webview_data_dir) {
+                Ok(()) => bootstrap_log("webview_data directory ready"),
+                Err(e) => bootstrap_log(&format!("failed to create webview_data: {}", e)),
+            }
+            std::env::set_var("WEBVIEW2_USER_DATA_FOLDER", &webview_data_dir);
 
-                // 检测已缓存的 WebView2 固定版本运行时
-                // 验证目录包含关键文件以确保运行时完整可用
-                if let Ok(webview2_runtime_dir) = webview2::get_webview2_runtime_dir() {
-                    if webview2_runtime_dir.is_dir()
-                        && webview2_runtime_dir.join("msedgewebview2.exe").exists()
-                    {
-                        std::env::set_var(
-                            "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER",
-                            &webview2_runtime_dir,
-                        );
-                    }
+            // 检测已缓存的 WebView2 固定版本运行时
+            // 验证目录包含关键文件以确保运行时完整可用，否则回退到系统 WebView2/重新下载
+            if let Ok(webview2_runtime_dir) = webview2::get_webview2_runtime_dir() {
+                if is_fixed_webview2_runtime_usable(&webview2_runtime_dir) {
+                    std::env::set_var(
+                        "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER",
+                        &webview2_runtime_dir,
+                    );
+                    bootstrap_log("using fixed WebView2 runtime");
+                } else if webview2_runtime_dir.exists() {
+                    bootstrap_log(
+                        "fixed WebView2 runtime is incomplete; falling back to system/runtime install",
+                    );
                 }
             }
         }
@@ -40,6 +134,7 @@ fn main() {
         if std::env::var_os("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER").is_none()
             && !webview2::ensure_webview2()
         {
+            bootstrap_log("WebView2 is unavailable; exiting before Tauri run");
             std::process::exit(1);
         }
 
@@ -51,6 +146,8 @@ fn main() {
                 Ok(p) => p,
                 Err(_) => {
                     // 获取路径失败就按普通权限继续
+                    bootstrap_log("failed to get current exe before elevation; entering run");
+                    mark_webview_boot_pending();
                     mxu_lib::run();
                     return;
                 }
@@ -69,9 +166,17 @@ fn main() {
 
             if result.is_ok() {
                 // 新的管理员进程已启动，退出当前普通权限进程
+                bootstrap_log("elevated process started; exiting non-elevated bootstrap");
                 std::process::exit(0);
             }
+            bootstrap_log("elevation failed or was cancelled; continuing normally");
         }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        bootstrap_log("entering mxu_lib::run");
+        mark_webview_boot_pending();
     }
 
     mxu_lib::run()


### PR DESCRIPTION
## Summary
- add an early Windows bootstrap log before Tauri logging starts
- mark WebView startup as pending and rotate cache/webview_data on the next launch if Tauri setup was never reached
- avoid using an incomplete fixed WebView2 runtime and fall back to system/runtime install instead

## Testing
- git diff --check
- Not run: cargo fmt/check, cargo is not available in this environment

## Summary by Sourcery

提升 Windows WebView2 启动的健壮性和诊断能力，以从启动失败中恢复，并避免使用不完整的固定运行时。

New Features:
- 在 Tauri 日志初始化之前，将早期的 Windows 启动日志记录到 debug/bootstrap.log 文件中。
- 使用标记文件跟踪 WebView 启动状态，如果从未到达 Tauri setup 阶段，则在下次启动时触发缓存的 `webview_data` 轮换。

Bug Fixes:
- 当缓存的固定 WebView2 运行时缺少必需文件时，跳过使用该缓存，改为回退到系统或运行时安装。
- 通过备份并重新创建 `webview_data` 目录，从之前失败的 WebView 启动中恢复。

Enhancements:
- 统一 Windows 可执行文件目录解析逻辑，并在各个启动辅助模块中复用。
- 确保记录 WebView2 用户数据和运行时选择，以帮助排查启动相关问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Windows WebView2 startup robustness and diagnostics to recover from failed boots and avoid using incomplete fixed runtimes.

New Features:
- Add early Windows bootstrap logging to a debug/bootstrap.log file before Tauri logging initializes.
- Track WebView startup state with a marker file to trigger rotation of cached webview_data on the next launch if Tauri setup is never reached.

Bug Fixes:
- Skip using a cached fixed WebView2 runtime when required files are missing and fall back to system or runtime installation instead.
- Recover from previous failed WebView boots by backing up and recreating the webview_data directory.

Enhancements:
- Centralize Windows executable directory resolution and reuse it across bootstrap helpers.
- Ensure WebView2 user data and runtime selection are logged to aid troubleshooting of bootstrap issues.

</details>