### PR TITLE
fix: 读取过大window尺寸导致mxu无法启动

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,6 +85,7 @@ import { WebUIBetaBanner } from './components/app/WebUIBetaBanner';
 import { startGlobalCallbackListener } from './components/connection/callbackCache';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { ScrollText } from 'lucide-react';
+import { defaultWindowSize } from '@/types/config';
 
 const log = loggers.app;
 
@@ -615,7 +616,14 @@ function App() {
 
       // 应用保存的窗口大小和位置
       if (config.settings.windowSize) {
-        await setWindowSize(config.settings.windowSize.width, config.settings.windowSize.height);
+        const { width, height } = config.settings.windowSize;
+        if (isValidWindowSize(width, height)) {
+          await setWindowSize(width, height);
+        } else {
+          log.warn('保存的窗口大小无效，已回退默认值:', { width, height });
+          setWindowSizeStore(defaultWindowSize);
+          await setWindowSize(defaultWindowSize.width, defaultWindowSize.height);
+        }
       }
       if (config.settings.windowPosition && isTauri()) {
         const { x, y } = config.settings.windowPosition;

--- a/src/utils/windowUtils.ts
+++ b/src/utils/windowUtils.ts
@@ -10,6 +10,11 @@ const log = loggers.app;
 export const MIN_WINDOW_WIDTH = 800;
 export const MIN_WINDOW_HEIGHT = 500;
 
+// 最大窗口尺寸（逻辑像素）
+// 多屏/DPI 异常时可能出现离谱的尺寸回传，需在持久化与恢复前拦截
+export const MAX_WINDOW_WIDTH = 16384;
+export const MAX_WINDOW_HEIGHT = 16384;
+
 // 左侧面板最小宽度（确保工具栏按钮文字不换行）
 export const MIN_LEFT_PANEL_WIDTH = 530;
 
@@ -17,7 +22,14 @@ export const MIN_LEFT_PANEL_WIDTH = 530;
  * 验证窗口尺寸是否有效
  */
 export function isValidWindowSize(width: number, height: number): boolean {
-  return width >= MIN_WINDOW_WIDTH && height >= MIN_WINDOW_HEIGHT;
+  return (
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width >= MIN_WINDOW_WIDTH &&
+    height >= MIN_WINDOW_HEIGHT &&
+    width <= MAX_WINDOW_WIDTH &&
+    height <= MAX_WINDOW_HEIGHT
+  );
 }
 
 /**


### PR DESCRIPTION
close https://github.com/MaaEnd/MaaEnd/issues/4011

## Summary by Sourcery

验证持久化的窗口大小，并在异常情况下回退到安全的默认值，以防止由异常窗口尺寸导致的启动问题。

Bug Fixes:
- 当先前保存的窗口尺寸过大或无效时，防止应用程序在启动时发生故障。

Enhancements:
- 在窗口持久化和恢复之前，引入窗口最大尺寸边界，并对窗口尺寸进行更严格的校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate persisted window size and fall back to a safe default to prevent startup issues caused by abnormal window dimensions.

Bug Fixes:
- Prevent application startup failures when previously saved window dimensions are excessively large or invalid.

Enhancements:
- Introduce maximum window size bounds and stricter validation of window dimensions before persistence and restoration.

</details>