### PR TITLE
feat: 为每个控制器缓存任务勾选状态

### DIFF
--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -154,8 +154,12 @@ function useImportConfigActions(instanceId: string) {
       // 任务写入后 PresetSelector 自动消失，无需调用 skipPreset（避免触发 showAddTaskPanel）
       updateInstance(instanceId, {
         selectedTasks: importedTasks,
-        controllerName: payload.controllerName,
-        resourceName: payload.resourceName,
+        ...(payload.controllerName !== undefined && {
+          controllerName: payload.controllerName,
+        }),
+        ...(payload.resourceName !== undefined && {
+          resourceName: payload.resourceName,
+        }),
         preActions: payload.preActions,
       });
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -65,6 +65,7 @@ import {
   sanitizeOptionValues,
 } from './helpers';
 import { persistRuntimeLogs } from '@/utils/runtimeLogPersistence';
+import { cacheTaskEnabledForController } from '@/utils/taskControllerCache';
 // 从独立模块导入类型和辅助函数
 import type { AppState, LogEntry, TaskRunStatus } from './types';
 
@@ -105,6 +106,59 @@ function cleanOptionValues(
 ): Record<string, OptionValue> {
   if (!pi?.option) return {};
   return sanitizeOptionValues(optionValues, pi.option, (message) => loggers.config.warn(message));
+}
+
+function updateSelectedName(
+  selectedNames: Record<string, string>,
+  instanceId: string,
+  name: string | undefined,
+): Record<string, string> {
+  const updatedNames = { ...selectedNames };
+  if (name === undefined) {
+    delete updatedNames[instanceId];
+  } else {
+    updatedNames[instanceId] = name;
+  }
+  return updatedNames;
+}
+
+function isTaskControllerCompatible(
+  taskDef: { controller?: string[] } | undefined,
+  controllerName: string | undefined,
+): boolean {
+  return (
+    !controllerName ||
+    !taskDef?.controller ||
+    taskDef.controller.length === 0 ||
+    taskDef.controller.includes(controllerName)
+  );
+}
+
+function resolveTaskEnabledForController(
+  task: SelectedTask,
+  taskDef: { controller?: string[] } | undefined,
+  previousControllerName: string | undefined,
+  controllerName: string,
+  enabledByController: Record<string, boolean>,
+): boolean {
+  if (!isTaskControllerCompatible(taskDef, controllerName)) return false;
+
+  if (Object.prototype.hasOwnProperty.call(enabledByController, controllerName)) {
+    return enabledByController[controllerName];
+  }
+
+  // 首次进入新控制器时继承当前值，但不能继承由“不支持该任务”产生的 false。
+  if (isTaskControllerCompatible(taskDef, previousControllerName)) {
+    return task.enabled;
+  }
+
+  const cachedEntries = Object.entries(enabledByController);
+  for (let index = cachedEntries.length - 1; index >= 0; index -= 1) {
+    const [cachedControllerName, enabled] = cachedEntries[index];
+    if (isTaskControllerCompatible(taskDef, cachedControllerName)) return enabled;
+  }
+
+  return task.enabled;
 }
 
 function forwardLogToStdout(message: string) {
@@ -399,6 +453,11 @@ export const useAppStore = create<AppState>()(
               taskName: t.taskName,
               customName: t.customName,
               enabled: t.enabled,
+              enabledByController: cacheTaskEnabledForController(
+                t.enabledByController,
+                instanceToClose.controllerName,
+                t.enabled,
+              ),
               optionValues: t.optionValues,
             })),
             schedulePolicies: instanceToClose.schedulePolicies,
