### PR TITLE
feat(onboarding): 强制走完新手引导，开发版本可跳过

### DIFF
--- a/src/components/OnboardingOverlay.tsx
+++ b/src/components/OnboardingOverlay.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@/stores/appStore';
 import { loggers } from '@/utils/logger';
+import { isDebugVersion } from '@/services/updateService';
 import type {
   Driver as DriverInstance,
   DriverConfig as DriverFactoryOptions,
@@ -52,15 +53,18 @@ export function OnboardingOverlay() {
     onboardingCompleted,
     setOnboardingCompleted,
     setShowAddTaskPanel,
-    instanceConnectionStatus,
-    instanceResourceLoaded,
-    activeInstanceId,
+    projectInterface,
   } = useAppStore();
+
+  const isDevMode = useMemo(
+    () => import.meta.env.DEV || isDebugVersion(projectInterface?.version),
+    [projectInterface?.version],
+  );
 
   const driverRef = useRef<DriverInstance | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const startedRef = useRef(false);
-  // 只有用户点击最后一步的"知道了"才视为完成；中途关闭下次启动仍提示
+  // 仅合法完成路径置 true；组件卸载触发的 destroy 走 false 分支，下次重新弹出
   const tourFinishedRef = useRef(false);
 
   // 启动 driver.js 引导
@@ -80,7 +84,7 @@ export function OnboardingOverlay() {
           description: t('onboarding.message'),
           side: 'left',
           align: 'start',
-          showButtons: ['next', 'close'],
+          showButtons: ['next'],
           nextBtnText: t('onboarding.next'),
         },
       },
