### PR TITLE
feat: 当前是最新版本时也显示更新日志

### DIFF
--- a/src/components/settings/UpdateSection.tsx
+++ b/src/components/settings/UpdateSection.tsx
@@ -30,7 +30,7 @@ import { createProxySettings, proxySettingsForUpdateDownload } from '@/services/
 import { resolveI18nText } from '@/services/contentResolver';
 import { getInterfaceLangKey } from '@/i18n';
 import { loggers } from '@/utils/logger';
-import { ReleaseNotes, DownloadProgressBar } from '../UpdateInfoCard';
+import { ReleaseNotes, DownloadProgressBar, VersionInfo } from '../UpdateInfoCard';
 
 export function UpdateSection() {
   const { t } = useTranslation();
@@ -543,24 +543,25 @@ export function UpdateSection() {
                 </div>
               )}
 
-              {/* 有更新时显示更新内容和下载进度 */}
-              {updateInfo?.hasUpdate && (
+              {/* 有更新或已有更新日志时显示内容 */}
+              {updateInfo && (updateInfo.hasUpdate || updateInfo.releaseNote) && (
                 <div className="space-y-4 p-4 bg-bg-tertiary rounded-lg border border-border">
-                  {/* 新版本标题 */}
+                  {/* 版本信息 */}
                   <div className="flex items-center gap-2">
                     <Download className="w-4 h-4 text-accent" />
                     <span className="text-sm font-medium text-text-primary">
-                      {t('mirrorChyan.newVersion')}
+                      {updateInfo.hasUpdate
+                        ? t('mirrorChyan.newVersion')
+                        : t('mirrorChyan.latestVersion')}
                     </span>
-                    <span className="font-mono text-sm text-accent font-semibold">
-                      {updateInfo.versionName}
-                    </span>
-                    {updateInfo.channel && updateInfo.channel !== 'stable' && (
-                      <span className="px-1.5 py-0.5 bg-warning/20 text-warning text-xs rounded font-medium">
-                        {updateInfo.channel}
-                      </span>
-                    )}
                   </div>
+
+                  <VersionInfo
+                    currentVersion={projectInterface?.version || updateInfo.versionName}
+                    latestVersion={updateInfo.versionName}
+                    channel={updateInfo.channel}
+                    isUpdated={false}
+                  />
 
                   {/* 更新日志 */}
                   {updateInfo.releaseNote && (
@@ -573,21 +574,8 @@ export function UpdateSection() {
                     />
                   )}
 
-                  {/* API 错误提示 */}
-                  {updateInfo.errorCode && errorText && (
-                    <div
-                      className={clsx(
-                        'flex items-start gap-2 p-2 rounded-lg text-xs',
-                        isCdkError ? 'bg-warning/10 text-warning' : 'bg-error/10 text-error',
-                      )}
-                    >
-                      <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
-                      <span>{errorText}</span>
-                    </div>
-                  )}
-
                   {/* 没有下载链接的提示 */}
-                  {!updateInfo.downloadUrl && !updateInfo.errorCode && (
+                  {!updateInfo.downloadUrl && !updateInfo.errorCode && updateInfo.hasUpdate && (
                     <div className="flex items-center gap-2 text-xs text-text-muted">
                       <AlertCircle className="w-3.5 h-3.5 text-warning" />
                       <span>{t('mirrorChyan.noDownloadUrl')}</span>
@@ -595,7 +583,7 @@ export function UpdateSection() {
                   )}
 
                   {/* 下载进度 */}
-                  {updateInfo.downloadUrl && downloadStatus !== 'idle' && (
+                  {updateInfo.downloadUrl && downloadStatus !== 'idle' && updateInfo.hasUpdate && (
                     <DownloadProgressBar
                       downloadStatus={downloadStatus}
                       downloadProgress={downloadProgress}
@@ -611,7 +599,7 @@ export function UpdateSection() {
                   )}
 
                   {/* 等待下载 */}
-                  {updateInfo.downloadUrl && downloadStatus === 'idle' && (
+                  {updateInfo.downloadUrl && downloadStatus === 'idle' && updateInfo.hasUpdate && (
                     <div className="flex items-center gap-2 text-xs text-text-muted">
                       <RefreshCw className="w-3.5 h-3.5 animate-spin" />
                       <span>{t('mirrorChyan.preparingDownload')}</span>
@@ -620,8 +608,8 @@ export function UpdateSection() {
                 </div>
               )}
 
-              {/* 只有错误没有更新时显示错误 */}
-              {updateInfo && !updateInfo.hasUpdate && updateInfo.errorCode && errorText && (
+              {/* API 错误提示 */}
+              {updateInfo?.errorCode && errorText && (
                 <div
                   className={clsx(
                     'flex items-start gap-2 p-3 rounded-lg text-sm',

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -129,10 +129,10 @@ interface GitHubAsset {
 
 // 获取操作系统类型
 function getOS(): string {
-  const platform = navigator.platform.toLowerCase();
-  if (platform.includes('win')) return 'windows';
-  if (platform.includes('mac')) return 'darwin';
-  if (platform.includes('linux')) return 'linux';
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('win')) return 'windows';
+  if (ua.includes('mac')) return 'darwin';
+  if (ua.includes('linux')) return 'linux';
   return '';
 }
 
@@ -844,7 +844,34 @@ export async function checkAndPrepareDownload(
   // 始终使用 Mirror酱 检查更新
   const updateInfo = await checkUpdate({ ...checkOptions, cdk, channel });
 
-  if (!updateInfo || !updateInfo.hasUpdate) {
+  if (!updateInfo) {
+    return null;
+  }
+
+  // 当已经是最新版本时，也尝试补充更新日志，方便设置页展示 changelog
+  if (!updateInfo.hasUpdate && githubUrl && !updateInfo.releaseNote && updateInfo.versionName) {
+    const parsedGitHubUrl = parseGitHubUrl(githubUrl);
+    if (parsedGitHubUrl) {
+      log.info(`当前已是最新版本，尝试从 GitHub 获取版本 ${updateInfo.versionName} 的更新日志`);
+      const githubRelease = await getGitHubReleaseByVersion(
+        parsedGitHubUrl.owner,
+        parsedGitHubUrl.repo,
+        updateInfo.versionName,
+        githubPat,
+        proxyUrl,
+      );
+
+      if (githubRelease?.body) {
+        log.info('已从 GitHub 补充更新日志');
+        return {
+          ...updateInfo,
+          releaseNote: githubRelease.body,
+        };
+      }
+    }
+  }
+
+  if (!updateInfo.hasUpdate) {
     return updateInfo;
   }
 

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -129,10 +129,10 @@ interface GitHubAsset {
 
 // 获取操作系统类型
 function getOS(): string {
-  const ua = navigator.userAgent.toLowerCase();
-  if (ua.includes('win')) return 'windows';
-  if (ua.includes('mac')) return 'darwin';
-  if (ua.includes('linux')) return 'linux';
+  const platform = navigator.platform.toLowerCase();
+  if (platform.includes('win')) return 'windows';
+  if (platform.includes('mac')) return 'darwin';
+  if (platform.includes('linux')) return 'linux';
   return '';
 }
 
@@ -844,34 +844,7 @@ export async function checkAndPrepareDownload(
   // 始终使用 Mirror酱 检查更新
   const updateInfo = await checkUpdate({ ...checkOptions, cdk, channel });
 
-  if (!updateInfo) {
-    return null;
-  }
-
-  // 当已经是最新版本时，也尝试补充更新日志，方便设置页展示 changelog
-  if (!updateInfo.hasUpdate && githubUrl && !updateInfo.releaseNote && updateInfo.versionName) {
-    const parsedGitHubUrl = parseGitHubUrl(githubUrl);
-    if (parsedGitHubUrl) {
-      log.info(`当前已是最新版本，尝试从 GitHub 获取版本 ${updateInfo.versionName} 的更新日志`);
-      const githubRelease = await getGitHubReleaseByVersion(
-        parsedGitHubUrl.owner,
-        parsedGitHubUrl.repo,
-        updateInfo.versionName,
-        githubPat,
-        proxyUrl,
-      );
-
-      if (githubRelease?.body) {
-        log.info('已从 GitHub 补充更新日志');
-        return {
-          ...updateInfo,
-          releaseNote: githubRelease.body,
-        };
-      }
-    }
-  }
-
-  if (!updateInfo.hasUpdate) {
+  if (!updateInfo || !updateInfo.hasUpdate) {
     return updateInfo;
   }
 


### PR DESCRIPTION
close https://github.com/MaaEnd/MaaEnd/issues/3348

## Summary by Sourcery

即使客户端已是最新版本，也在更新区域显示版本信息和发行说明，同时将与下载相关的提示限制在实际存在可用更新的场景中。

新功能：
- 当当前版本已经是最新版本时，仍然显示发行说明和版本详情。

改进：
- 在设置的更新区域复用共享的 `VersionInfo` 组件，以统一版本信息展示。
- 只要存在 API 错误消息，就始终显示，与是否有可用更新无关。
- 将下载 URL 警告和进度指示仅限定在存在可用更新的情况下显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show version information and release notes in the update section even when the client is already on the latest version, while constraining download-related messages to scenarios where an update is actually available.

New Features:
- Display release notes and version details when the current version is already the latest.

Enhancements:
- Reuse the shared VersionInfo component in the settings update section for consistent version display.
- Always show API error messages when present, independent of whether an update is available.
- Limit download URL warnings and progress indicators to cases where an update is available.

</details>