### PR TITLE
fix: 修正 MXU_WEBHOOK_ACTION 的 HTTP 請求處理

### DIFF
--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -6,7 +6,12 @@ use chrono::TimeZone;
 use log::{info, warn};
 use maa_framework::custom::FnAction;
 use maa_framework::resource::Resource;
-use serde::Serialize;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::{Method, Url};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 
 // ============================================================================
@@ -314,16 +319,78 @@ fn mxu_launch_action_fn(
 /// MXU_WEBHOOK 动作名称常量
 const MXU_WEBHOOK_ACTION: &str = "MXU_WEBHOOK_ACTION";
 
+#[derive(Debug, Deserialize)]
+struct WebhookConfig {
+    url: String,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    #[serde(default)]
+    body: Option<Value>,
+    #[serde(default)]
+    json: Option<Value>,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+    #[serde(default)]
+    fail_on_non_success: Option<bool>,
+}
+
+fn parse_webhook_method(method: Option<&str>, has_body: bool) -> Result<Method, String> {
+    let method = method
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_uppercase)
+        .unwrap_or_else(|| {
+            // 有 body 時預設使用 POST，避免 Discord webhook 這類服務被誤送成 GET。
+            if has_body {
+                "POST".to_string()
+            } else {
+                "GET".to_string()
+            }
+        });
+
+    Method::from_bytes(method.as_bytes()).map_err(|e| format!("invalid HTTP method '{}': {}", method, e))
+}
+
+fn build_webhook_headers(headers: HashMap<String, String>) -> Result<HeaderMap, String> {
+    let mut header_map = HeaderMap::new();
+
+    for (name, value) in headers {
+        let name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| format!("invalid header name '{}': {}", name, e))?;
+        let value = HeaderValue::from_str(&value)
+            .map_err(|e| format!("invalid header value for '{}': {}", name, e))?;
+        header_map.insert(name, value);
+    }
+
+    Ok(header_map)
+}
+
+fn sanitize_webhook_url(url: &Url) -> String {
+    let Some(host) = url.host_str() else {
+        return "<invalid-url>".to_string();
+    };
+
+    let authority = match url.port() {
+        Some(port) => format!("{}:{}", host, port),
+        None => host.to_string(),
+    };
+
+    // Webhook token 通常藏在 path 或 query，日志只保留 scheme + host。
+    format!("{}://{}/...", url.scheme(), authority)
+}
+
 /// MXU_WEBHOOK custom action 回调函数