@@ -91,7 +95,7 @@ export function OnboardingOverlay() {
           description: t('onboarding.tabBarMessage'),
           side: 'bottom',
           align: 'start',
-          showButtons: ['next', 'close'],
+          showButtons: ['next'],
           nextBtnText: t('onboarding.next'),
           // 进入"添加任务"步骤前，先打开面板再推进
           onNextClick: (_el, _step, { driver: d }) => {
@@ -107,9 +111,8 @@ export function OnboardingOverlay() {
           description: t('onboarding.addTaskMessage'),
           side: 'top',
           align: 'center',
-          showButtons: ['next', 'close'],
+          showButtons: ['next'],
           doneBtnText: t('onboarding.gotIt'),
-          // 点击"知道了"才标记完成，中途关闭不算
           onNextClick: (_el, _step, { driver: d }) => {
             tourFinishedRef.current = true;
             d.moveNext();
@@ -127,13 +130,28 @@ export function OnboardingOverlay() {
         overlayOpacity: 0.4,
         stagePadding: 6,
         stageRadius: 8,
-        allowClose: true,
+        allowClose: false,
         popoverClass: 'mxu-onboarding-popover',
+        onPopoverRender: (popover) => {
+          if (!isDevMode) return;
+          const footer = popover.footerButtons;
+          if (!footer || footer.querySelector('.mxu-onboarding-skip')) return;
+          const btn = document.createElement('button');
+          // className 不能包含 "driver-popover"，否则会被 driver.js 的事件嗅探吞掉点击
+          btn.className = 'mxu-onboarding-skip';
+          btn.type = 'button';
+          btn.textContent = t('onboarding.skipDev');
+          btn.addEventListener('click', () => {
+            tourFinishedRef.current = true;
+            driverRef.current?.destroy();
+          });
+          footer.insertBefore(btn, footer.firstChild);
+        },
         onDestroyed: () => {
+          // 唯一的 completed 写入口；中途关闭（含关软件）走 false 分支，下次重新弹
           if (tourFinishedRef.current) {
             setOnboardingCompleted(true);
           } else {
-            // 用户中途关闭，重置 startedRef 以便下次启动重新触发
             startedRef.current = false;
           }
         },
@@ -145,29 +163,7 @@ export function OnboardingOverlay() {
       startedRef.current = false;
       log.warn('Failed to load onboarding driver:', err);
     }
-  }, [onboardingCompleted, t, setOnboardingCompleted, setShowAddTaskPanel]);
-
-  // 监听连接状态，一旦用户成功连接设备并加载资源，自动关闭引导
-  useEffect(() => {
-    if (onboardingCompleted || !driverRef.current?.isActive()) return;
-
-    const currentInstanceId = activeInstanceId;
-    if (!currentInstanceId) return;
-
-    const isConnected = instanceConnectionStatus[currentInstanceId] === 'Connected';
-    const isResourceLoaded = instanceResourceLoaded[currentInstanceId];
-
-    if (isConnected && isResourceLoaded) {
-      driverRef.current?.destroy();
-      setOnboardingCompleted(true);
-    }
-  }, [
-    onboardingCompleted,
-    activeInstanceId,
-    instanceConnectionStatus,
-    instanceResourceLoaded,
-    setOnboardingCompleted,
-  ]);
+  }, [onboardingCompleted, t, setOnboardingCompleted, setShowAddTaskPanel, isDevMode]);
 
   // 等待所有模态弹窗关闭后再启动引导
   useEffect(() => {

--- a/src/components/WelcomeDialog.tsx
+++ b/src/components/WelcomeDialog.tsx
@@ -46,6 +46,7 @@ export function WelcomeDialog() {
   useEffect(() => {
     if (!projectInterface?.welcome) {
       setIsOpen(false);
+      setIsLoading(false);
       return;
     }
 
@@ -60,6 +61,7 @@ export function WelcomeDialog() {
 
       if (!resolvedContent) {
         setIsOpen(false);
+        setIsLoading(false);
         return;
       }
 
@@ -70,6 +72,7 @@ export function WelcomeDialog() {
       // 如果内容已经显示过（hash 相同），不再显示
       if (welcomeShownHash === contentHash) {
         setIsOpen(false);
+        setIsLoading(false);
         return;
       }
 
@@ -95,7 +98,13 @@ export function WelcomeDialog() {
     setIsOpen(false);
   };
 
-  if (!isOpen || isLoading) return null;
+  if (!isOpen || isLoading) {
+    // 加载中渲染不可见的 z-50 占位，让 OnboardingOverlay 感知 welcome 决策未完成，避免教程抢先弹出
+    if (projectInterface?.welcome && isLoading) {
+      return <div className="fixed inset-0 z-50 pointer-events-none" aria-hidden />;
+    }
+    return null;
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -571,6 +571,7 @@ export default {
     next: 'Next',
     prev: 'Previous',
     gotIt: 'Got it',
+    skipDev: 'Skip (DEV)',
   },
 
   // Instance

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -568,6 +568,7 @@ export default {
     next: '次へ',
     prev: '前へ',
     gotIt: '了解しました',
+    skipDev: 'スキップ (DEV)',
   },
 
   // インスタンス

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -563,6 +563,7 @@ export default {
     next: '다음',
     prev: '이전',
     gotIt: '알겠습니다',
+    skipDev: '건너뛰기 (DEV)',
   },
 
   // 인스턴스

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -554,6 +554,7 @@ export default {
     next: '下一步',
     prev: '上一步',
     gotIt: '知道了',
+    skipDev: '跳过（DEV）',
   },
 
   // 实例

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -550,6 +550,7 @@ export default {
     next: '下一步',
     prev: '上一步',
     gotIt: '知道了',
+    skipDev: '跳過（DEV）',
   },
 
   // 執行個體

--- a/src/index.css
+++ b/src/index.css
@@ -490,6 +490,11 @@ body {
   border-bottom-color: var(--color-accent);
 }
 
+/* className 不能包含 "driver-popover"，否则会被 driver.js 的事件嗅探吞掉点击 */
+.mxu-onboarding-popover .mxu-onboarding-skip {
+  margin-right: auto;
+}
+
 /* 背景图片模式下让UI元素背景半透明 */
 .has-background-image .bg-bg-secondary {
   background-color: color-mix(in srgb, var(--color-bg-secondary) 40%, transparent) !important;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,6 +10,18 @@ declare module 'driver.js' {
     moveNext: () => void;
   }
 
+  export interface PopoverDOM {
+    wrapper: HTMLElement;
+    arrow: HTMLElement;
+    title: HTMLElement;
+    description: HTMLElement;
+    footer: HTMLElement;
+    footerButtons: HTMLElement;
+    previousButton: HTMLButtonElement;
+    nextButton: HTMLButtonElement;
+    closeButton: HTMLButtonElement;
+  }
+
   export interface DriverStep {
     element: string;
     popover: {
@@ -17,7 +29,7 @@ declare module 'driver.js' {
       description: string;
       side: 'left' | 'right' | 'top' | 'bottom';
       align: 'start' | 'center' | 'end';
-      showButtons: Array<'next' | 'close'>;
+      showButtons: Array<'next' | 'previous' | 'close'>;
       nextBtnText?: string;
       doneBtnText?: string;
       onNextClick?: (
@@ -39,6 +51,7 @@ declare module 'driver.js' {
     stageRadius: number;
     allowClose: boolean;
     popoverClass: string;
+    onPopoverRender?: (popover: PopoverDOM) => void;
     onDestroyed: () => void;
   }
 


### PR DESCRIPTION
- close https://github.com/MistEO/MXU/issues/238

## 正文:
- 屏蔽 ESC、遮罩点击、× 按钮，引导必须走完最后一步才视为完成； 中途关闭软件不写入 completed，下次启动重新弹出

- 开发模式（import.meta.env.DEV 或 isDebugVersion）下在 popover 左侧注入「跳过（DEV）」按钮，非开发版完全不渲染

- 以及修复 WelcomeDialog 异步加载窗口期内教程抢先弹出后被公告盖住的 竞态(测 maaend 的 api 测出来的,加载超过 600 ms 容易触发)：加载中渲染一个不可见的 z-50 占位，让 hasActiveModal 能 正确感知决策未完成

### 效果演示 :

https://github.com/user-attachments/assets/afffdaf1-15ad-443e-a89c-7d14b52e7559

## Summary by Sourcery

在强制完成新手引导教程的同时，增加仅用于开发环境的跳过选项，并防止教程在欢迎对话框之前过早开始。

New Features:
- 要求用户完成所有新手引导步骤后才视为完成，在正常构建中移除引导流程中的关闭/跳过控件。
- 在新手引导气泡中添加仅限开发模式使用的跳过按钮，允许开发者绕过教程。
- 暴露更多 `driver.js` 气泡的类型定义，以支持自定义气泡渲染钩子和导航按钮。

Bug Fixes:
- 确保在所有提前返回的路径中正确清除欢迎对话框的加载状态，防止其被阻塞或被新手引导教程覆盖。
- 在欢迎对话框加载期间渲染一个不可见但具有高 z-index 的占位元素，使新手引导能够正确检测到活动模态窗口，从而不会抢先于它显示。

Enhancements:
- 通过移除“设备资源加载完成后自动完成引导”的行为，简化新手引导完成逻辑。
- 调整新手引导气泡样式以对齐新的跳过按钮，并为开发环境中的跳过标签在所有支持的语言中添加本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce completion of the onboarding tutorial while adding a development-only skip option and preventing the tutorial from racing ahead of the welcome dialog.

New Features:
- Require users to complete all onboarding steps before it is considered finished, removing close/skip controls from the tour in normal builds.
- Add a development-mode-only skip button to the onboarding popover, allowing developers to bypass the tutorial.
- Expose additional driver.js popover typing to support custom popover render hooks and navigation buttons.

Bug Fixes:
- Ensure the welcome dialog loading state is cleared correctly in all early-return paths, preventing it from blocking or being overlaid by the onboarding tutorial.
- Render an invisible high-z-index placeholder while the welcome dialog is loading so onboarding correctly detects an active modal and does not preempt it.

Enhancements:
- Simplify onboarding completion logic by removing auto-completion when device resources finish loading.
- Adjust onboarding popover styling to align the new skip button, and add localized strings for the development skip label in all supported languages.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在强制完成新手引导教程的同时，增加仅用于开发环境的跳过选项，并防止教程在欢迎对话框之前过早开始。

New Features:
- 要求用户完成所有新手引导步骤后才视为完成，在正常构建中移除引导流程中的关闭/跳过控件。
- 在新手引导气泡中添加仅限开发模式使用的跳过按钮，允许开发者绕过教程。
- 暴露更多 `driver.js` 气泡的类型定义，以支持自定义气泡渲染钩子和导航按钮。

Bug Fixes:
- 确保在所有提前返回的路径中正确清除欢迎对话框的加载状态，防止其被阻塞或被新手引导教程覆盖。
- 在欢迎对话框加载期间渲染一个不可见但具有高 z-index 的占位元素，使新手引导能够正确检测到活动模态窗口，从而不会抢先于它显示。

Enhancements:
- 通过移除“设备资源加载完成后自动完成引导”的行为，简化新手引导完成逻辑。
- 调整新手引导气泡样式以对齐新的跳过按钮，并为开发环境中的跳过标签在所有支持的语言中添加本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce completion of the onboarding tutorial while adding a development-only skip option and preventing the tutorial from racing ahead of the welcome dialog.

New Features:
- Require users to complete all onboarding steps before it is considered finished, removing close/skip controls from the tour in normal builds.
- Add a development-mode-only skip button to the onboarding popover, allowing developers to bypass the tutorial.
- Expose additional driver.js popover typing to support custom popover render hooks and navigation buttons.

Bug Fixes:
- Ensure the welcome dialog loading state is cleared correctly in all early-return paths, preventing it from blocking or being overlaid by the onboarding tutorial.
- Render an invisible high-z-index placeholder while the welcome dialog is loading so onboarding correctly detects an active modal and does not preempt it.

Enhancements:
- Simplify onboarding completion logic by removing auto-completion when device resources finish loading.
- Adjust onboarding popover styling to align the new skip button, and add localized strings for the development skip label in all supported languages.

</details>

</details>