### PR TITLE
feat: ui支持dpi缩放

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback, lazy, Suspense } from 'react';
 import {
   useAppStore,
   flushConfig,
@@ -78,6 +78,7 @@ import {
   focusWindow,
   showWindow,
   MIN_LEFT_PANEL_WIDTH,
+  syncUiScale,
 } from '@/utils/windowUtils';
 import { LoadingScreen } from './components/app';
 import { ConnectionLostOverlay } from './components/app/ConnectionLostOverlay';
@@ -1271,6 +1272,40 @@ function App() {
       mediaQuery.removeEventListener('change', handleSystemThemeChange);
     };
   }, [theme]);
+
+  // 监听页面缩放变化，自动适配 4K / 高 DPI 显示器
+  useLayoutEffect(() => {
+    let cleanup: (() => void) | null = null;
+    let cancelled = false;
+
+    const setupUiScaleListener = async () => {
+      const initialScale = await syncUiScale();
+      if (cancelled) return;
+      log.info('UI 缩放已同步:', initialScale);
+
+      if (!isTauri()) return;
+
+      try {
+        const { getCurrentWindow } = await import('@tauri-apps/api/window');
+        const currentWindow = getCurrentWindow();
+        cleanup = await currentWindow.onScaleChanged(async (event) => {
+          if (cancelled) return;
+          const nextScale = event.payload.scaleFactor;
+          const appliedScale = await syncUiScale();
+          log.info('窗口 DPI 缩放变化:', { nextScale, appliedScale });
+        });
+      } catch (err) {
+        log.warn('注册窗口缩放监听失败:', err);
+      }
+    };
+
+    void setupUiScaleListener();
+
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, []);
 
   // 回到主界面时，根据状态弹出相应的弹窗
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,8 @@
   --radius-md: 0.5rem;
   --radius-lg: 0.75rem;
   --radius-xl: 1rem;
+  --mxu-ui-scale: 1;
+  font-size: calc(16px * var(--mxu-ui-scale));
 }
 
 /* Base styles */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,9 @@ import { Provider as TooltipProvider } from '@radix-ui/react-tooltip';
 import App from './App';
 import './i18n';
 import './index.css';
+import { setUiScale } from '@/utils/windowUtils';
+
+setUiScale(window.devicePixelRatio || 1);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/utils/windowUtils.ts
+++ b/src/utils/windowUtils.ts
@@ -13,11 +13,65 @@ export const MIN_WINDOW_HEIGHT = 500;
 // 左侧面板最小宽度（确保工具栏按钮文字不换行）
 export const MIN_LEFT_PANEL_WIDTH = 530;
 
+// 全局 UI 缩放范围（按窗口 DPI 自动调整）
+export const MIN_UI_SCALE = 1;
+export const MAX_UI_SCALE = 2;
+const DEFAULT_UI_SCALE = 1;
+let currentUiScale = DEFAULT_UI_SCALE;
+
 /**
  * 验证窗口尺寸是否有效
  */
 export function isValidWindowSize(width: number, height: number): boolean {
   return width >= MIN_WINDOW_WIDTH && height >= MIN_WINDOW_HEIGHT;
+}
+
+/**
+ * 将 UI 缩放值限制在安全范围内
+ */
+export function clampUiScale(scale: number): number {
+  if (!Number.isFinite(scale)) return DEFAULT_UI_SCALE;
+  return Math.max(MIN_UI_SCALE, Math.min(MAX_UI_SCALE, scale));
+}
+
+/**
+ * 应用全局 UI 缩放到根节点
+ */
+export function setUiScale(scale: number): number {
+  const clamped = clampUiScale(scale);
+  currentUiScale = clamped;
+
+  if (typeof document !== 'undefined') {
+    document.documentElement.style.setProperty('--mxu-ui-scale', String(clamped));
+  }
+
+  return clamped;
+}
+
+/**
+ * 获取当前 UI 缩放值
+ */
+export function getUiScale(): number {
+  return currentUiScale;
+}
+
+/**
+ * 从当前窗口或浏览器环境同步 UI 缩放
+ */
+export async function syncUiScale(): Promise<number> {
+  if (isTauri()) {
+    try {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window');
+      const currentWindow = getCurrentWindow();
+      const scaleFactor = await currentWindow.scaleFactor();
+      return setUiScale(scaleFactor);
+    } catch (err) {
+      log.warn('同步 UI 缩放失败，回退到默认值:', err);
+      return setUiScale(DEFAULT_UI_SCALE);
+    }
+  }
+
+  return setUiScale(window.devicePixelRatio || DEFAULT_UI_SCALE);
 }
 
 /**
@@ -112,6 +166,23 @@ export async function getWindowSize(): Promise<{ width: number; height: number }
     }
   }
   return null;
+}
+
+/**
+ * 获取当前窗口 DPI 缩放因子
+ */
+export async function getWindowScaleFactor(): Promise<number> {
+  if (isTauri()) {
+    try {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window');
+      const currentWindow = getCurrentWindow();
+      return await currentWindow.scaleFactor();
+    } catch (err) {
+      log.warn('获取窗口缩放因子失败:', err);
+    }
+  }
+
+  return window.devicePixelRatio || 1;
 }
 
 /**


### PR DESCRIPTION
opus4.8
close https://github.com/MaaEnd/MaaEnd/issues/1978

<img width="823" height="695" alt="image" src="https://github.com/user-attachments/assets/0980ade0-5637-4a6a-b74f-93076cc363db" />

## Summary by Sourcery

根据窗口 DPI / 设备像素比自动缩放 UI，以提升在高 DPI 和 4K 显示器上的显示效果。

新功能：
- 引入全局 UI 缩放配置，包含限定范围，并可根据窗口 DPI 或浏览器的 `devicePixelRatio` 进行同步。
- 通过 CSS 变量将 UI 缩放应用到根字体大小，使界面能够随 DPI 变化一致缩放。
- 在主应用中监听 Tauri 窗口的 DPI 缩放变化，并动态更新 UI 缩放。

改进：
- 提供辅助函数，用于获取当前窗口 DPI 缩放因子，以便在与 UI 相关的逻辑中使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic UI scaling based on window DPI / device pixel ratio to improve display on high-DPI and 4K monitors.

New Features:
- Introduce global UI scale configuration with clamped range and synchronization from window DPI or browser devicePixelRatio.
- Apply UI scale to the root font size via a CSS variable so the interface scales consistently with DPI changes.
- Listen for Tauri window DPI scale changes in the main app and update UI scaling dynamically.

Enhancements:
- Expose a helper to retrieve the current window DPI scale factor for use in UI-related logic.

</details>