### PR TITLE
feat: Webhook 支持 POST 请求与自定义请求内容

### DIFF
--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -315,7 +315,7 @@ fn mxu_launch_action_fn(
 const MXU_WEBHOOK_ACTION: &str = "MXU_WEBHOOK_ACTION";
 
 /// MXU_WEBHOOK custom action 回调函数
-/// 从 custom_action_param 中读取 url，执行 HTTP GET 请求
+/// 从 custom_action_param 中读取 url、method、headers 和 body，执行 HTTP 请求
 fn mxu_webhook_action_fn(
     _ctx: &maa_framework::context::Context,
     args: &maa_framework::custom::ActionArgs,
@@ -339,7 +339,34 @@ fn mxu_webhook_action_fn(
         }
     };
 
-    info!("[MXU_WEBHOOK] Sending GET request to: {}", url);
+    let method = json
+        .get("method")
+        .and_then(|v| v.as_str())
+        .unwrap_or("GET")
+        .to_uppercase();
+
+    let headers_str = json.get("headers").and_then(|v| v.as_str()).unwrap_or("");
+    let body = json.get("body").and_then(|v| v.as_str()).unwrap_or("");
+
+    // 解析 headers JSON
+    let headers_map: Option<serde_json::Map<String, serde_json::Value>> =
+        if !headers_str.trim().is_empty() {
+            match serde_json::from_str::<serde_json::Value>(headers_str) {
+                Ok(serde_json::Value::Object(m)) => Some(m),
+                Ok(_) => {
+                    warn!("[MXU_WEBHOOK] Headers is not a JSON object, ignoring");
+                    None
+                }
+                Err(e) => {
+                    warn!("[MXU_WEBHOOK] Failed to parse headers JSON: {}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+    info!("[MXU_WEBHOOK] Sending {} request to: {}", method, url);
 
     let client = match reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
@@ -352,7 +379,42 @@ fn mxu_webhook_action_fn(
         }
     };
 
-    match client.get(&url).send() {
+    let send_result = match method.as_str() {
+        "POST" => {
+            let mut req = client.post(&url);
+            let mut has_content_type = false;
+            if let Some(ref map) = headers_map {
+                for (k, v) in map {
+                    if let Some(val) = v.as_str() {
+                        if k.eq_ignore_ascii_case("content-type") {
+                            has_content_type = true;
+                        }
+                        req = req.header(k.as_str(), val);
+                    }
+                }
+            }
+            if !body.is_empty() {
+                if !has_content_type {
+                    req = req.header("Content-Type", "application/json");
+                }
+                req = req.body(body.to_string());
+            }
+            req.send()
+        }
+        _ => {
+            let mut req = client.get(&url);
+            if let Some(ref map) = headers_map {
+                for (k, v) in map {
+                    if let Some(val) = v.as_str() {
+                        req = req.header(k.as_str(), val);
+                    }
+                }
+            }
+            req.send()
+        }
+    };
+
+    match send_result {
         Ok(resp) => {
             let status = resp.status();
             info!("[MXU_WEBHOOK] Response status: {}", status);

--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -191,7 +191,20 @@ function OptionDescription({
   );
 }
 
-/** 输入字段组件，支持验证 */
+/** 解析 disabled_when 表达式（格式 "fieldName=value"），判断是否应禁用 */
+function isInputDisabledByCondition(
+  disabledWhen: string | undefined,
+  siblingValues: Record<string, string>,
+): boolean {
+  if (!disabledWhen) return false;
+  const eqIdx = disabledWhen.indexOf('=');
+  if (eqIdx < 0) return false;
+  const fieldName = disabledWhen.slice(0, eqIdx);
+  const expectedValue = disabledWhen.slice(eqIdx + 1);
+  return siblingValues[fieldName] === expectedValue;
+}
+
+/** 输入字段组件，支持验证、下拉选择和条件禁用 */
 function InputField({
   input,
   value,
@@ -200,6 +213,7 @@ function InputField({
   resolveI18nText,
   basePath,
   disabled,
+  siblingValues,
   isMxuOption = false,
   isHotkey = false,
   t,
@@ -211,6 +225,7 @@ function InputField({
   resolveI18nText: (text: string | undefined, lang: string) => string;
   basePath: string;
   disabled?: boolean;
+  siblingValues?: Record<string, string>;
   isMxuOption?: boolean;
   isHotkey?: boolean;
   t?: (key: string) => string;
@@ -239,19 +254,39 @@ function InputField({
         : input.default || undefined
       : resolveI18nText(input.placeholder, langKey) || input.default || undefined;
 
+  // 条件禁用
+  const conditionallyDisabled = isInputDisabledByCondition(
+    input.disabled_when,
+    siblingValues || {},
+  );
+  const effectiveDisabled = disabled || conditionallyDisabled;
+
   // 验证输入
   const validationError = useMemo(() => {
-    if (!input.verify || !value) return null;
-    try {
-      const regex = new RegExp(input.verify);
-      if (!regex.test(value)) {
-        return patternMsg || `输入不符合格式要求`;
+    if (!value) return null;
+
+    // JSON 格式校验
+    if (input.validate_json) {
+      try {
+        JSON.parse(value);
+      } catch {
+        return t?.('optionEditor.invalidJson') || 'Invalid JSON format';
       }
-    } catch {
-      // 正则无效，跳过验证
+    }
+
+    // 正则校验
+    if (input.verify) {
+      try {
+        const regex = new RegExp(input.verify);
+        if (!regex.test(value)) {
+          return patternMsg || `输入不符合格式要求`;
+        }
+      } catch {
+        // 正则无效，跳过验证
+      }
     }
     return null;
-  }, [input.verify, value, patternMsg]);
+  }, [input.verify, input.validate_json, value, patternMsg, t]);
 
   return (
     <div className="space-y-1">
@@ -276,22 +311,46 @@ function InputField({
             value={value}
             onChange={onChange}
             placeholder={inputPlaceholder}
-            disabled={disabled}
+            disabled={effectiveDisabled}
             className="min-w-[min(12rem,100%)] flex-1 basis-[30%]"
           />
+        ) : input.options ? (
+          <select
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={effectiveDisabled}
+            className={clsx(
+              'px-3 py-1.5 text-sm rounded-md border appearance-none',
+              'bg-bg-secondary text-text-primary',
+              'focus:outline-none focus:ring-1',
+              effectiveDisabled && 'opacity-60 cursor-not-allowed',
+              'border-border focus:border-accent focus:ring-accent/20',
+              'min-w-[min(12rem,100%)] flex-1 basis-[30%]',
+            )}
+          >
+            {input.options.map((opt) => {
+              const optLabel =
+                isMxuOption && t ? t(opt.label) : resolveI18nText(opt.label, langKey) || opt.label;
+              return (
+                <option key={opt.value} value={opt.value}>
+                  {optLabel}
+                </option>
+              );
+            })}
+          </select>
         ) : input.input_type === 'file' ? (
           <FileInput
             value={value}
             onChange={onChange}
             placeholder={inputPlaceholder}
-            disabled={disabled}
+            disabled={effectiveDisabled}
             className="min-w-[min(12rem,100%)] flex-1 basis-[30%]"
           />
         ) : input.input_type === 'time' ? (
           <TimeInput
             value={value}
             onChange={onChange}
-            disabled={disabled}
+            disabled={effectiveDisabled}
             className="min-w-[min(12rem,100%)] flex-1 basis-[30%]"
           />
         ) : (
@@ -299,7 +358,7 @@ function InputField({
             value={value}
             onChange={onChange}
             placeholder={inputPlaceholder}
-            disabled={disabled}
+            disabled={effectiveDisabled}
             hasError={!!validationError}
             className="min-w-[min(12rem,100%)] flex-1 basis-[30%]"
             type={input.pipeline_type === 'int' ? 'number' : 'text'}
@@ -611,32 +670,40 @@ export function OptionEditor({
             translations={translations}
           />
         </div>
-        {fields.map((input) => {
-          const inputValue = inputValues[input.name] ?? input.default ?? '';
-          const isHotkey = optionDef.type === 'hotkey';
+        {(() => {
+          // 构建包含默认值的完整兄弟字段值映射，用于 disabled_when 条件判断
+          const fullValues: Record<string, string> = {};
+          for (const f of fields) {
+            fullValues[f.name] = inputValues[f.name] ?? f.default ?? '';
+          }
+          return fields.map((input) => {
+            const inputValue = fullValues[input.name] ?? '';
+            const isHotkey = optionDef.type === 'hotkey';
 
-          return (
-            <InputField
-              key={input.name}
-              input={input}
-              value={inputValue}
-              isHotkey={isHotkey}
-              onChange={(newVal) => {
-                if (effectiveDisabled) return;
-                commitOptionValue({
-                  type: isHotkey ? 'hotkey' : 'input',
-                  values: { ...inputValues, [input.name]: newVal },
-                });
-              }}
-              langKey={langKey}
-              resolveI18nText={resolveI18nText}
-              basePath={basePath}
-              disabled={effectiveDisabled}
-              isMxuOption={isMxuOption}
-              t={t}
-            />
-          );
-        })}
+            return (
+              <InputField
+                key={input.name}
+                input={input}
+                value={inputValue}
+                isHotkey={isHotkey}
+                onChange={(newVal) => {
+                  if (effectiveDisabled) return;
+                  commitOptionValue({
+                    type: isHotkey ? 'hotkey' : 'input',
+                    values: { ...inputValues, [input.name]: newVal },
+                  });
+                }}
+                langKey={langKey}
+                resolveI18nText={resolveI18nText}
+                basePath={basePath}
+                disabled={effectiveDisabled}
+                siblingValues={fullValues}
+                isMxuOption={isMxuOption}
+                t={t}
+              />
+            );
+          });
+        })()}
       </div>
     );
   }

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -174,6 +174,13 @@ export default {
       optionLabel: 'Request Settings',
       urlLabel: 'Request URL',
       urlPlaceholder: 'Enter full URL (e.g. https://example.com/webhook?key=xxx)',
+      methodLabel: 'Request Method',
+      methodGet: 'GET',
+      methodPost: 'POST',
+      headersLabel: 'Request Headers',
+      headersPlaceholder: 'Enter JSON request headers (e.g. {"Authorization":"Bearer xxx"})',
+      bodyLabel: 'Request Body (POST available)',
+      bodyPlaceholder: 'Enter JSON request body (e.g. {"key":"value"})',
     },
     killProc: {
       label: '⛔ Kill Process',
@@ -347,6 +354,7 @@ export default {
     incompatibleResource: 'Not supported by current resource',
     hotkeyPlaceholder: 'Click to record shortcut',
     hotkeyCapturing: 'Press keys...',
+    invalidJson: 'Invalid JSON format',
   },
 
   // Preset

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -172,6 +172,13 @@ export default {
       optionLabel: 'リクエスト設定',
       urlLabel: 'リクエストURL',
       urlPlaceholder: '完全なURLを入力（例：https://example.com/webhook?key=xxx）',
+      methodLabel: 'リクエストメソッド',
+      methodGet: 'GET',
+      methodPost: 'POST',
+      headersLabel: 'リクエストヘッダー',
+      headersPlaceholder: 'JSON を入力（例：{"Authorization":"Bearer xxx"}）',
+      bodyLabel: 'リクエストボディ（POST 使用時）',
+      bodyPlaceholder: 'JSON ボディを入力（例：{"key":"value"}）',
     },
     killProc: {
       label: '⛔ プロセス終了',
@@ -341,6 +348,7 @@ export default {
     incompatibleResource: '現在のリソースパックに対応していません',
     hotkeyPlaceholder: 'クリックしてショートカットを記録',
     hotkeyCapturing: 'キーを押してください...',
+    invalidJson: 'JSON 形式が無効です',
   },
 
   // プリセット

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -171,6 +171,13 @@ export default {
       optionLabel: '요청 설정',
       urlLabel: '요청 URL',
       urlPlaceholder: '전체 URL을 입력하세요 (예: https://example.com/webhook?key=xxx)',
+      methodLabel: '요청 방식',
+      methodGet: 'GET',
+      methodPost: 'POST',
+      headersLabel: '요청 헤더',
+      headersPlaceholder: 'JSON 입력 (예: {"Authorization":"Bearer xxx"})',
+      bodyLabel: '요청 본문 (POST 사용 시)',
+      bodyPlaceholder: 'JSON 요청 본문을 입력하세요 (예: {"key":"value"})',
     },
     killProc: {
       label: '⛔ 프로세스 종료',
@@ -339,6 +346,7 @@ export default {
     incompatibleResource: '현재 리소스 팩에서 지원되지 않음',
     hotkeyPlaceholder: '클릭하여 단축키 입력',
     hotkeyCapturing: '키를 누르세요...',
+    invalidJson: 'JSON 형식이 올바르지 않습니다',
   },
 
   // 프리셋

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -168,6 +168,13 @@ export default {
       optionLabel: '请求设置',
       urlLabel: '请求地址',
       urlPlaceholder: '输入完整的 URL（如 https://example.com/webhook?key=xxx）',
+      methodLabel: '请求方式',
+      methodGet: 'GET',
+      methodPost: 'POST',
+      headersLabel: '请求头',
+      headersPlaceholder: '输入 JSON 格式的请求头（如 {"Authorization":"Bearer xxx"}）',
+      bodyLabel: '请求体（POST 可用）',
+      bodyPlaceholder: '输入 JSON 格式的请求体（如 {"key":"value"}）',
     },
     killProc: {
       label: '⛔ 结束进程',
@@ -337,6 +344,7 @@ export default {
     incompatibleResource: '不支持当前资源包',
     hotkeyPlaceholder: '点击录入快捷键',
     hotkeyCapturing: '按下快捷键...',
+    invalidJson: 'JSON 格式无效',
   },
 
   // 预设配置

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -168,6 +168,13 @@ export default {
       optionLabel: '請求設定',
       urlLabel: '請求地址',
       urlPlaceholder: '輸入完整的 URL（如 https://example.com/webhook?key=xxx）',
+      methodLabel: '請求方式',
+      methodGet: 'GET',
+      methodPost: 'POST',
+      headersLabel: '請求標頭',
+      headersPlaceholder: '輸入 JSON 格式的請求標頭（如 {"Authorization":"Bearer xxx"}）',
+      bodyLabel: '請求體（POST 可用）',
+      bodyPlaceholder: '輸入 JSON 格式的請求體（如 {"key":"value"}）',
     },
     killProc: {
       label: '⛔ 結束程序',
@@ -333,6 +340,7 @@ export default {
     incompatibleResource: '不支援目前資源包',
     hotkeyPlaceholder: '點擊錄入快捷鍵',
     hotkeyCapturing: '按下快捷鍵...',
+    invalidJson: 'JSON 格式無效',
   },
 
   // 預設設定

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -211,6 +211,12 @@ export interface InputItem {
   input_type?: 'text' | 'file' | 'time';
   /** MXU 扩展：输入框占位提示文本（i18n key） */
   placeholder?: string;
+  /** MXU 扩展：下拉选择项（渲染为 select 而非 input），label 支持 i18n key */
+  options?: { value: string; label: string }[];
+  /** MXU 扩展：条件禁用，格式 "fieldName=value"，同组字段值匹配时该输入被禁用 */
+  disabled_when?: string;
+  /** MXU 扩展：启用 JSON 格式校验，输入内容必须是合法 JSON */
+  validate_json?: boolean;
 }
 
 export interface SelectOption {

--- a/src/types/specialTasks.ts
+++ b/src/types/specialTasks.ts
@@ -316,7 +316,7 @@ const MXU_WEBHOOK_TASK_DEF_INTERNAL: TaskItem = {
   },
 };
 
-// MXU_WEBHOOK 输入选项定义（URL）
+// MXU_WEBHOOK 输入选项定义（URL、Method、Headers、Body）
 const MXU_WEBHOOK_OPTION_DEF_INTERNAL: InputOption = {
   type: 'input',
   label: 'specialTask.webhook.optionLabel',
@@ -328,11 +328,41 @@ const MXU_WEBHOOK_OPTION_DEF_INTERNAL: InputOption = {
       pipeline_type: 'string',
       placeholder: 'specialTask.webhook.urlPlaceholder',
     },
+    {
+      name: 'method',
+      label: 'specialTask.webhook.methodLabel',
+      default: 'GET',
+      pipeline_type: 'string',
+      options: [
+        { value: 'GET', label: 'specialTask.webhook.methodGet' },
+        { value: 'POST', label: 'specialTask.webhook.methodPost' },
+      ],
+    },
+    {
+      name: 'headers',
+      label: 'specialTask.webhook.headersLabel',
+      default: '',
+      pipeline_type: 'string',
+      placeholder: 'specialTask.webhook.headersPlaceholder',
+      validate_json: true,
+    },
+    {
+      name: 'body',
+      label: 'specialTask.webhook.bodyLabel',
+      default: '',
+      pipeline_type: 'string',
+      placeholder: 'specialTask.webhook.bodyPlaceholder',
+      disabled_when: 'method=GET',
+      validate_json: true,
+    },
   ],
   pipeline_override: {
     [MXU_WEBHOOK_ENTRY]: {
       custom_action_param: {
         url: '{url}',
+        method: '{method}',
+        headers: '{headers}',
+        body: '{body}',
       },
     },
   },


### PR DESCRIPTION
## Webhook 支持 POST 请求、自定义请求头和请求体
### What
扩展 MXU_WEBHOOK 特殊任务，从仅支持 GET 请求升级为支持 GET/POST 请求方式，并新增自定义请求头和请求体功能。

### Why
原有 Webhook 仅支持 HTTP GET，无法满足需要 POST 请求体或自定义认证头的 API 调用场景（如钉钉机器人、企业微信等）。

### Changes
后端

- mxu_webhook_action_fn 支持解析 method 、 headers 、 body 参数
- POST 时自动设置 Content-Type: application/json （用户已自定义时不覆盖）
前端

- InputItem 类型新增 options （下拉选择）、 disabled_when （条件禁用）、 validate_json （JSON 校验）
- InputField 组件支持上述三种新能力
- Webhook 任务：method 改为 GET/POST 下拉选择，headers/body 启用 JSON 校验，method=GET 时 body 自动禁用
i18n

- 5 个语言包同步新增 webhook 相关文本及 invalidJson 校验提示
### Files Changed
- src-tauri/src/mxu_actions.rs
- src/types/interface.ts
- src/types/specialTasks.ts
- src/components/OptionEditor.tsx
- src/i18n/locales/en-US.ts
- src/i18n/locales/zh-CN.ts
- src/i18n/locales/zh-TW.ts
- src/i18n/locales/ja-JP.ts
- src/i18n/locales/ko-KR.ts

## Summary by Sourcery

扩展 MXU webhook 任务，以支持可配置的 HTTP 方法、请求头和请求体，并提供 JSON 校验以及条件禁用功能。

新特性：
- 在后端为 `MXU_WEBHOOK` 操作添加 `POST` 支持以及可配置的请求头/请求体。
- 在 UI 中用于通用输入字段的组件中，引入下拉选项、条件禁用以及 JSON 校验能力。
- 将 webhook 请求的 URL、方法、请求头和请求体暴露为可配置的任务选项。

改进：
- 改进 webhook 日志记录和请求头解析，包括对无效 header JSON 对象的优雅处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend MXU webhook tasks to support configurable HTTP method, headers, and body with JSON validation and conditional disabling.

New Features:
- Add POST support and configurable headers/body to MXU_WEBHOOK actions in the backend.
- Introduce dropdown options, conditional disabling, and JSON validation capabilities to generic input fields used in the UI.
- Expose webhook request URL, method, headers, and body as configurable task options.

Enhancements:
- Improve webhook logging and header parsing, including graceful handling of invalid header JSON objects.

</details>