### PR TITLE
fix(agent): 修复退出时套接字残留

### DIFF
--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -58,7 +58,7 @@ impl PendingAgent {
     }
 
     fn set_child(&self, child: Child) -> Result<(), Child> {
-        if self.state.cancelled.load(Ordering::SeqCst) {
+        if self.state.cancelled.load(Ordering::Relaxed) {
             return Err(child);
         }
 
@@ -66,7 +66,7 @@ impl PendingAgent {
             Ok(child_slot) => child_slot,
             Err(poisoned) => poisoned.into_inner(),
         };
-        if self.state.cancelled.load(Ordering::SeqCst) {
+        if self.state.cancelled.load(Ordering::Relaxed) {
             return Err(child);
         }
         *child_slot = Some(child);
@@ -375,7 +375,7 @@ async fn start_single_agent(
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        if maa_state.agent_shutdown_requested.load(Ordering::SeqCst) {
+        if maa_state.agent_shutdown_requested.load(Ordering::Relaxed) {
             return Err("Application is shutting down".to_string());
         }
 
@@ -415,8 +415,8 @@ async fn start_single_agent(
         if pending_agent
             .maa_state
             .agent_shutdown_requested
-            .load(Ordering::SeqCst)
-            || pending_agent.state.cancelled.load(Ordering::SeqCst)
+            .load(Ordering::Relaxed)
+            || pending_agent.state.cancelled.load(Ordering::Relaxed)
         {
             return Err("Agent startup was interrupted by application shutdown".to_string());
         }
@@ -655,7 +655,7 @@ pub async fn start_tasks_impl(
 ) -> Result<Vec<i64>, String> {
     info!("start_tasks_impl called");
 
-    if maa_state.agent_shutdown_requested.load(Ordering::SeqCst) {
+    if maa_state.agent_shutdown_requested.load(Ordering::Relaxed) {
         return Err("Application is shutting down".to_string());
     }
 
@@ -766,7 +766,7 @@ pub async fn start_tasks_impl(
             let mut pending_agents = Vec::new();
 
             for (idx, config) in configs.iter().enumerate() {
-                if maa_state.agent_shutdown_requested.load(Ordering::SeqCst) {
+                if maa_state.agent_shutdown_requested.load(Ordering::Relaxed) {
                     cleanup_untracked_agents(new_clients, pending_agents, Vec::new());
                     return Err("Application is shutting down".to_string());
                 }
@@ -827,7 +827,7 @@ pub async fn start_tasks_impl(
                     poisoned.into_inner()
                 }
             };
-            if maa_state.agent_shutdown_requested.load(Ordering::SeqCst) {
+            if maa_state.agent_shutdown_requested.load(Ordering::Relaxed) {
                 drop(instances);
                 cleanup_untracked_agents(new_clients, pending_agents, Vec::new());
                 return Err("Application is shutting down".to_string());

--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -7,7 +7,8 @@ use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Component, Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -19,11 +20,82 @@ use maa_framework::controller::Controller;
 use maa_framework::resource::Resource;
 use maa_framework::tasker::Tasker;
 
-use super::types::{AgentConfig, MaaState, TaskConfig};
+use super::types::{
+    terminate_agent_child, AgentConfig, MaaState, PendingAgentState, TaskConfig,
+    AGENT_DISCONNECT_TIMEOUT_MS,
+};
 use super::utils::{emit_callback_event, get_logs_dir, handle_task_callback, normalize_path};
 use regex::Regex;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
+
+const AGENT_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct PendingAgent {
+    maa_state: Arc<MaaState>,
+    identifier: String,
+    state: Arc<PendingAgentState>,
+}
+
+impl PendingAgent {
+    fn register(maa_state: Arc<MaaState>, identifier: String, instance_id: String) -> Self {
+        let state = Arc::new(PendingAgentState::new(instance_id));
+        let mut pending = match maa_state.pending_agent_children.lock() {
+            Ok(pending) => pending,
+            Err(poisoned) => {
+                warn!("Pending agent children lock was poisoned; continuing registration");
+                poisoned.into_inner()
+            }
+        };
+        pending.insert(identifier.clone(), state.clone());
+        drop(pending);
+
+        Self {
+            maa_state,
+            identifier,
+            state,
+        }
+    }
+
+    fn set_child(&self, child: Child) -> Result<(), Child> {
+        if self.state.cancelled.load(Ordering::SeqCst) {
+            return Err(child);
+        }
+
+        let mut child_slot = match self.state.child.lock() {
+            Ok(child_slot) => child_slot,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if self.state.cancelled.load(Ordering::SeqCst) {
+            return Err(child);
+        }
+        *child_slot = Some(child);
+        Ok(())
+    }
+
+    fn take_child(&self) -> Option<Child> {
+        match self.state.child.lock() {
+            Ok(mut child) => child.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        }
+    }
+
+    fn terminate_child(&self) {
+        if let Some(child) = self.take_child() {
+            terminate_agent_child(child);
+        }
+    }
+}
+
+impl Drop for PendingAgent {
+    fn drop(&mut self) {
+        let mut pending = match self.maa_state.pending_agent_children.lock() {
+            Ok(pending) => pending,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        pending.remove(&self.identifier);
+    }
+}
 
 /// Agent 输出事件载荷
 #[derive(Clone, serde::Serialize)]
@@ -285,17 +357,28 @@ async fn start_single_agent(
     agent: AgentConfig,
     agent_index: usize,
     instance_id: String,
+    maa_state: Arc<MaaState>,
     cwd: String,
     tcp_compat_mode: bool,
     resource: Resource,
     controller: Controller,
     tasker: Tasker,
     pi_envs: Arc<HashMap<String, String>>,
-) -> Result<(AgentClient, std::process::Child), String> {
+) -> Result<(AgentClient, PendingAgent), String> {
     info!("[agent#{}] Starting agent: {:?}", agent_index, agent);
 
     // 将整个启动过程移入 spawn_blocking，避免阻塞 async runtime 线程
     tauri::async_runtime::spawn_blocking(move || {
+        // 端点创建与 pending 登记必须相对退出清理原子化。退出流程会先设置
+        // agent_shutdown_requested，再等待同一把锁，因此不会漏掉半创建的客户端。
+        let lifecycle_guard = match maa_state.agent_lifecycle_lock.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if maa_state.agent_shutdown_requested.load(Ordering::SeqCst) {
+            return Err("Application is shutting down".to_string());
+        }
+
         let mut client = if tcp_compat_mode {
             debug!("[agent#{}] Creating TCP agent client...", agent_index);
             AgentClient::create_tcp(0).or_else(|e| {
@@ -319,6 +402,24 @@ async fn start_single_agent(
             .identifier()
             .ok_or_else(|| format!("Failed to get identifier for agent #{}", agent_index))?;
         info!("[agent#{}] Agent socket_id: {}", agent_index, socket_id);
+
+        // AgentClient 创建 IPC 端点后立即登记 identifier。即使退出发生在 spawn 前，
+        // 全局清理也能精确删除这个尚未转入 InstanceRuntime 的 socket。
+        let pending_agent = PendingAgent::register(
+            Arc::clone(&maa_state),
+            socket_id.clone(),
+            instance_id.clone(),
+        );
+        drop(lifecycle_guard);
+
+        if pending_agent
+            .maa_state
+            .agent_shutdown_requested
+            .load(Ordering::SeqCst)
+            || pending_agent.state.cancelled.load(Ordering::SeqCst)
+        {
+            return Err("Agent startup was interrupted by application shutdown".to_string());
+        }
 
         // 启动子进程
         let mut args = agent.child_args.clone().unwrap_or_default();
@@ -387,7 +488,7 @@ async fn start_single_agent(
             );
         }
 
-        let mut child = cmd.spawn().map_err(|e| {
+        let child = cmd.spawn().map_err(|e| {
             let mut msg = format!(
                 "Failed to spawn agent #{}: {} (path: {:?})",
                 agent_index, e, exec_path
@@ -398,15 +499,30 @@ async fn start_single_agent(
             msg
         })?;
 
+        // 退出线程和启动线程通过同一个 Option<Child> 槽位转移所有权。
+        if let Err(child) = pending_agent.set_child(child) {
+            terminate_agent_child(child);
+            return Err("Agent startup was interrupted by application shutdown".to_string());
+        }
+        let (pid, stdout, stderr) = {
+            let mut child_slot = match pending_agent.state.child.lock() {
+                Ok(child) => child,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            let child = child_slot
+                .as_mut()
+                .ok_or("Agent startup was interrupted by application shutdown")?;
+            (child.id(), child.stdout.take(), child.stderr.take())
+        };
+
         // agent 日志文件路径（延迟创建：仅在有实际输出时才打开文件）
-        let pid = child.id();
         let log_filename = format!("mxu-agent-{}-{}.log", agent_index, pid);
         let agent_log_path = Arc::new(get_logs_dir().join(&log_filename));
         let log_file: Arc<Mutex<Option<std::fs::File>>> = Arc::new(Mutex::new(None));
         let output_batcher = AgentOutputBatcher::new(app.clone(), instance_id.clone());
 
         // 在单独线程中读取 stdout
-        if let Some(stdout) = child.stdout.take() {
+        if let Some(stdout) = stdout {
             let lf = log_file.clone();
             let lf_path = agent_log_path.clone();
             let batcher = output_batcher.clone();
@@ -443,7 +559,7 @@ async fn start_single_agent(
         }
 
         // Stderr thread
-        if let Some(stderr) = child.stderr.take() {
+        if let Some(stderr) = stderr {
             let lf = log_file.clone();
             let lf_path = agent_log_path.clone();
             let batcher = output_batcher.clone();
@@ -489,8 +605,7 @@ async fn start_single_agent(
 
         if let Err(e) = client.connect() {
              error!("[agent#{}] Connection failed: {}", agent_index, e);
-             let _ = child.kill();
-             let _ = child.wait();
+             pending_agent.terminate_child();
              return Err(e.to_string());
         }
 
@@ -499,13 +614,31 @@ async fn start_single_agent(
         // 注册 Agent sink
         if let Err(e) = client.register_sinks(resource, controller, tasker) {
             error!("[agent#{}] Failed to register sinks: {}", agent_index, e);
-            let _ = child.kill();
-            let _ = child.wait();
+            pending_agent.terminate_child();
             return Err(e.to_string());
         }
 
-        Ok((client, child))
+        Ok((client, pending_agent))
     }).await.map_err(|e| e.to_string())?
+}
+
+fn cleanup_untracked_agents(
+    clients: Vec<AgentClient>,
+    pending_agents: Vec<PendingAgent>,
+    children: Vec<Child>,
+) {
+    for mut client in clients {
+        if client.set_timeout(AGENT_DISCONNECT_TIMEOUT_MS).is_ok() {
+            let _ = client.disconnect();
+        }
+    }
+
+    for pending_agent in pending_agents {
+        pending_agent.terminate_child();
+    }
+    for child in children {
+        terminate_agent_child(child);
+    }
 }
 
 /// 启动任务的核心实现（Tauri invoke 和 HTTP handler 共享）
@@ -521,6 +654,10 @@ pub async fn start_tasks_impl(
     reset_state: bool,
 ) -> Result<Vec<i64>, String> {
     info!("start_tasks_impl called");
+
+    if maa_state.agent_shutdown_requested.load(Ordering::SeqCst) {
+        return Err("Application is shutting down".to_string());
+    }
 
     info!("instance_id: {}", instance_id);
     info!("tasks: {:?}", tasks);
@@ -626,14 +763,20 @@ pub async fn start_tasks_impl(
 
             // 用于收集所有成功启动的 agent，失败时需要回滚清理
             let mut new_clients = Vec::new();
-            let mut new_children = Vec::new();
+            let mut pending_agents = Vec::new();
 
             for (idx, config) in configs.iter().enumerate() {
+                if maa_state.agent_shutdown_requested.load(Ordering::SeqCst) {
+                    cleanup_untracked_agents(new_clients, pending_agents, Vec::new());
+                    return Err("Application is shutting down".to_string());
+                }
+
                 let res_clone = resource.clone();
                 let ctrl_clone = controller.clone();
                 let tasker_clone = tasker.clone();
                 let app_handle = app.clone();
                 let inst_id = instance_id.clone();
+                let maa_state_clone = Arc::clone(maa_state);
                 let cwd_clone = cwd.clone();
                 let pi_envs_clone = Arc::clone(&pi_envs);
 
@@ -642,6 +785,7 @@ pub async fn start_tasks_impl(
                     config.clone(),
                     idx,
                     inst_id,
+                    maa_state_clone,
                     cwd_clone,
                     tcp_compat_mode,
                     res_clone,
@@ -651,9 +795,9 @@ pub async fn start_tasks_impl(
                 )
                 .await
                 {
-                    Ok((client, child)) => {
+                    Ok((client, pending_agent)) => {
                         new_clients.push(client);
-                        new_children.push(child);
+                        pending_agents.push(pending_agent);
                     }
                     Err(e) => {
                         error!(
@@ -662,24 +806,68 @@ pub async fn start_tasks_impl(
                         );
 
                         // 回滚：清理已启动的 agent
-                        for client in &new_clients {
-                            let _ = client.disconnect();
-                        }
-                        for mut child in new_children {
-                            let _ = child.kill();
-                            let _ = child.wait();
-                        }
+                        cleanup_untracked_agents(new_clients, pending_agents, Vec::new());
                         return Err(format!("Agent start failed: {}", e));
                     }
                 }
             }
 
+            // pending -> instance 的最终转移与 stop/exit 使用同一把生命周期锁，
+            // 防止 stop 在 tracked 与 pending 两次清理之间漏掉刚完成连接的 Agent。
+            let lifecycle_guard = match maa_state.agent_lifecycle_lock.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+
             // 保存所有 agent 状态到 instance
-            let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
-            if let Some(instance) = instances.get_mut(&instance_id) {
-                instance.agent_clients.extend(new_clients);
-                instance.agent_children.extend(new_children);
+            let mut instances = match maa_state.instances.lock() {
+                Ok(instances) => instances,
+                Err(poisoned) => {
+                    warn!("MaaState instances lock was poisoned; continuing agent transfer");
+                    poisoned.into_inner()
+                }
+            };
+            if maa_state.agent_shutdown_requested.load(Ordering::SeqCst) {
+                drop(instances);
+                cleanup_untracked_agents(new_clients, pending_agents, Vec::new());
+                return Err("Application is shutting down".to_string());
             }
+
+            if !instances.contains_key(&instance_id) {
+                drop(instances);
+                cleanup_untracked_agents(new_clients, pending_agents, Vec::new());
+                return Err(format!(
+                    "Instance '{}' was removed while starting agents",
+                    instance_id
+                ));
+            }
+
+            let mut new_children = Vec::with_capacity(pending_agents.len());
+            let mut startup_interrupted = false;
+            for pending_agent in &pending_agents {
+                match pending_agent.take_child() {
+                    Some(child) => new_children.push(child),
+                    None => {
+                        startup_interrupted = true;
+                        break;
+                    }
+                }
+            }
+            if startup_interrupted {
+                drop(instances);
+                cleanup_untracked_agents(new_clients, pending_agents, new_children);
+                return Err("Agent startup was interrupted by application shutdown".to_string());
+            }
+
+            let instance = instances
+                .get_mut(&instance_id)
+                .expect("instance existence checked while holding instances lock");
+            instance.agent_clients.extend(new_clients);
+            instance.agent_children.extend(new_children);
+            // 句柄已经在 instances 锁内完成转移，现在可以从 pending 监督表移除。
+            drop(pending_agents);
+            drop(instances);
+            drop(lifecycle_guard);
 
             info!(
                 "[start_tasks] All {} agent(s) started successfully",
@@ -798,9 +986,13 @@ pub async fn maa_start_tasks(
     .await
 }
 
-/// 停止所有 Agent 的核心实现（Tauri invoke 和 HTTP handler 共享）
-pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(), String> {
+fn stop_agent_blocking(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(), String> {
     info!("stop_agent_impl called for instance: {}", instance_id);
+
+    let _lifecycle_guard = maa_state
+        .agent_lifecycle_lock
+        .lock()
+        .map_err(|e| e.to_string())?;
 
     let (clients, children) = {
         let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
@@ -812,60 +1004,93 @@ pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(
         )
     };
 
+    // 同一实例仍在 connect 的 Agent 也属于本次 stop；取消后它们无法再写回实例。
+    maa_state.cleanup_pending_agents(Some(instance_id));
+
     if clients.is_empty() && children.is_empty() {
         debug!("[stop_agent] No agents to stop");
         return Ok(());
     }
 
     info!(
-        "[stop_agent] Stopping {} agent client(s) and {} child process(es) in background...",
+        "[stop_agent] Disconnecting {} agent client(s) and stopping {} child process(es)...",
         clients.len(),
         children.len()
     );
 
-    thread::spawn(move || {
-        for client in clients {
-            let _ = client.disconnect();
+    // 必须在返回前销毁 AgentClient。临时收紧 timeout，避免失联 Agent 无限阻塞 stop。
+    for mut client in clients {
+        if let Err(e) = client.set_timeout(AGENT_DISCONNECT_TIMEOUT_MS) {
+            warn!("Failed to set agent disconnect timeout: {}", e);
+            continue;
         }
+        if let Err(e) = client.disconnect() {
+            warn!("Failed to disconnect agent client: {}", e);
+        }
+    }
 
-        for (i, mut child) in children.into_iter().enumerate() {
-            debug!("Waiting for agent process #{} to exit...", i);
+    // 所有子进程共享一个总 deadline，避免多个失联 Agent 产生 N * timeout 的等待。
+    let deadline = Instant::now() + AGENT_STOP_TIMEOUT;
+    for (i, mut child) in children.into_iter().enumerate() {
+        debug!("Waiting for agent process #{} to exit...", i);
+        let mut exited = false;
 
-            let start = std::time::Instant::now();
-            let timeout = std::time::Duration::from_secs(5);
-            let mut exited = false;
-
-            while start.elapsed() < timeout {
-                match child.try_wait() {
-                    Ok(Some(_)) => {
-                        exited = true;
-                        break;
-                    }
-                    Ok(None) => {
-                        thread::sleep(std::time::Duration::from_millis(100));
-                    }
-                    Err(e) => {
-                        error!("Error waiting for agent #{}: {}", i, e);
-                        break;
-                    }
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    exited = true;
+                    break;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    error!("Error waiting for agent #{}: {}", i, e);
+                    break;
                 }
             }
 
-            if !exited {
-                warn!("Agent process #{} did not exit in time, killing it...", i);
-                let _ = child.kill();
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+            thread::sleep((deadline - now).min(Duration::from_millis(100)));
+        }
+
+        if exited {
+            info!("Agent #{} child process exited", i);
+            continue;
+        }
+
+        warn!("Agent process #{} did not exit in time, killing it...", i);
+        match child.kill() {
+            Ok(()) => {
                 let _ = child.wait();
-            } else {
-                info!("Background: Agent #{} child process exited", i);
+            }
+            Err(e) => {
+                // kill 失败时不再无界 wait；退出兜底也不会因此永久阻塞。
+                error!("Failed to kill agent process #{}: {}", i, e);
             }
         }
-    });
+    }
 
     Ok(())
 }
 
+/// 停止所有 Agent 的核心实现（Tauri invoke 和 HTTP handler 共享）。
+pub async fn stop_agent_impl(
+    maa_state: Arc<MaaState>,
+    instance_id: String,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || stop_agent_blocking(&maa_state, &instance_id))
+        .await
+        .map_err(|e| format!("Agent cleanup worker failed: {}", e))?
+}
+
 /// 停止所有 Agent 并断开连接 — Tauri invoke 入口，委托给 stop_agent_impl
 #[tauri::command]
-pub fn maa_stop_agent(state: State<'_, Arc<MaaState>>, instance_id: String) -> Result<(), String> {
-    stop_agent_impl(&state, &instance_id)
+pub async fn maa_stop_agent(
+    state: State<'_, Arc<MaaState>>,
+    instance_id: String,
+) -> Result<(), String> {
+    let maa_state = state.inner().clone();
+    stop_agent_impl(maa_state, instance_id).await
 }

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -339,7 +339,7 @@ impl MaaState {
     /// 句柄先从共享状态中取出，避免在可能阻塞的原生调用期间持有 instances 锁。
     /// 该操作可重复调用；首轮清理后，后续调用不会再取得任何句柄。
     pub fn cleanup_all_agents(&self) {
-        self.agent_shutdown_requested.store(true, Ordering::SeqCst);
+        self.agent_shutdown_requested.store(true, Ordering::Relaxed);
 
         let _lifecycle_guard = match self.agent_lifecycle_lock.lock() {
             Ok(guard) => guard,
@@ -452,7 +452,7 @@ impl MaaState {
         };
 
         for (identifier, pending_agent) in pending_agents {
-            pending_agent.cancelled.store(true, Ordering::SeqCst);
+            pending_agent.cancelled.store(true, Ordering::Relaxed);
             let child = match pending_agent.child.lock() {
                 Ok(mut slot) => slot.take(),
                 Err(poisoned) => {
@@ -490,20 +490,27 @@ fn remove_pending_agent_socket(identifier: &str) {
         return;
     }
 
+    let mut socket_dirs = vec![std::env::temp_dir()];
     #[cfg(windows)]
-    let socket_dir = PathBuf::from("C:/Temp");
-    #[cfg(not(windows))]
-    let socket_dir = std::env::temp_dir();
+    {
+        // MaaFramework 在 Windows 上使用该 IPC 兼容目录。
+        let legacy_dir = PathBuf::from("C:/Temp");
+        if !socket_dirs.contains(&legacy_dir) {
+            socket_dirs.push(legacy_dir);
+        }
+    }
 
-    let socket_path = socket_dir.join(format!("maafw-agent-{}.sock", identifier));
-    match std::fs::remove_file(&socket_path) {
-        Ok(()) => log::info!("Removed pending agent socket: {:?}", socket_path),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => log::warn!(
-            "Failed to remove pending agent socket {:?}: {}",
-            socket_path,
-            e
-        ),
+    for socket_dir in socket_dirs {
+        let socket_path = socket_dir.join(format!("maafw-agent-{}.sock", identifier));
+        match std::fs::remove_file(&socket_path) {
+            Ok(()) => log::info!("Removed pending agent socket: {:?}", socket_path),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => log::warn!(
+                "Failed to remove pending agent socket {:?}: {}",
+                socket_path,
+                e
+            ),
+        }
     }
 }
 

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -5,7 +5,8 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::process::Child;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
@@ -169,6 +170,33 @@ pub struct AllInstanceStates {
     pub cached_wlroots_sockets: Vec<String>,
 }
 
+pub(crate) const AGENT_DISCONNECT_TIMEOUT_MS: i64 = 1_000;
+
+pub(crate) fn terminate_agent_child(mut child: Child) {
+    if matches!(child.try_wait(), Ok(Some(_))) {
+        return;
+    }
+    if child.kill().is_ok() {
+        let _ = child.wait();
+    }
+}
+
+pub(crate) struct PendingAgentState {
+    pub(crate) instance_id: String,
+    pub(crate) child: Mutex<Option<Child>>,
+    pub(crate) cancelled: AtomicBool,
+}
+
+impl PendingAgentState {
+    pub(crate) fn new(instance_id: String) -> Self {
+        Self {
+            instance_id,
+            child: Mutex::new(None),
+            cancelled: AtomicBool::new(false),
+        }
+    }
+}
+
 /// 实例运行时状态（持有 MaaFramework 对象句柄）
 #[derive(Default)]
 pub struct InstanceRuntime {
@@ -192,15 +220,16 @@ pub struct InstanceRuntime {
 impl Drop for InstanceRuntime {
     fn drop(&mut self) {
         // 断开并销毁所有 agent
-        for client in &self.agent_clients {
-            let _ = client.disconnect();
+        for client in &mut self.agent_clients {
+            if client.set_timeout(AGENT_DISCONNECT_TIMEOUT_MS).is_ok() {
+                let _ = client.disconnect();
+            }
         }
         self.agent_clients.clear();
 
         // 终止并回收所有 agent 子进程
-        for mut child in self.agent_children.drain(..) {
-            let _ = child.kill();
-            let _ = child.wait();
+        for child in self.agent_children.drain(..) {
+            terminate_agent_child(child);
         }
 
         if let Some(tasker) = self.tasker.take() {
@@ -282,6 +311,12 @@ pub struct MaaState {
     pub lib_dir: Mutex<Option<PathBuf>>,
     pub resource_dir: Mutex<Option<PathBuf>>,
     pub instances: Mutex<HashMap<String, InstanceRuntime>>,
+    /// 串行化 Agent 句柄的转移与清理，确保退出流程能等待正在进行的 stop。
+    pub agent_lifecycle_lock: Mutex<()>,
+    /// 应用已进入退出清理阶段，不再接受新的 Agent 句柄写回。
+    pub agent_shutdown_requested: AtomicBool,
+    /// 已生成子进程、但尚未完成连接并写回 InstanceRuntime 的 Agent。
+    pub(crate) pending_agent_children: Mutex<HashMap<String, Arc<PendingAgentState>>>,
     /// 前置程序停止请求（用于中断等待退出）
     pub pre_action_stop_requests: Mutex<HashSet<String>>,
     /// Controller 连接池：相同配置的 Controller 复用同一个 MaaControllerHandle
@@ -299,24 +334,176 @@ pub struct MaaState {
 }
 
 impl MaaState {
-    /// 清理所有实例的 agent 子进程
-    pub fn cleanup_all_agent_children(&self) {
-        if let Ok(mut instances) = self.instances.lock() {
-            for (id, instance) in instances.iter_mut() {
-                for mut child in instance.agent_children.drain(..) {
-                    log::info!("Killing agent child process for instance: {}", id);
-                    if let Err(e) = child.kill() {
+    /// 销毁所有 AgentClient，然后终止对应的子进程。
+    ///
+    /// 句柄先从共享状态中取出，避免在可能阻塞的原生调用期间持有 instances 锁。
+    /// 该操作可重复调用；首轮清理后，后续调用不会再取得任何句柄。
+    pub fn cleanup_all_agents(&self) {
+        self.agent_shutdown_requested.store(true, Ordering::SeqCst);
+
+        let _lifecycle_guard = match self.agent_lifecycle_lock.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                log::warn!("Agent lifecycle lock was poisoned; continuing agent cleanup");
+                poisoned.into_inner()
+            }
+        };
+
+        let agents = {
+            let mut instances = match self.instances.lock() {
+                Ok(instances) => instances,
+                Err(poisoned) => {
+                    log::warn!("MaaState instances lock was poisoned; continuing agent cleanup");
+                    poisoned.into_inner()
+                }
+            };
+
+            instances
+                .iter_mut()
+                .filter_map(|(id, instance)| {
+                    let clients = std::mem::take(&mut instance.agent_clients);
+                    let children = std::mem::take(&mut instance.agent_children);
+
+                    if clients.is_empty() && children.is_empty() {
+                        None
+                    } else {
+                        Some((id.clone(), clients, children))
+                    }
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for (id, clients, children) in agents {
+            log::info!(
+                "Cleaning up {} agent client(s) and {} child process(es) for instance: {}",
+                clients.len(),
+                children.len(),
+                id
+            );
+
+            // 退出流程不能受 Agent 配置中的无限 RPC timeout 阻塞。直接 Drop 会销毁
+            // MaaFramework Transceiver 并删除 IPC socket，随后再强制终止服务端进程。
+            drop(clients);
+
+            for mut child in children {
+                match child.try_wait() {
+                    Ok(Some(_)) => continue,
+                    Ok(None) => {}
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to query agent child process for instance {}: {:?}",
+                            id,
+                            e
+                        );
+                    }
+                }
+
+                match child.kill() {
+                    Ok(()) => {
+                        // kill 成功后回收子进程，避免 *nix 上产生僵尸进程。
+                        let _ = child.wait();
+                    }
+                    Err(e) => {
+                        // kill 失败时不再无界 wait，避免把应用退出永久卡住。
                         log::warn!(
                             "Failed to kill agent child process for instance {}: {:?}",
                             id,
                             e
                         );
                     }
-                    // 回收子进程，避免 *nix 上产生僵尸进程
-                    let _ = child.wait();
                 }
             }
         }
+
+        self.cleanup_pending_agents(None);
+    }
+
+    /// 清理全部 pending Agent，或仅清理指定实例的 pending Agent。
+    /// 调用方必须持有 agent_lifecycle_lock，防止端点创建与筛选交错。
+    pub(crate) fn cleanup_pending_agents(&self, instance_id: Option<&str>) {
+        let pending_agents = {
+            let mut pending = match self.pending_agent_children.lock() {
+                Ok(pending) => pending,
+                Err(poisoned) => {
+                    log::warn!(
+                        "Pending agent children lock was poisoned; continuing agent cleanup"
+                    );
+                    poisoned.into_inner()
+                }
+            };
+
+            if let Some(instance_id) = instance_id {
+                let identifiers = pending
+                    .iter()
+                    .filter(|(_, state)| state.instance_id == instance_id)
+                    .map(|(identifier, _)| identifier.clone())
+                    .collect::<Vec<_>>();
+                identifiers
+                    .into_iter()
+                    .filter_map(|identifier| {
+                        pending
+                            .remove(&identifier)
+                            .map(|state| (identifier, state))
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                pending.drain().collect::<Vec<_>>()
+            }
+        };
+
+        for (identifier, pending_agent) in pending_agents {
+            pending_agent.cancelled.store(true, Ordering::SeqCst);
+            let child = match pending_agent.child.lock() {
+                Ok(mut slot) => slot.take(),
+                Err(poisoned) => {
+                    log::warn!(
+                        "Pending agent child lock was poisoned for identifier: {}",
+                        identifier
+                    );
+                    poisoned.into_inner().take()
+                }
+            };
+
+            if let Some(child) = child {
+                log::info!(
+                    "Terminating pending agent child process for identifier: {}",
+                    identifier
+                );
+                terminate_agent_child(child);
+            }
+
+            remove_pending_agent_socket(&identifier);
+        }
+    }
+}
+
+fn remove_pending_agent_socket(identifier: &str) {
+    // TCP identifier 是纯数字端口，不存在 socket 文件。
+    if identifier.parse::<u16>().is_ok() {
+        return;
+    }
+    if !identifier
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+    {
+        log::warn!("Skipping invalid pending agent identifier: {}", identifier);
+        return;
+    }
+
+    #[cfg(windows)]
+    let socket_dir = PathBuf::from("C:/Temp");
+    #[cfg(not(windows))]
+    let socket_dir = std::env::temp_dir();
+
+    let socket_path = socket_dir.join(format!("maafw-agent-{}.sock", identifier));
+    match std::fs::remove_file(&socket_path) {
+        Ok(()) => log::info!("Removed pending agent socket: {:?}", socket_path),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => log::warn!(
+            "Failed to remove pending agent socket {:?}: {}",
+            socket_path,
+            e
+        ),
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -318,15 +318,25 @@ pub fn run() {
                         api.prevent_close();
                     }
                 }
-                // 窗口销毁时清理所有 agent 子进程
+                // 窗口销毁时提前清理所有 Agent；全局 Exit 事件会再次幂等兜底。
                 tauri::WindowEvent::Destroyed => {
-                    if let Some(state) = window.try_state::<Arc<MaaState>>() {
-                        state.cleanup_all_agent_children();
+                    if window.label() == "main" {
+                        if let Some(state) = window.try_state::<Arc<MaaState>>() {
+                            state.cleanup_all_agents();
+                        }
                     }
                 }
                 _ => {}
             }
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            // 覆盖托盘退出、process 插件退出、管理员重启等不一定销毁窗口的路径。
+            if let tauri::RunEvent::Exit = event {
+                if let Some(state) = app.try_state::<Arc<MaaState>>() {
+                    state.cleanup_all_agents();
+                }
+            }
+        });
 }

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -1007,7 +1007,7 @@ async fn handle_stop_agent(
     State(state): State<WebState>,
     axum::extract::Path(instance_id): axum::extract::Path<String>,
 ) -> impl IntoResponse {
-    match stop_agent_impl(&state.maa_state, &instance_id) {
+    match stop_agent_impl(state.maa_state.clone(), instance_id).await {
         Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
在应用全局退出和主窗口销毁时统一清理 AgentClient 与子进程。

监督尚未写回实例的 Agent，避免连接、停止和退出并发时遗留套接字或孤儿进程。

## Summary by Sourcery

确保在应用程序关闭和主窗口销毁期间，一致地清理代理及其子进程，防止遗留套接字或孤立进程。

Bug Fixes（错误修复）:
- 通过跟踪待处理代理并在执行清理时取消它们，防止在关闭过程中启动的代理遗留 IPC 套接字或孤立进程。
- 通过强制更短的断开连接超时时间并强制终止无响应的子进程，避免因代理的长 RPC 超时时间而阻塞关闭流程。
- 使用生命周期锁和关闭标志来保护代理的启动、停止和清理过程，消除任务启动与全局退出之间的竞态条件，从而避免漏掉代理。

Enhancements（增强改进）:
- 引入统一的代理清理例程，在所有实例中断开客户端连接、终止子进程并移除待处理代理套接字。
- 优化代理停止处理逻辑，在具有有界等待时间的阻塞工作线程中执行子进程退出，并在多个进程之间共享一个全局超时。
- 扩展清理机制以处理非窗口退出路径（托盘菜单、进程插件退出、提权重启），确保在所有关闭场景中都能释放代理资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure agents and their child processes are consistently cleaned up during application shutdown and main window destruction to prevent leftover sockets or orphaned processes.

Bug Fixes:
- Prevent agents started during shutdown from leaving behind IPC sockets or orphan processes by tracking pending agents and cancelling them when cleanup runs.
- Avoid blocking shutdown on agents with long RPC timeouts by enforcing shorter disconnect timeouts and force-terminating unresponsive child processes.
- Guard agent start, stop, and cleanup with a lifecycle lock and shutdown flag to eliminate races between task startup and global exit that could miss agents.

Enhancements:
- Introduce a unified agent cleanup routine that disconnects clients, terminates child processes, and removes pending agent sockets across all instances.
- Refine agent stop handling to run in a blocking worker with bounded wait times for child exit, sharing a global timeout across processes.
- Extend cleanup to handle non-window exit paths (tray menu, process plugin exit, elevated restart) so agent resources are freed in all shutdown scenarios.

</details>