### PR TITLE
feat: windows启动任务前检测是否锁屏

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -170,6 +170,29 @@ pub fn is_elevated() -> bool {
     }
 }
 
+/// 检查当前 Windows 工作站是否处于锁屏状态（仅 Windows 生效，其他平台恒为 false）
+///
+/// 原理：锁屏时输入桌面会切换到 Winlogon 安全桌面，普通用户进程无法打开该桌面，
+/// `OpenInputDesktop` 返回 Err；未锁屏时可正常打开 "Default" 输入桌面。
+#[tauri::command]
+pub fn is_workstation_locked() -> bool {
+    #[cfg(windows)]
+    {
+        use winsafe::co::DESKTOP_RIGHTS;
+        use winsafe::HDESK;
+
+        match HDESK::OpenInputDesktop(None, false, DESKTOP_RIGHTS::READOBJECTS) {
+            Ok(_) => false,
+            Err(_) => true,
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 /// 以管理员权限重启应用
 #[tauri::command]
 pub fn restart_as_admin(app_handle: tauri::AppHandle) -> Result<(), String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -279,6 +279,7 @@ pub fn run() {
             commands::download::cancel_download,
             // 系统相关命令
             commands::system::is_elevated,
+            commands::system::is_workstation_locked,
             commands::system::is_autostart,
             commands::system::get_start_instance,
             commands::system::has_quit_after_run_flag,

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -312,6 +312,16 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
         });
         return false;
       }
+
+      // 连接 Controller 前检测锁屏状态：若电脑处于锁屏，快速失败并提示用户
+      if (await maaService.isWorkstationLocked()) {
+        log.warn(`实例 ${targetInstance.name}: 检测到电脑处于锁屏状态，取消启动`);
+        addLog(targetId, {
+          type: 'error',
+          message: t('taskList.autoConnect.workstationLocked'),
+        });
+        return false;
+      }
       const controller = projectInterface?.controller.find((c) => c.name === controllerName);
       const resource = projectInterface?.resource.find((r) => r.name === resourceName);
       const savedDevice = targetInstance.savedDevice;

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -234,6 +234,7 @@ export default {
         'No window was previously selected. Automatically matched "{{name}}". To change, select manually in Connection Settings — your choice will be remembered next time.',
       resourceFailed: 'Resource loading failed',
       startFailed: 'Failed to start tasks',
+      workstationLocked: 'The computer is locked. Please unlock it before running tasks.',
       agentStartParams: 'Agent #{{index}} start params: {{cmd}}  (cwd: {{cwd}})',
       agentSpawnHintFileNotFound:
         'Check whether antivirus blocked the Agent, then reinstall by overwriting the installation.',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -228,6 +228,7 @@ export default {
         'ウィンドウが未設定のため、「{{name}}」を自動的に選択しました。変更する場合は接続設定で手動選択してください。次回以降は選択内容が保存されます。',
       resourceFailed: 'リソースの読み込みに失敗しました',
       startFailed: 'タスクの開始に失敗しました',
+      workstationLocked: 'パソコンがロック画面の状態です。ロックを解除してからタスクを実行してください',
       agentStartParams: 'Agent #{{index}} 起動パラメータ: {{cmd}}  (作業ディレクトリ: {{cwd}})',
       agentSpawnHintFileNotFound:
         'Agent がセキュリティソフトにブロックされていないか確認し、問題なければ上書き再インストールしてください。',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -227,6 +227,7 @@ export default {
         '창이 설정되지 않아 「{{name}}」을(를) 자동으로 선택했습니다. 변경하려면 연결 설정에서 수동으로 선택하세요. 다음 번에는 선택 내용이 저장됩니다.',
       resourceFailed: '리소스 로딩에 실패했습니다',
       startFailed: '작업 시작에 실패했습니다',
+      workstationLocked: '컴퓨터가 잠금 화면 상태입니다. 잠금을 해제한 후 작업을 실행하세요',
       agentStartParams: 'Agent #{{index}} 시작 파라미터: {{cmd}}  (작업 디렉토리: {{cwd}})',
       agentSpawnHintFileNotFound:
         'Agent가 백신에 의해 차단되지 않았는지 확인한 뒤, 문제가 없으면 덮어쓰기 재설치를 진행하세요.',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -227,6 +227,7 @@ export default {
         '尚未手动选择过窗口，已自动匹配到「{{name}}」。如需更换，请在连接设置中手动选择，下次将记住您的选择。',
       resourceFailed: '资源加载失败',
       startFailed: '任务启动失败',
+      workstationLocked: '检测到电脑处于锁屏状态，请先解锁后再运行任务',
       agentStartParams: 'Agent #{{index}} 启动参数: {{cmd}}  (工作目录: {{cwd}})',
       agentSpawnHintFileNotFound: '请先检查 Agent 是否被杀软拦截，确认无误后重新覆盖安装。',
       agentSpawnHintAppControl:

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -223,6 +223,7 @@ export default {
         '尚未手動選擇過視窗，已自動匹配到「{{name}}」。如需更換，請在連接設定中手動選擇，下次將記住您的選擇。',
       resourceFailed: '資源載入失敗',
       startFailed: '任務啟動失敗',
+      workstationLocked: '偵測到電腦處於鎖定畫面狀態，請先解鎖後再執行任務',
       agentStartParams: 'Agent #{{index}} 啟動參數: {{cmd}}  (工作目錄: {{cwd}})',
       agentSpawnHintFileNotFound: '請先檢查 Agent 是否被防毒軟體攔截，確認無誤後重新覆蓋安裝。',
       agentSpawnHintAppControl:

--- a/src/services/maaService.ts
+++ b/src/services/maaService.ts
@@ -1047,6 +1047,22 @@ export const maaService = {
   },
 
   /**
+   * 检查当前电脑是否处于锁屏状态（仅 Tauri + Windows 生效）
+   * 检测异常或非 Tauri 环境按未锁屏处理，避免误拦截任务启动
+   */
+  async isWorkstationLocked(): Promise<boolean> {
+    try {
+      if (isTauri()) {
+        return await invoke<boolean>('is_workstation_locked');
+      }
+      return false;
+    } catch (err) {
+      log.warn('检测锁屏状态失败，按未锁屏处理:', err);
+      return false;
+    }
+  },
+
+  /**
    * 以管理员权限重启应用
    * @returns 如果成功启动新进程会退出当前进程，否则返回错误信息
    */


### PR DESCRIPTION
opus4.8

close https://github.com/MaaEnd/MaaEnd/issues/4283

## Summary by Sourcery

添加 Windows 特定的锁屏检测功能，并将其集成到任务启动流程中，以防止在工作站被锁定时运行任务。

新功能：
- 暴露一个 Tauri 命令和前端服务方法，用于检测当前 Windows 工作站是否处于锁定状态。
- 当检测到工作站被锁定时，阻止控制器连接和任务启动，并向用户显示错误信息。
- 在所有支持的语言中新增本地化的用户可见文案，解释在电脑被锁定时无法运行任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Windows-specific lock-screen detection and integrate it into task startup to prevent running tasks while the workstation is locked.

New Features:
- Expose a Tauri command and frontend service method to detect whether the Windows workstation is currently locked.
- Block controller connection and task startup when the workstation is detected as locked, with user-facing error messages.
- Add localized user-facing strings in all supported languages to explain that tasks cannot run while the computer is locked.

</details>