### PR TITLE
feat: 关闭多个标签页时进行二次确认

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -44,7 +44,7 @@ export function TabBar() {
   const { t } = useTranslation();
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
-  const [closeConfirm, setCloseConfirm] = useState<{ id: string; name: string } | null>(null);
+  const [closeConfirm, setCloseConfirm] = useState<{ ids: string[]; name?: string } | null>(null);
   const [dragState, setDragState] = useState<{
     isDragging: boolean;
     draggedIndex: number;
@@ -106,7 +106,7 @@ export function TabBar() {
       if (confirmBeforeDelete) {
         const instance = instances.find((inst) => inst.id === id);
         if (instance) {
-          setCloseConfirm({ id, name: instance.name });
+          setCloseConfirm({ ids:[id], name: instance.name });
         }
       } else {
         startTabCloseAnimation(id);
@@ -116,7 +116,9 @@ export function TabBar() {
 
   const handleConfirmClose = () => {
     if (closeConfirm) {
-      startTabCloseAnimation(closeConfirm.id);
+      closeConfirm.ids.forEach((id) => {
+        startTabCloseAnimation(id);
+      })
       setCloseConfirm(null);
     }
   };
@@ -269,7 +271,7 @@ export function TabBar() {
           onClick: () => {
             if (confirmBeforeDelete) {
               const inst = instances.find((i) => i.id === instanceId);
-              if (inst) setCloseConfirm({ id: instanceId, name: inst.name });
+              if (inst) setCloseConfirm({ ids: [instanceId], name: inst.name });
             } else {
               startTabCloseAnimation(instanceId);
             }
@@ -281,11 +283,14 @@ export function TabBar() {
           icon: XCircle,
           disabled: instances.length <= 1,
           onClick: () => {
-            instances.forEach((inst) => {
-              if (inst.id !== instanceId) {
-                startTabCloseAnimation(inst.id);
-              }
-            });
+            let instanceIdsWithoutCurrent = instances
+                .map((inst) => inst.id)
+                .filter((id) => id !== instanceId);
+            if (confirmBeforeDelete) {
+              setCloseConfirm({ids:instanceIdsWithoutCurrent})
+            } else {
+              instanceIdsWithoutCurrent.forEach((id) => startTabCloseAnimation(id));
+            }
           },
         },
         {
@@ -294,9 +299,14 @@ export function TabBar() {
           icon: PanelRightClose,
           disabled: instanceIndex >= instances.length - 1,
           onClick: () => {
-            instances.slice(instanceIndex + 1).forEach((inst) => {
-              startTabCloseAnimation(inst.id);
-            });
+            let rightInstanceIds = instances
+                .slice(instanceIndex + 1)
+                .map((inst) => inst.id);
+            if (confirmBeforeDelete) {
+              setCloseConfirm({ids:rightInstanceIds});
+            } else {
+              rightInstanceIds.forEach((id) => startTabCloseAnimation(id));
+            }
           },
         },
       ];
@@ -652,7 +662,12 @@ export function TabBar() {
       <ConfirmDialog
         open={closeConfirm !== null}
         title={t('titleBar.closeTabConfirmTitle')}
-        message={t('titleBar.closeTabConfirmMessage', { name: closeConfirm?.name ?? '' })}
+        message={
+          ((closeConfirm?.ids.length ?? 0) > 1) ?
+          t('titleBar.closeMultiTabConfirmMessage', { count: closeConfirm?.ids.length ?? 0})
+        :
+          t('titleBar.closeTabConfirmMessage', { name: closeConfirm?.name ?? ''})
+      }
         confirmText={t('common.confirm')}
         cancelText={t('common.cancel')}
         destructive

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -44,7 +44,9 @@ export function TabBar() {
   const { t } = useTranslation();
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
-  const [closeConfirm, setCloseConfirm] = useState<{ ids: string[]; name?: string } | null>(null);
+  const [closeConfirm, setCloseConfirm] = useState<
+    { type: 'single'; ids: string[]; name: string } | { type: 'multi'; ids: string[] } | null
+  >(null);
   const [dragState, setDragState] = useState<{
     isDragging: boolean;
     draggedIndex: number;
@@ -100,16 +102,24 @@ export function TabBar() {
     createInstance(t('instance.defaultName'));
   };
 
+  const requestCloseTabs = (ids: string[], name?: string) => {
+    if (confirmBeforeDelete) {
+      if (name !== undefined) {
+        setCloseConfirm({ type: 'single', ids, name });
+      } else {
+        setCloseConfirm({ type: 'multi', ids });
+      }
+    } else {
+      ids.forEach((id) => startTabCloseAnimation(id));
+    }
+  };
+
   const handleCloseTab = (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
     if (instances.length > 1) {
-      if (confirmBeforeDelete) {
-        const instance = instances.find((inst) => inst.id === id);
-        if (instance) {
-          setCloseConfirm({ ids:[id], name: instance.name });
-        }
-      } else {
-        startTabCloseAnimation(id);
+      const instance = instances.find((inst) => inst.id === id);
+      if (instance) {
+        requestCloseTabs([id], instance.name);
       }
     }
   };
@@ -269,12 +279,8 @@ export function TabBar() {
           icon: X,
           disabled: instances.length <= 1,
           onClick: () => {
-            if (confirmBeforeDelete) {
-              const inst = instances.find((i) => i.id === instanceId);
-              if (inst) setCloseConfirm({ ids: [instanceId], name: inst.name });
-            } else {
-              startTabCloseAnimation(instanceId);
-            }
+            const inst = instances.find((i) => i.id === instanceId);
+            if (inst) requestCloseTabs([instanceId], inst.name);
           },
         },
         {
@@ -283,14 +289,10 @@ export function TabBar() {
           icon: XCircle,
           disabled: instances.length <= 1,
           onClick: () => {
-            let instanceIdsWithoutCurrent = instances
+            const instanceIdsWithoutCurrent = instances
                 .map((inst) => inst.id)
                 .filter((id) => id !== instanceId);
-            if (confirmBeforeDelete) {
-              setCloseConfirm({ids:instanceIdsWithoutCurrent})
-            } else {
-              instanceIdsWithoutCurrent.forEach((id) => startTabCloseAnimation(id));
-            }
+            requestCloseTabs(instanceIdsWithoutCurrent);
           },
         },
         {
@@ -299,14 +301,10 @@ export function TabBar() {
           icon: PanelRightClose,
           disabled: instanceIndex >= instances.length - 1,
           onClick: () => {
-            let rightInstanceIds = instances
+            const rightInstanceIds = instances
                 .slice(instanceIndex + 1)
                 .map((inst) => inst.id);
-            if (confirmBeforeDelete) {
-              setCloseConfirm({ids:rightInstanceIds});
-            } else {
-              rightInstanceIds.forEach((id) => startTabCloseAnimation(id));
-            }
+            requestCloseTabs(rightInstanceIds);
           },
         },
       ];
@@ -662,17 +660,15 @@ export function TabBar() {
       <ConfirmDialog
         open={closeConfirm !== null}
         title={
-          ((closeConfirm?.ids.length ?? 0) > 1) ?
-          t('titleBar.closeMultiTabConfirmTitle')
-        :
-          t('titleBar.closeTabConfirmTitle')
-      }
+          closeConfirm?.type === 'multi'
+            ? t('titleBar.closeMultiTabConfirmTitle')
+            : t('titleBar.closeTabConfirmTitle')
+        }
         message={
-          ((closeConfirm?.ids.length ?? 0) > 1) ?
-          t('titleBar.closeMultiTabConfirmMessage', { count: closeConfirm?.ids.length ?? 0})
-        :
-          t('titleBar.closeTabConfirmMessage', { name: closeConfirm?.name ?? ''})
-      }
+          closeConfirm?.type === 'multi'
+            ? t('titleBar.closeMultiTabConfirmMessage', { count: closeConfirm.ids.length })
+            : t('titleBar.closeTabConfirmMessage', { name: closeConfirm?.name ?? '' })
+        }
         confirmText={t('common.confirm')}
         cancelText={t('common.cancel')}
         destructive

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -661,7 +661,12 @@ export function TabBar() {
       {/* 关闭标签确认弹窗 */}
       <ConfirmDialog
         open={closeConfirm !== null}
-        title={t('titleBar.closeTabConfirmTitle')}
+        title={
+          ((closeConfirm?.ids.length ?? 0) > 1) ?
+          t('titleBar.closeMultiTabConfirmTitle')
+        :
+          t('titleBar.closeTabConfirmTitle')
+      }
         message={
           ((closeConfirm?.ids.length ?? 0) > 1) ?
           t('titleBar.closeMultiTabConfirmMessage', { count: closeConfirm?.ids.length ?? 0})

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -30,6 +30,8 @@ import { getInterfaceLangKey } from '@/i18n';
 import { exportFileWithToast, exportWithToast } from '@/utils/tabExportImport';
 import clsx from 'clsx';
 
+type CloseConfirmData = { type: 'single'; ids: string[]; name: string } | { type: 'multi'; ids: string[] } | null;
+
 const LazyUpdatePanel = lazy(async () => {
   const module = await import('./UpdatePanel');
   return { default: module.UpdatePanel };
@@ -44,9 +46,7 @@ export function TabBar() {
   const { t } = useTranslation();
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
-  const [closeConfirm, setCloseConfirm] = useState<
-    { type: 'single'; ids: string[]; name: string } | { type: 'multi'; ids: string[] } | null
-  >(null);
+  const [closeConfirm, setCloseConfirm] = useState<CloseConfirmData>(null);
   const [dragState, setDragState] = useState<{
     isDragging: boolean;
     draggedIndex: number;

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -32,6 +32,7 @@ export default {
     dragToReorder: 'Drag to reorder',
     closeTabConfirmTitle: 'Close Tab',
     closeTabConfirmMessage: 'Are you sure you want to close "{{name}}"?',
+    closeMultiTabConfirmMessage: 'Are you sure you want to close {{count}} tabs?',
   },
 
   // Window controls

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -32,6 +32,7 @@ export default {
     dragToReorder: 'Drag to reorder',
     closeTabConfirmTitle: 'Close Tab',
     closeTabConfirmMessage: 'Are you sure you want to close "{{name}}"?',
+    closeMultiTabConfirmTitle: 'Close Tabs',
     closeMultiTabConfirmMessage: 'Are you sure you want to close {{count}} tabs?',
   },
 

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -31,6 +31,7 @@ export default {
     dragToReorder: 'ドラッグして並べ替え',
     closeTabConfirmTitle: '設定を閉じる',
     closeTabConfirmMessage: '「{{name}}」を閉じてもよろしいですか？',
+    closeMultiTabConfirmMessage: '{{count}} 個の設定を閉じてもよろしいですか？',
   },
 
   // ウィンドウコントロール

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -31,6 +31,7 @@ export default {
     dragToReorder: 'ドラッグして並べ替え',
     closeTabConfirmTitle: '設定を閉じる',
     closeTabConfirmMessage: '「{{name}}」を閉じてもよろしいですか？',
+    closeMultiTabConfirmTitle: '設定を複数閉じる',
     closeMultiTabConfirmMessage: '{{count}} 個の設定を閉じてもよろしいですか？',
   },
 

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -31,6 +31,7 @@ export default {
     dragToReorder: '드래그하여 순서 변경',
     closeTabConfirmTitle: '탭 닫기',
     closeTabConfirmMessage: '"{{name}}"을(를) 닫으시겠습니까?',
+    closeMultiTabConfirmTitle: '탭 여러 개 닫기',
     closeMultiTabConfirmMessage: '{{count}}개의 탭을 닫으시겠습니까?',
   },
 

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -31,6 +31,7 @@ export default {
     dragToReorder: '드래그하여 순서 변경',
     closeTabConfirmTitle: '탭 닫기',
     closeTabConfirmMessage: '"{{name}}"을(를) 닫으시겠습니까?',
+    closeMultiTabConfirmMessage: '{{count}}개의 탭을 닫으시겠습니까?',
   },
 
   // 창 컨트롤

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -32,6 +32,7 @@ export default {
     dragToReorder: '拖拽以重新排序',
     closeTabConfirmTitle: '关闭配置',
     closeTabConfirmMessage: '确定要关闭「{{name}}」吗？',
+    closeMultiTabConfirmMessage: '确定要关闭 {{count}} 个配置吗？'
   },
 
   // 窗口控制按钮

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -32,6 +32,7 @@ export default {
     dragToReorder: '拖拽以重新排序',
     closeTabConfirmTitle: '关闭配置',
     closeTabConfirmMessage: '确定要关闭「{{name}}」吗？',
+    closeMultiTabConfirmTitle: '关闭多个配置',
     closeMultiTabConfirmMessage: '确定要关闭 {{count}} 个配置吗？'
   },
 

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -31,6 +31,7 @@ export default {
     dragToReorder: '拖動以重新排序',
     closeTabConfirmTitle: '關閉配置',
     closeTabConfirmMessage: '確定要關閉「{{name}}」嗎？',
+    closeMultiTabConfirmMessage: '確定要關閉 {{count}} 個配置嗎？',
   },
 
   // 視窗控制按钮

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -31,6 +31,7 @@ export default {
     dragToReorder: '拖動以重新排序',
     closeTabConfirmTitle: '關閉配置',
     closeTabConfirmMessage: '確定要關閉「{{name}}」嗎？',
+    closeMultiTabConfirmTitle: '關閉多個配置',
     closeMultiTabConfirmMessage: '確定要關閉 {{count}} 個配置嗎？',
   },
 


### PR DESCRIPTION
Close #211 
<img width="1002" height="620" alt="Confirm" src="https://github.com/user-attachments/assets/bedc629d-f278-4c49-a689-01fe0abcf22c" />

## Summary by Sourcery

在一次关闭多个标签页时新增确认对话框支持，同时保留现有的单个标签页关闭确认行为。

新功能：
- 当启用了关闭确认时，通过标签栏操作在关闭多个标签页前提示用户进行确认。

增强内容：
- 统一标签页关闭确认的处理逻辑，使用共享对话框同时支持单标签页和多标签页关闭。
- 为多标签页关闭确认的标题和消息提供多语言本地化支持（en、ja、ko、zh-CN、zh-TW）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add confirmation dialog support when closing multiple tabs at once while preserving existing single-tab confirmation behavior.

New Features:
- Prompt users for confirmation before closing multiple tabs via the tab bar actions when confirmation is enabled.

Enhancements:
- Unify tab-close confirmation handling to support both single and multi-tab closures using a shared dialog.
- Localize multi-tab close confirmation titles and messages across supported languages (en, ja, ko, zh-CN, zh-TW).

</details>