@@ -430,6 +489,16 @@ export const useAppStore = create<AppState>()(
     updateInstance: (id, updates) =>
       set((state) => ({
         instances: state.instances.map((i) => (i.id === id ? { ...i, ...updates } : i)),
+        ...(Object.prototype.hasOwnProperty.call(updates, 'controllerName') && {
+          selectedController: updateSelectedName(
+            state.selectedController,
+            id,
+            updates.controllerName,
+          ),
+        }),
+        ...(Object.prototype.hasOwnProperty.call(updates, 'resourceName') && {
+          selectedResource: updateSelectedName(state.selectedResource, id, updates.resourceName),
+        }),
       })),
 
     renameInstance: (id, newName) =>
@@ -854,6 +923,9 @@ export const useAppStore = create<AppState>()(
         ...originalTask,
         id: generateId(),
         customName: newCustomName,
+        enabledByController: originalTask.enabledByController
+          ? { ...originalTask.enabledByController }
+          : undefined,
         optionValues: { ...originalTask.optionValues },
       };
 
@@ -949,6 +1021,7 @@ export const useAppStore = create<AppState>()(
         selectedTasks: sourceInstance.selectedTasks.map((t) => ({
           ...t,
           id: generateId(),
+          enabledByController: t.enabledByController ? { ...t.enabledByController } : undefined,
           optionValues: { ...t.optionValues },
         })),
         isRunning: false,
@@ -1118,6 +1191,7 @@ export const useAppStore = create<AppState>()(
                 taskName: t.taskName,
                 customName: t.customName,
                 enabled: t.enabled,
+                enabledByController: t.enabledByController,
                 optionValues: t.optionValues,
                 expanded: prevExpandedByTask.get(t.id) ?? false,
               };
@@ -1140,6 +1214,7 @@ export const useAppStore = create<AppState>()(
                 taskName: t.taskName,
                 customName: t.customName,
                 enabled: t.enabled,
+                enabledByController: t.enabledByController,
                 optionValues: mergedValues,
                 expanded: prevExpandedByTask.get(t.id) ?? false,
               };
@@ -1162,6 +1237,7 @@ export const useAppStore = create<AppState>()(
               taskName: t.taskName,
               customName: t.customName,
               enabled: t.enabled,
+              enabledByController: t.enabledByController,
               optionValues: mergedValues,
               expanded: prevExpandedByTask.get(t.id) ?? false,
             };
@@ -1421,20 +1497,41 @@ export const useAppStore = create<AppState>()(
     setSelectedController: (instanceId, controllerName) =>
       set((state) => {
         const pi = state.projectInterface;
-        // 自动取消不兼容任务的勾选
         const updatedInstances = state.instances.map((instance) => {
           if (instance.id !== instanceId)
             return { ...instance, controllerName: instance.controllerName };
 
+          const previousControllerName =
+            state.selectedController[instanceId] ||
+            instance.controllerName ||
+            pi?.controller[0]?.name;
+
           const updatedTasks = instance.selectedTasks.map((task) => {
-            const taskDef = pi?.task.find((t) => t.name === task.taskName);
-            // 如果任务指定了 controller 限制且不包含新控制器，取消勾选
-            if (taskDef?.controller && taskDef.controller.length > 0) {
-              if (!taskDef.controller.includes(controllerName)) {
-                return { ...task, enabled: false };
-              }
-            }
-            return task;
+            const taskDef = resolveCompatTaskDef(pi, task.taskName);
+            const enabledByController =
+              cacheTaskEnabledForController(
+                task.enabledByController,
+                previousControllerName,
+                task.enabled,
+              ) ?? {};
+
+            const enabled = resolveTaskEnabledForController(
+              task,
+              taskDef,
+              previousControllerName,
+              controllerName,
+              enabledByController,
+            );
+
+            return {
+              ...task,
+              enabled,
+              enabledByController: cacheTaskEnabledForController(
+                enabledByController,
+                controllerName,
+                enabled,
+              ),
+            };
           });
 
           return { ...instance, controllerName, selectedTasks: updatedTasks };
@@ -1907,6 +2004,7 @@ export const useAppStore = create<AppState>()(
           taskName: t.taskName,
           customName: t.customName,
           enabled: t.enabled,
+          enabledByController: t.enabledByController ? { ...t.enabledByController } : undefined,
           optionValues: cleanOptionValues(t.optionValues, pi),
           expanded: false,
         })),
@@ -2170,6 +2268,11 @@ function generateConfig(): MxuConfig {
         taskName: t.taskName,
         customName: t.customName,
         enabled: t.enabled,
+        enabledByController: cacheTaskEnabledForController(
+          t.enabledByController,
+          inst.controllerName,
+          t.enabled,
+        ),
         optionValues: t.optionValues,
       })),
       schedulePolicies: inst.schedulePolicies,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -20,6 +20,8 @@ export interface SavedTask {
   taskName: string; // 对应 interface 中的 task.name
   customName?: string; // 用户自定义名称
   enabled: boolean;
+  /** 各控制器独立的勾选状态（旧配置中不存在时按 enabled 初始化） */
+  enabledByController?: Record<string, boolean>;
   optionValues: Record<string, OptionValue>;
 }
 

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -284,6 +284,8 @@ export interface SelectedTask {
   taskName: string;
   customName?: string; // 用户自定义名称
   enabled: boolean;
+  /** 各控制器独立的勾选状态；enabled 始终表示当前控制器的状态 */
+  enabledByController?: Record<string, boolean>;
   optionValues: Record<string, OptionValue>;
   expanded: boolean;
 }

--- a/src/utils/tabExportImport.ts
+++ b/src/utils/tabExportImport.ts
@@ -1,6 +1,7 @@
 import type { SavedTask } from '@/types/config';
 import type { ActionConfig, Instance, OptionValue } from '@/types/interface';
 import { isTauri } from '@/utils/paths';
+import { cacheTaskEnabledForController } from '@/utils/taskControllerCache';
 import { toast } from 'sonner';
 
 const PROTOCOL_SEGMENT = 'tab-sharing';
@@ -35,6 +36,7 @@ interface WireTask {
   tn: string; // taskName
   cn?: string; // customName
   e: boolean; // enabled
+  ec?: Record<string, boolean>; // enabledByController
   ov: Record<string, WireOptionValue>; // optionValues
 }
 
@@ -85,6 +87,7 @@ function encodeTask(task: SavedTask): WireTask {
     ),
   };
   if (task.customName !== undefined) wire.cn = task.customName;
+  if (task.enabledByController !== undefined) wire.ec = task.enabledByController;
   return wire;
 }
 
@@ -137,6 +140,7 @@ function decodeTask(w: WireTask): SavedTask {
     taskName: w.tn,
     customName: w.cn,
     enabled: w.e,
+    enabledByController: w.ec,
     optionValues: Object.fromEntries(
       Object.entries(w.ov).map(([k, v]) => [k, decodeOptionValue(v)]),
     ),
@@ -256,6 +260,11 @@ export async function buildTabConfigExportText(
       taskName: t.taskName,
       customName: t.customName,
       enabled: t.enabled,
+      enabledByController: cacheTaskEnabledForController(
+        t.enabledByController,
+        instance.controllerName,
+        t.enabled,
+      ),
       optionValues: t.optionValues,
     })),
     preActions: instance.preActions,

