### PR TITLE
fix: 任务开始时禁用顶部tab栏

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -158,6 +158,7 @@ export function TabBar() {
   };
 
   const langKey = getInterfaceLangKey(language);
+  const topBarLocked = instances.some((inst) => inst.isRunning);
 
   // 右键菜单处理
   const handleTabContextMenu = useCallback(
@@ -348,7 +349,14 @@ export function TabBar() {
   return (
     <div className="flex items-center h-10 bg-bg-secondary border-b border-border select-none">
       {/* 标签页区域 */}
-      <div id="tab-bar-area" className="flex-1 flex items-center h-full overflow-x-auto">
+      <div
+        id="tab-bar-area"
+        className={clsx(
+          'flex-1 flex items-center h-full overflow-x-auto',
+          topBarLocked && 'pointer-events-none',
+        )}
+        aria-disabled={topBarLocked}
+      >
         {instances.map((instance, index) => {
           const isAnimatingIn = animatingTabIds.includes(instance.id);
           const isClosing = closingTabIds.includes(instance.id);
@@ -361,7 +369,7 @@ export function TabBar() {
                 else tabRefs.current.delete(instance.id);
               }}
               onMouseDown={(e) => handleMouseDown(e, index)}
-              onClick={() => !isClosing && setActiveInstance(instance.id)}
+              onClick={() => !topBarLocked && !isClosing && setActiveInstance(instance.id)}
               onDoubleClick={(e) => handleDoubleClick(e, instance.id, instance.name)}
               onContextMenu={(e) => handleTabContextMenu(e, instance.id, instance.name)}
               onAnimationEnd={() => {
@@ -371,6 +379,7 @@ export function TabBar() {
               }}
               className={clsx(
                 'group flex items-center gap-1 h-full px-2 cursor-pointer border-r border-border min-w-[120px] max-w-[200px]',
+                topBarLocked && 'cursor-not-allowed opacity-70',
                 instance.id === activeInstanceId
                   ? 'bg-bg-primary text-accent border-b-2 border-b-accent'
                   : 'bg-bg-tertiary text-text-secondary hover:bg-bg-hover border-b-2 border-b-transparent',
@@ -471,7 +480,11 @@ export function TabBar() {
         {/* 新建标签按钮 */}
         <button
           onClick={handleNewTab}
-          className="flex items-center justify-center w-8 h-full hover:bg-bg-hover transition-colors"
+          disabled={topBarLocked}
+          className={clsx(
+            'flex items-center justify-center w-8 h-full transition-colors',
+            topBarLocked ? 'cursor-not-allowed opacity-50' : 'hover:bg-bg-hover',
+          )}
           title={t('titleBar.newTab')}
         >
           <Plus className="w-4 h-4 text-text-secondary" />
@@ -489,10 +502,11 @@ export function TabBar() {
         {(updateInfo?.hasUpdate || updateInfo?.errorCode || downloadStatus === 'downloading') && (
           <button
             ref={bellButtonRef}
-            onClick={() => setShowUpdatePanel(!showUpdatePanel)}
+            onClick={() => !topBarLocked && setShowUpdatePanel(!showUpdatePanel)}
+            disabled={topBarLocked}
             className={clsx(
               'relative p-2 rounded-md transition-colors',
-              showUpdatePanel ? 'bg-accent/10' : 'hover:bg-bg-hover',
+              topBarLocked ? 'cursor-not-allowed opacity-50' : showUpdatePanel ? 'bg-accent/10' : 'hover:bg-bg-hover',
             )}
             title={
               updateInfo?.hasUpdate
@@ -525,12 +539,15 @@ export function TabBar() {
         {recentlyClosed.length > 0 && (
           <button
             ref={recentlyClosedButtonRef}
-            onClick={() => setShowRecentlyClosedPanel(!showRecentlyClosedPanel)}
+            onClick={() => !topBarLocked && setShowRecentlyClosedPanel(!showRecentlyClosedPanel)}
+            disabled={topBarLocked}
             className={clsx(
               'p-2 rounded-md transition-colors',
-              showRecentlyClosedPanel
-                ? 'bg-accent/10 text-accent'
-                : 'hover:bg-bg-hover text-text-secondary',
+              topBarLocked
+                ? 'cursor-not-allowed opacity-50'
+                : showRecentlyClosedPanel
+                  ? 'bg-accent/10 text-accent'
+                  : 'hover:bg-bg-hover text-text-secondary',
             )}
             title={t('recentlyClosed.title')}
           >
@@ -538,18 +555,27 @@ export function TabBar() {
           </button>
         )}
         <button
-          onClick={toggleDashboardView}
+          onClick={() => !topBarLocked && toggleDashboardView()}
+          disabled={topBarLocked}
           className={clsx(
             'p-2 rounded-md transition-colors',
-            dashboardView ? 'bg-accent/10 text-accent' : 'hover:bg-bg-hover text-text-secondary',
+            topBarLocked
+              ? 'cursor-not-allowed opacity-50'
+              : dashboardView
+                ? 'bg-accent/10 text-accent'
+                : 'hover:bg-bg-hover text-text-secondary',
           )}
           title={t('dashboard.toggle')}
         >
           <LayoutGrid className="w-4 h-4" />
         </button>
         <button
-          onClick={toggleTheme}
-          className="p-2 rounded-md hover:bg-bg-hover transition-colors"
+          onClick={() => !topBarLocked && toggleTheme()}
+          disabled={topBarLocked}
+          className={clsx(
+            'p-2 rounded-md transition-colors',
+            topBarLocked ? 'cursor-not-allowed opacity-50' : 'hover:bg-bg-hover',
+          )}
           title={
             resolveThemeMode(theme) === 'light' ? t('settings.themeDark') : t('settings.themeLight')
           }
@@ -561,8 +587,12 @@ export function TabBar() {
           )}
         </button>
         <button
-          onClick={() => setCurrentPage('settings')}
-          className="p-2 rounded-md hover:bg-bg-hover transition-colors"
+          onClick={() => !topBarLocked && setCurrentPage('settings')}
+          disabled={topBarLocked}
+          className={clsx(
+            'p-2 rounded-md transition-colors',
+            topBarLocked ? 'cursor-not-allowed opacity-50' : 'hover:bg-bg-hover',
+          )}
           title={t('titleBar.settings')}
         >
           <Settings className="w-4 h-4 text-text-secondary" />

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -246,14 +246,14 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
       }
 
       // 获取控制器和资源配置
-        const controllerName = selectedController[targetId] || projectInterface?.controller[0]?.name;
-        const resourceName = selectedResource[targetId] || projectInterface?.resource[0]?.name;
+      const controllerName = selectedController[targetId] || projectInterface?.controller[0]?.name;
+      const resourceName = selectedResource[targetId] || projectInterface?.resource[0]?.name;
 
-        // 过滤掉不兼容当前控制器/资源的任务
-        const compatibleTasks = enabledTasks.filter((t) => {
-          const taskDef = projectInterface?.task.find((td) => td.name === t.taskName);
-          return isTaskCompatible(taskDef, controllerName, resourceName);
-        });
+      // 过滤掉不兼容当前控制器/资源的任务
+      const compatibleTasks = enabledTasks.filter((t) => {
+        const taskDef = projectInterface?.task.find((td) => td.name === t.taskName);
+        return isTaskCompatible(taskDef, controllerName, resourceName);
+      });
 
       // 如果有任务因不兼容被跳过，记录警告
       const compatibleTaskIds = new Set(compatibleTasks.map((t) => t.id));

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -245,8 +245,7 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
         return false;
       }
 
-      try {
-        // 获取控制器和资源配置
+      // 获取控制器和资源配置
         const controllerName = selectedController[targetId] || projectInterface?.controller[0]?.name;
         const resourceName = selectedResource[targetId] || projectInterface?.resource[0]?.name;
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -245,15 +245,16 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
         return false;
       }
 
-      // 获取控制器和资源配置
-      const controllerName = selectedController[targetId] || projectInterface?.controller[0]?.name;
-      const resourceName = selectedResource[targetId] || projectInterface?.resource[0]?.name;
+      try {
+        // 获取控制器和资源配置
+        const controllerName = selectedController[targetId] || projectInterface?.controller[0]?.name;
+        const resourceName = selectedResource[targetId] || projectInterface?.resource[0]?.name;
 
-      // 过滤掉不兼容当前控制器/资源的任务
-      const compatibleTasks = enabledTasks.filter((t) => {
-        const taskDef = projectInterface?.task.find((td) => td.name === t.taskName);
-        return isTaskCompatible(taskDef, controllerName, resourceName);
-      });
+        // 过滤掉不兼容当前控制器/资源的任务
+        const compatibleTasks = enabledTasks.filter((t) => {
+          const taskDef = projectInterface?.task.find((td) => td.name === t.taskName);
+          return isTaskCompatible(taskDef, controllerName, resourceName);
+        });
 
       // 如果有任务因不兼容被跳过，记录警告
       const compatibleTaskIds = new Set(compatibleTasks.map((t) => t.id));


### PR DESCRIPTION
close https://github.com/MaaEnd/MaaEnd/issues/2694
opus 4.8
<img width="861" height="609" alt="image" src="https://github.com/user-attachments/assets/e641c3e8-6b3a-4290-ad57-ad9871ba66e8" />


## Summary by Sourcery

在任务运行期间禁用顶部导航交互，并在筛选兼容任务时提升任务启动的健壮性。

错误修复：
- 在实例运行时，阻止通过顶部栏切换标签页、打开面板或更改设置，以避免任务状态不一致。
- 在启动任务之前，当解析控制器/资源并筛选兼容任务时，正确处理错误，从而防止运行时故障。

改进：
- 在任务执行期间锁定交互时，为顶部栏标签和按钮添加可视化的禁用状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable top navigation interactions while a task is running and improve task-start robustness when filtering compatible tasks.

Bug Fixes:
- Prevent switching tabs, opening panels, or changing settings from the top bar while an instance is running to avoid inconsistent task state.
- Handle errors when resolving controller/resource and filtering compatible tasks before starting a task to prevent runtime failures.

Enhancements:
- Add visual disabled states to top-bar tabs and buttons when interactions are locked during task execution.

</details>

## Summary by Sourcery

在任务运行期间禁用顶部导航交互，以防止状态不一致，并在视觉上指示锁定状态。

Bug Fixes（错误修复）:
- 在实例运行时，禁止切换顶部标签、打开面板以及通过顶部栏更改设置，以避免任务状态和界面状态不一致。

Enhancements（增强）:
- 当任务正在运行时，为顶部栏标签和操作按钮添加禁用状态和可视化的锁定状态，以明确当前不可用的交互。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable top navigation interactions while tasks are running to prevent state inconsistencies and visually indicate the locked state.

Bug Fixes:
- Prevent switching top tabs, opening panels, and changing settings from the top bar while an instance is running to avoid inconsistent task and UI state.

Enhancements:
- Add disabled and visual locked states to top-bar tabs and action buttons when a task is running to clarify unavailable interactions.

</details>