### PR TITLE
fix: support task field defined only in imported interface.json

### DIFF
--- a/src/services/interfaceLoader.ts
+++ b/src/services/interfaceLoader.ts
@@ -84,6 +84,7 @@ async function loadInterfaceFromLocal(interfacePath: string): Promise<ProjectInt
     throw new Error(`不支持的 interface 版本: ${pi.interface_version}，仅支持 version 2`);
   }
 
+  pi.task ??= [];
   return pi;
 }
 
@@ -145,6 +146,7 @@ async function loadInterfaceFromHttp(path: string): Promise<ProjectInterface> {
     throw new Error(`不支持的 interface 版本: ${pi.interface_version}，仅支持 version 2`);
   }
 
+  pi.task ??= [];
   return pi;
 }
 
@@ -219,7 +221,7 @@ async function loadImportFromHttp(importPath: string): Promise<ImportableInterfa
 function mergeImported(pi: ProjectInterface, imported: ImportableInterface): void {
   // 合并 task 数组（追加到末尾）
   if (imported.task && imported.task.length > 0) {
-    pi.task = [...pi.task, ...imported.task];
+    pi.task = [...(pi.task || []), ...imported.task];
     log.info(`合并了 ${imported.task.length} 个导入的 task`);
   }
 


### PR DESCRIPTION
When the root \interface.json\ has no \	ask\ field (tasks are defined entirely via the \import\ mechanism), \mergeImported\ crashed because \pi.task\ was \undefined\ when spreading into the merged array.

**Changes:**
- Fix spread of potentially undefined \pi.task\ in \mergeImported\ — same \|| []\ pattern already used for \preset\ and \group\
- Ensure \pi.task\ is always initialized as an array after loading, preventing downstream crashes in \ppStore.ts\ and components that call \.forEach()\ / \.find()\ on it

Fixes the case where \	ask\ lives entirely in imported files (e.g. M9A project)

## Summary by Sourcery

通过在加载和合并接口时增强任务数组的健壮性，防止在任务仅定义于导入的接口文件中时发生崩溃。

Bug 修复：
- 在合并导入的接口时处理未定义的任务数组，以避免运行时错误。
- 在从本地和 HTTP 源加载接口时，将任务字段初始化为一个空数组，使下游代码可以安全地对其进行迭代。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent crashes when tasks are defined only in imported interface files by making task arrays robust during interface loading and merging.

Bug Fixes:
- Handle undefined task arrays when merging imported interfaces to avoid runtime errors.
- Initialize the task field as an empty array when loading interfaces from local and HTTP sources so downstream code can safely iterate over it.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在加载和合并接口时增强任务数组的健壮性，防止在任务仅定义于导入的接口文件中时发生崩溃。

Bug 修复：
- 在合并导入的接口时处理未定义的任务数组，以避免运行时错误。
- 在从本地和 HTTP 源加载接口时，将任务字段初始化为一个空数组，使下游代码可以安全地对其进行迭代。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent crashes when tasks are defined only in imported interface files by making task arrays robust during interface loading and merging.

Bug Fixes:
- Handle undefined task arrays when merging imported interfaces to avoid runtime errors.
- Initialize the task field as an empty array when loading interfaces from local and HTTP sources so downstream code can safely iterate over it.

</details>

</details>