### PR TITLE
fix: 通过快捷方式打开mxu无法启动pretask进程

### DIFF
--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -247,7 +247,11 @@ fn classify_child_exec(child_exec: &str) -> ChildExecKind {
 /// - 裸命令名（如 `python` / `node`）-> 原样返回，由系统 PATH 解析
 /// - 相对路径型 child_exec -> 先基于 cwd 拼接，再通过 `normalize_path` 规范化
 /// - 绝对路径 / 带盘符前缀路径 -> 不拼接 cwd，但会通过 `normalize_path` 规范化
-fn resolve_child_exec_path(child_exec: &str, cwd: &str) -> PathBuf {
+///
+/// 供 Agent 启动与 pretask 执行共用，确保相对入口的解析行为一致：Windows 下相对
+/// 可执行路径会相对“父进程当前目录”而非子进程 `current_dir` 解析，因此必须在拼好
+/// 绝对路径后再交给 `Command`，否则会出现“系统找不到指定的路径 (os error 3)”。
+pub(crate) fn resolve_child_exec_path(child_exec: &str, cwd: &str) -> PathBuf {
     match classify_child_exec(child_exec) {
         // 空字符串由上层提前校验；这里保守返回原值，避免误拼 cwd。
         ChildExecKind::Empty => PathBuf::from(child_exec),

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -627,7 +627,17 @@ pub async fn run_pretask(
         instance_id, program, args, cwd
     );
 
-    let mut cmd = super::utils::build_launch_command(&program, &args, false);
+    // Windows 下相对可执行路径会相对“父进程当前目录”解析，而非下方设置的 `current_dir`，
+    // 因此必须先基于 cwd 把相对 exec（如 `agent/go-service`）拼成绝对路径，复用 Agent
+    // 启动时相同的解析逻辑，避免出现“系统找不到指定的路径 (os error 3)”。
+    let resolved_program = match cwd {
+        Some(ref dir) => super::maa_agent::resolve_child_exec_path(&program, dir)
+            .to_string_lossy()
+            .into_owned(),
+        None => program.clone(),
+    };
+
+    let mut cmd = super::utils::build_launch_command(&resolved_program, &args, false);
 
     // 设置工作目录
     if let Some(ref dir) = cwd {


### PR DESCRIPTION
opus4.8
<img width="1666" height="1046" alt="image" src="https://github.com/user-attachments/assets/4565d479-965f-4873-8414-f84e039018d6" />

## Summary by Sourcery

通过将可执行文件路径解析方式与代理启动逻辑对齐，确保在通过快捷方式启动 MXU 时前置任务进程能够正确启动。

Bug Fixes:
- 修复在 Windows 上由于相对可执行文件路径相对于父进程目录而非预期工作目录进行解析，从而导致前置任务启动失败的问题。

Enhancements:
- 在代理启动和前置任务执行之间共享子进程可执行文件路径解析辅助函数，以在这两种流程中保持相对路径处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure pretask processes start correctly when MXU is launched via shortcuts by aligning executable path resolution with the agent startup logic.

Bug Fixes:
- Fix pretask startup failures on Windows caused by relative executable paths being resolved against the parent process directory instead of the intended working directory.

Enhancements:
- Share the child executable path resolution helper between agent startup and pretask execution to keep relative path handling consistent across both flows.

</details>