### PR TITLE
fix: respect wlroots hotkey keycode mode

### DIFF
--- a/src/utils/pipelineOverride.ts
+++ b/src/utils/pipelineOverride.ts
@@ -531,10 +531,15 @@ export const generateTaskPipelineOverride = (
 
   if (!projectInterface) return '[]';
 
-  // 热键键码按控制器 **类型**（Win32 / MacOS / Adb / WlRoots）查表，这里先由 name 解析出 type
-  const controllerType = controllerName
-    ? projectInterface.controller.find((c) => c.name === controllerName)?.type
+  // 热键键码按控制器 **类型**（Win32 / MacOS / Adb / WlRoots）查表，这里先由 name 解析出 type。
+  // WlRoots 可配置接受 Win32 VK 或原始 evdev 键码，热键 override 必须与控制器配置一致。
+  const controllerDef = controllerName
+    ? projectInterface.controller.find((c) => c.name === controllerName)
     : undefined;
+  const controllerType =
+    controllerDef?.type === 'WlRoots' && controllerDef.wlroots?.use_win32_vk_code
+      ? 'Win32'
+      : controllerDef?.type;
 
   const overrides: Record<string, unknown>[] = [];
   const taskDef = projectInterface.task.find((t) => t.name === selectedTask.taskName);


### PR DESCRIPTION
修复在 wlroots 已经启用 use_win32_vk_code 的情况下，仍然为 hotkey 生成 evdev 键码的问题

close MaaEnd/MaaEnd#4869

## Summary by Sourcery

Bug Fixes:
- 修复在 wlroots 控制器配置为使用 Win32 VK 代码时，使用 evdev 键码生成快捷键的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix hotkey generation using evdev keycodes when the wlroots controller is configured to use Win32 VK codes.

</details>

## Summary by Sourcery

错误修复：
- 修复在 wlroots 控制器配置为使用 Win32 VK 代码时，使用 evdev 键码生成热键的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix hotkey generation using evdev keycodes when the wlroots controller is configured to use Win32 VK codes.

</details>