### PR TITLE
fix: webui在使用反向代理时url无法正确处理

### DIFF
--- a/src/components/settings/DebugSection.tsx
+++ b/src/components/settings/DebugSection.tsx
@@ -139,14 +139,20 @@ export function DebugSection() {
     }
   };
 
-  const webServerAddress = (() => {
-    if (!webServerPort) return null;
-    if (allowLanAccess) {
-      const host = isTauri() ? lanIp || 'localhost' : window.location.hostname;
-      return `http://${host}:${webServerPort}`;
-    }
-    return `http://localhost:${webServerPort}`;
-  })();
+const webServerAddress = (() => {
+
+  if (window.location.host && !isTauri()) {
+    return window.location.origin;
+  }
+  
+  // Tauri 桌面端直连后端
+  if (!webServerPort) return null;
+  
+  const host = allowLanAccess 
+    ? (lanIp || 'localhost') 
+    : 'localhost';
+  return `http://${host}:${webServerPort}`;
+})();
 
   const handleOpenWebServer = useCallback(async () => {
     if (!webServerAddress) return;

--- a/src/services/wsService.ts
+++ b/src/services/wsService.ts
@@ -91,12 +91,16 @@ export function setServerPort(port: number): void {
 
 function getWsUrl(): string {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  if (serverPort) {
-    const hostname = window.location.hostname;
-    return `${protocol}//${hostname}:${serverPort}/api/ws`;
+
+  // 正常情况：通过 Nginx 反向代理
+  if (window.location.host) {
+    return `${protocol}//${window.location.host}/api/ws`;
   }
-  const host = window.location.host;
-  return `${protocol}//${host}/api/ws`;
+
+  // Fallback：直连后端
+  const hostname = window.location.hostname || '127.0.0.1';
+  const port = serverPort || 12701;
+  return `${protocol}//${hostname}:${port}/api/ws`;
 }
 
 // ============================================================================

--- a/src/utils/backendApi.ts
+++ b/src/utils/backendApi.ts
@@ -16,11 +16,16 @@ export function setBackendPort(port: number): void {
 }
 
 export function getApiBase(): string {
-  if (backendPort) {
-    const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
-    return `${protocol}//${window.location.hostname}:${backendPort}/api`;
+  // 正常情况：通过 Nginx 反向代理，用相对路径
+  if (window.location.host) {
+    return '/api';
   }
-  return '/api';
+  
+  // Fallback：直连后端
+  const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
+  const hostname = window.location.hostname || '127.0.0.1';
+  const port = backendPort || 12701;
+  return `${protocol}//${hostname}:${port}/api`;
 }
 
 /** 安全解析 JSON 响应，204 / 空 body 时返回 undefined */


### PR DESCRIPTION
bug触发条件：
1. 在 windows 主机上开启 webui 并允许局域网访问
2. 在另一台服务器的 nginx 上配置反向代理 “maaend.example.icu” -> "192.168.1.114:12701"
3. 在局域网内另一台电脑访问 “maaend.example.icu”
结果：wss 和 /api/* 的连接会请求 “maaend.example.icu:12701/{uri}”

本 pr 使用 `window.location.host` 获取正确的 url，并在失败时 fallback 到原本的逻辑

## Sourcery 总结

修复 Web UI 中的 URL 处理问题，使在通过反向代理访问时 WebSocket 和 API 请求能够正常工作，并在直接连接后端时提供合理的回退机制。

Bug 修复：
- 当在反向代理之后使用 Web UI 时，通过基于 `window.location.host` 和 `origin` 来解析 WebSocket 和 API 端点 URL，解决端点 URL 不正确的问题。
- 在自动主机检测不可用的情况下，通过显式的主机名/端口回退机制，确保桌面端（Tauri）和直接 LAN/后端访问路径仍然可以正常工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix URL handling in the web UI so that WebSocket and API requests work correctly when accessed via a reverse proxy, with sensible fallbacks for direct backend connections.

Bug Fixes:
- Resolve incorrect WebSocket and API endpoint URLs when the web UI is used behind a reverse proxy by basing them on window.location.host and origin.
- Ensure desktop (Tauri) and direct LAN/backend access paths still function via explicit hostname/port fallbacks when automatic host detection is unavailable.

</details>