### PR TITLE
fix(自定义程序任务): 修复窗口较窄时导入文件按钮显示不全

### DIFF
--- a/src/components/FormControls.tsx
+++ b/src/components/FormControls.tsx
@@ -312,13 +312,13 @@ export function FileInput({
   };
 
   return (
-    <div className={clsx('flex gap-2', className)}>
+    <div className={clsx('flex min-w-0 gap-2', className)}>
       <TextInput
         value={value}
         onChange={onChange}
         placeholder={placeholder}
         disabled={disabled}
-        className="flex-1"
+        className="min-w-0 flex-1"
       />
       {isTauri() && (
         <button

--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -250,8 +250,8 @@ function InputField({
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center gap-3">
-        <div className="flex items-center gap-1.5 min-w-0 flex-1">
+      <div className="flex flex-wrap items-center gap-3 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0 flex-1 basis-[14rem]">
           {input.icon && (
             <AsyncIcon
               icon={input.icon}
@@ -272,14 +272,14 @@ function InputField({
             onChange={onChange}
             placeholder={inputPlaceholder}
             disabled={disabled}
-            className="w-[30%] flex-shrink-0"
+            className="min-w-[min(12rem,100%)] flex-1 basis-[30%]"
           />
         ) : input.input_type === 'time' ? (
           <TimeInput
             value={value}
             onChange={onChange}
             disabled={disabled}
-            className="w-[30%] flex-shrink-0"
+            className="min-w-[min(12rem,100%)] flex-1 basis-[30%]"
           />
         ) : (
           <TextInput
@@ -288,7 +288,7 @@ function InputField({
             placeholder={inputPlaceholder}
             disabled={disabled}
             hasError={!!validationError}
-            className="w-[30%] flex-shrink-0"
+            className="min-w-[min(12rem,100%)] flex-1 basis-[30%]"
             type={input.pipeline_type === 'int' ? 'number' : 'text'}
             inputMode={input.pipeline_type === 'int' ? 'numeric' : undefined}
             step={input.pipeline_type === 'int' ? 1 : undefined}


### PR DESCRIPTION
- fix https://github.com/MaaEnd/MaaEnd/issues/3446

## Summary by Sourcery

Bug Fixes:
- 确保在窗口变窄时，导入文件按钮及其相关输入字段仍然完全可见且可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the import file button and associated input fields remain fully visible and usable when the window is narrow.

</details>