### PR TITLE
fix: 下载整体请求超时时间从十分钟改为一百分钟

### DIFF
--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -183,7 +183,7 @@ pub async fn download_file(
     // 构建 HTTP 客户端和请求
     let mut client_builder = reqwest::Client::builder()
         .user_agent(build_user_agent())
-        .timeout(std::time::Duration::from_secs(600)) // 10 分钟超时，足够下载大文件但防止无限挂起
+        .timeout(std::time::Duration::from_secs(6000)) // 100 分钟超时，足够下载大文件但防止无限挂起
         .connect_timeout(std::time::Duration::from_secs(10));
 
     // 配置代理（如果提供）


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 将下载 HTTP 客户端超时时间从 10 分钟延长到 100 分钟，以防止大文件长时间下载时过早失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Extend the download HTTP client timeout from 10 minutes to 100 minutes to prevent premature failures for long-running large file downloads.

</details>