### PR TITLE
fix: 从启动命令中删除 CREATE_BREAKAWAY_FROM_JOB 以修复计划任务启动失败

### DIFF
--- a/src-tauri/src/commands/utils.rs
+++ b/src-tauri/src/commands/utils.rs
@@ -240,8 +240,18 @@ pub fn build_user_agent() -> String {
 ///
 /// - 子进程的 stdout/stderr 设为 null，避免继承父进程的标准流。
 /// - 当 `use_cmd` 为 true 时（仅 Windows），通过 `cmd /c` 启动并设置
-///   `CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB` 标志，隐藏控制台窗口
-///   且使子进程脱离父进程 job 对象。
+///   `CREATE_NO_WINDOW` 标志隐藏控制台窗口。
+///
+/// 注意：曾经使用 `CREATE_BREAKAWAY_FROM_JOB` 使子进程脱离父进程 Job 对象，
+/// 但 Windows 计划任务创建的 Job 默认不允许 breakaway（未设置
+/// `JOB_OBJECT_LIMIT_BREAKAWAY_OK`），导致 `CreateProcessW` 返回
+/// `ERROR_ACCESS_DENIED (os error 5)`。
+///
+/// 手动启动 MXU 时，MXU 不在任何 Job Object 中，该标志没有 Job 可脱离，
+/// 被 Windows 静默忽略，因此不会报错——但这只是巧合，不代表该标志真正生效。
+/// 计划任务启动时，MXU 被关在限制性 Job 中，该标志才真正触发错误。
+///
+/// `cmd /c` 本身已改变了 PPID 链，进程树隔离目的已达成，因此移除该标志。
 pub fn build_launch_command(
     program: &str,
     args: &[String],
@@ -271,8 +281,7 @@ pub fn build_launch_command(
     if use_cmd {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x0100_0000;
-        cmd.creation_flags(CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB);
+        cmd.creation_flags(CREATE_NO_WINDOW);
     }
 
     cmd


### PR DESCRIPTION
## 问题

当 MXU 由 Windows 计划任务启动时，勾选"cmd 运行"启动前置程序/游戏会报错：前置程序执行失败: Failed to spawn action: ...Endfield.exe - 拒绝访问。 (os error 5)
手动启动 MXU（管理员）时则一切正常。

## 根因

build_launch_command 在 use_cmd 模式下设置了 CREATE_BREAKAWAY_FROM_JOB 标志，意图让子进程脱离父进程的 Job Object。

- 手动启动：MXU 不在任何 Job Object 中，该标志没有 Job 可脱离，被 Windows 静默忽略，不会报错。
- 计划任务启动：Windows 任务计划程序会创建一个 Job Object 并将 MXU 放入其中，且默认不设置 JOB_OBJECT_LIMIT_BREAKAWAY_OK。当 CreateProcessW 尝试 breakaway 时，被 Job 拒绝，返回 ERROR_ACCESS_DENIED (os error 5)。

## 修复

移除 CREATE_BREAKAWAY_FROM_JOB 标志，仅保留 CREATE_NO_WINDOW。

cmd /c 本身已经改变了 PPID，进程树隔离的目的已经达成，不需要依赖 Job Object breakaway。

## 影响
计划任务 + cmd 运行不再报错
手动启动行为不变（该标志本来就无效）

## Summary by Sourcery

从基于 Windows `cmd` 的进程启动中移除 `CREATE_BREAKAWAY_FROM_JOB` 标志，以避免在从任务计划程序启动时出现“拒绝访问”错误。

Bug 修复：
- 修复在使用基于 `cmd` 的启动模式时，由于任务计划程序导致的“拒绝访问”错误而导致的 Windows 任务计划程序启动失败问题。

文档：
- 澄清启动命令的行为，并记录为什么移除了 `CREATE_BREAKAWAY_FROM_JOB` 标志，以及任务计划程序的作业对象是如何影响进程创建的。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the CREATE_BREAKAWAY_FROM_JOB flag from Windows cmd-based process launches to avoid access denied errors when started from Task Scheduler.

Bug Fixes:
- Fix Windows Task Scheduler launches failing with an access denied error when using the cmd-based launch mode.

Documentation:
- Clarify launch command behavior and document why the CREATE_BREAKAWAY_FROM_JOB flag was removed and how Task Scheduler job objects affect process creation.

</details>