--- a/src/utils/taskControllerCache.ts
+++ b/src/utils/taskControllerCache.ts
@@ -1,0 +1,8 @@
+export function cacheTaskEnabledForController(
+  cache: Record<string, boolean> | undefined,
+  controllerName: string | undefined,
+  enabled: boolean,
+): Record<string, boolean> | undefined {
+  if (!controllerName) return cache;
+  return { ...cache, [controllerName]: enabled };
+}


### PR DESCRIPTION
已实现：

- 每个标签页、每个任务按控制器名称独立缓存勾选状态，支持任意数量控制器。
- A→B→C→A 会分别恢复状态，不会继承“不支持任务”导致的假 false。
- 缓存随配置持久化，并支持标签页复制、关闭恢复和导入导出；分享协议保持 v1，新字段可选，兼容旧数据。
- 标签页的控制器/资源映射同步更新，不会跨标签页串状态。

## Summary by Sourcery

为每个控制器添加任务启用状态的缓存，并在标签页和配置的导出/导入之间持久化该状态。

新功能：
- 为每个控制器分别跟踪各任务的启用状态，并在切换控制器时使用该状态。
- 在已保存的配置和标签页的导出/导入中包含每个控制器的任务启用状态，以在不同会话之间持久化。

增强：
- 在更新实例时保持选定的控制器和资源映射同步，避免跨标签页的状态泄漏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-controller caching of task enabled state and persist it across tabs and config export/import.

New Features:
- Track each task’s enabled state separately for each controller and use it when switching controllers.
- Include per-controller task enabled state in saved configurations and tab export/import for persistence across sessions.

Enhancements:
- Keep selected controller and resource mappings in sync when updating instances to avoid cross-tab state leakage.

</details>