-/// 从 custom_action_param 中读取 url，执行 HTTP GET 请求
+/// 从 custom_action_param 中读取 url/method/headers/body，执行 HTTP 请求
 fn mxu_webhook_action_fn(
     _ctx: &maa_framework::context::Context,
     args: &maa_framework::custom::ActionArgs,
 ) -> bool {
     let param_str = args.param;
-    info!("[MXU_WEBHOOK] Received param: {}", param_str);
+    info!("[MXU_WEBHOOK] Received webhook param");
 
-    let json: serde_json::Value = match serde_json::from_str(param_str) {
+    let config: WebhookConfig = match serde_json::from_str(param_str) {
         Ok(v) => v,
         Err(e) => {
             warn!("[MXU_WEBHOOK] Failed to parse param JSON: {}", e);
@@ -331,18 +398,52 @@ fn mxu_webhook_action_fn(
         }
     };
 
-    let url = match json.get("url").and_then(|v| v.as_str()) {
-        Some(u) if !u.trim().is_empty() => u.to_string(),
-        _ => {
-            warn!("[MXU_WEBHOOK] Missing or empty 'url' parameter");
+    let WebhookConfig {
+        url,
+        method,
+        headers,
+        body,
+        json,
+        timeout_secs,
+        fail_on_non_success,
+    } = config;
+
+    let url = match Url::parse(url.trim()) {
+        Ok(value) => value,
+        Err(e) => {
+            warn!("[MXU_WEBHOOK] Invalid url: {}", e);
             return false;
         }
     };
 
-    info!("[MXU_WEBHOOK] Sending GET request to: {}", url);
+    let body = body.or(json);
+    let method = match parse_webhook_method(method.as_deref(), body.is_some()) {
+        Ok(value) => value,
+        Err(e) => {
+            warn!("[MXU_WEBHOOK] {}", e);
+            return false;
+        }
+    };
+
+    let headers = match build_webhook_headers(headers) {
+        Ok(value) => value,
+        Err(e) => {
+            warn!("[MXU_WEBHOOK] {}", e);
+            return false;
+        }
+    };
+
+    let timeout_secs = timeout_secs.unwrap_or(10).clamp(1, 300);
+    let fail_on_non_success = fail_on_non_success.unwrap_or(true);
+    let safe_url = sanitize_webhook_url(&url);
+
+    info!(
+        "[MXU_WEBHOOK] Sending {} request to {} with timeout={}s",
+        method, safe_url, timeout_secs
+    );
 
     let client = match reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(Duration::from_secs(timeout_secs))
         .build()
     {
         Ok(c) => c,
@@ -352,15 +453,26 @@ fn mxu_webhook_action_fn(
         }
     };
 
-    match client.get(&url).send() {
+    let request = client.request(method, url).headers(headers);
+    let request = match body {
+        Some(Value::Null) | None => request,
+        Some(Value::String(value)) => request.body(value),
+        Some(value) => request.json(&value),
+    };
+
+    match request.send() {
         Ok(resp) => {
             let status = resp.status();
             info!("[MXU_WEBHOOK] Response status: {}", status);
+
             if status.is_success() {
                 true
-            } else {
+            } else if fail_on_non_success {
                 warn!("[MXU_WEBHOOK] Non-success status code: {}", status);
-                true // 仍然返回成功，只要请求发出去了
+                false
+            } else {
+                warn!("[MXU_WEBHOOK] Non-success status code ignored: {}", status);
+                true
             }
         }
         Err(e) => {
@@ -733,7 +845,6 @@ fn execute_power_screenoff() -> bool {
         use winsafe::{HWND, POINT};
         unsafe {
             // NOTE: POINT::from(2) is equal to LPARAM(2)
-
             HWND::BROADCAST.SendMessage(wm::SysCommand {
                 request: SC::MONITORPOWER,
                 position: POINT::from(2),

--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -350,7 +350,8 @@ fn parse_webhook_method(method: Option<&str>, has_body: bool) -> Result<Method, 
             }
         });
 
-    Method::from_bytes(method.as_bytes()).map_err(|e| format!("invalid HTTP method '{}': {}", method, e))
+    Method::from_bytes(method.as_bytes())
+        .map_err(|e| format!("invalid HTTP method '{}': {}", method, e))
 }
 
 fn build_webhook_headers(headers: HashMap<String, String>) -> Result<HeaderMap, String> {


### PR DESCRIPTION
## 摘要

這個 PR 修正 `MXU_WEBHOOK_ACTION` 目前只能送出 GET 請求、且非成功 HTTP 狀態仍被視為成功的問題。

原本 webhook action 只支援：

```json
{
  "url": "https://example.com/webhook"
}
```

這對需要 POST JSON payload 的 webhook 服務不夠完整，例如 Discord Webhook。

## 主要變更

* 保留舊版 `{ "url": "..." }` 格式，預設仍以 GET 請求送出。
* 新增支援：

  * `method`
  * `headers`
  * `body`
  * `json`
  * `timeout_secs`
  * `fail_on_non_success`
* 當設定中包含 `body` 或 `json`，且沒有明確指定 `method` 時，預設改用 POST。
* HTTP 回應狀態不是 2xx 時，預設回傳 `false`，避免 4xx / 5xx 被誤判為 webhook 執行成功。
* log 不再輸出完整 webhook URL，避免 webhook token 被寫入 log。

## 使用範例

```json
{
  "url": "https://discord.com/api/webhooks/xxx/yyy",
  "method": "POST",
  "headers": {
    "Content-Type": "application/json"
  },
  "body": {
    "content": "MXU 任務已完成"
  }
}
```

## 相容性

舊設定格式仍可正常使用，不需要修改既有的 `interface.json` 設定。

## 驗證

已執行：

```bash
cd src-tauri
cargo check
```

結果通過。

## Summary by Sourcery

扩展 MXU webhook 自定义动作，以支持可配置的 HTTP 请求和更严格的成功判定标准。

新功能：
- 允许在 MXU_WEBHOOK_ACTION 中通过动作参数指定 HTTP 方法、请求头、请求体或 JSON 负载、超时时间以及失败行为。

缺陷修复：
- 默认将来自 MXU_WEBHOOK_ACTION 的非 2xx HTTP 响应视为失败，而不是始终报告成功。
- 防止记录完整的 webhook URL，以避免在日志中泄露令牌。

增强改进：
- 当存在 webhook 请求体或 JSON 负载时自动默认使用 POST，同时在无请求体的情况下保持 GET 为默认方法。
- 为 webhook 配置引入验证和规范化处理，包括 URL 解析、方法和请求头验证以及超时时间限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend MXU webhook custom action to support configurable HTTP requests and stricter success criteria.

New Features:
- Allow MXU_WEBHOOK_ACTION to specify HTTP method, headers, body or JSON payload, timeout, and failure behavior via action parameters.

Bug Fixes:
- Treat non-2xx HTTP responses from MXU_WEBHOOK_ACTION as failures by default instead of always reporting success.
- Prevent logging of full webhook URLs to avoid exposing tokens in logs.

Enhancements:
- Add automatic POST default when a webhook body or JSON payload is present while keeping GET as the default for body-less requests.
- Introduce validation and normalization for webhook configuration, including URL parsing, method and header validation, and timeout clamping.

</details>