### PR TITLE
fix: 锁屏时允许 ADB 控制器启动任务

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -15,7 +15,12 @@ import { isTaskCompatible } from '@/stores/helpers';
 import { maaService } from '@/services/maaService';
 import { buildTaskOptionSummary } from '@/services/telemetryService';
 import clsx from 'clsx';
-import { loggers, generateTaskPipelineOverride, computeResourcePaths } from '@/utils';
+import {
+  loggers,
+  generateTaskPipelineOverride,
+  computeResourcePaths,
+  requiresUnlockedWorkstation,
+} from '@/utils';
 import { getMxuSpecialTask } from '@/types/specialTasks';
 import {
   isPretaskName,
@@ -314,15 +319,6 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
         return false;
       }
 
-      // 连接 Controller 前检测锁屏状态：若电脑处于锁屏，快速失败并提示用户
-      if (await maaService.isWorkstationLocked()) {
-        log.warn(`实例 ${targetInstance.name}: 检测到电脑处于锁屏状态，取消启动`);
-        addLog(targetId, {
-          type: 'error',
-          message: t('taskList.autoConnect.workstationLocked'),
-        });
-        return false;
-      }
       const controller = projectInterface?.controller.find((c) => c.name === controllerName);
       const resource = projectInterface?.resource.find((r) => r.name === resourceName);
       const savedDevice = targetInstance.savedDevice;
@@ -337,6 +333,21 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
       );
       const hasVisualTasks = compatibleTasks.some((task) => !shouldSkipScreenshot(task.taskName));
       const shouldUseDummyController = !hasVisualTasks;
+
+      // 只有依赖 Windows 交互式桌面的实际控制器才受锁屏限制。
+      // ADB、WlRoots、PlayCover 以及非视觉任务使用的 Dummy Controller 均可在锁屏时运行。
+      if (
+        !shouldUseDummyController &&
+        requiresUnlockedWorkstation(controller?.type) &&
+        (await maaService.isWorkstationLocked())
+      ) {
+        log.warn(`实例 ${targetInstance.name}: 检测到电脑处于锁屏状态，取消启动`);
+        addLog(targetId, {
+          type: 'error',
+          message: t('taskList.autoConnect.workstationLocked'),
+        });
+        return false;
+      }
 
       if (shouldUseDummyController) {
         log.info(`实例 ${targetInstance.name}: 仅包含非视觉特殊任务，跳过截图/识别流程`);

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -334,19 +334,32 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
       const hasVisualTasks = compatibleTasks.some((task) => !shouldSkipScreenshot(task.taskName));
       const shouldUseDummyController = !hasVisualTasks;
 
-      // 只有依赖 Windows 交互式桌面的实际控制器才受锁屏限制。
-      // ADB、WlRoots、PlayCover 以及非视觉任务使用的 Dummy Controller 均可在锁屏时运行。
-      if (
-        !shouldUseDummyController &&
-        requiresUnlockedWorkstation(controller?.type) &&
-        (await maaService.isWorkstationLocked())
-      ) {
-        log.warn(`实例 ${targetInstance.name}: 检测到电脑处于锁屏状态，取消启动`);
-        addLog(targetId, {
-          type: 'error',
-          message: t('taskList.autoConnect.workstationLocked'),
-        });
-        return false;
+      if (!shouldUseDummyController) {
+        // 视觉任务必须有明确的控制器配置，避免状态异常时绕过按类型执行的安全检查。
+        if (!controller) {
+          log.warn(
+            `实例 ${targetInstance.name}: 找不到控制器配置${controllerName ? ` (${controllerName})` : ''}`,
+          );
+          addLog(targetId, {
+            type: 'error',
+            message: t('errors.controllerNotFound'),
+          });
+          return false;
+        }
+
+        // 只有依赖 Windows 交互式桌面的实际控制器才受锁屏限制。
+        // ADB、WlRoots 和 PlayCover 均可在锁屏时运行。
+        if (
+          requiresUnlockedWorkstation(controller.type) &&
+          (await maaService.isWorkstationLocked())
+        ) {
+          log.warn(`实例 ${targetInstance.name}: 检测到电脑处于锁屏状态，取消启动`);
+          addLog(targetId, {
+            type: 'error',
+            message: t('taskList.autoConnect.workstationLocked'),
+          });
+          return false;
+        }
       }
 
       if (shouldUseDummyController) {

--- a/src/utils/controller.ts
+++ b/src/utils/controller.ts
@@ -1,6 +1,15 @@
 import type { ControllerType } from '@/types/interface';
 
+const WORKSTATION_UNLOCK_REQUIREMENT: Record<ControllerType, boolean> = {
+  Adb: false,
+  Win32: true,
+  WlRoots: false,
+  PlayCover: false,
+  Gamepad: true,
+};
+
 /** Whether the controller depends on the interactive Windows desktop. */
-export function requiresUnlockedWorkstation(controllerType?: ControllerType): boolean {
-  return controllerType === 'Win32' || controllerType === 'Gamepad';
+export function requiresUnlockedWorkstation(controllerType: ControllerType): boolean {
+  // Fail closed for unexpected runtime values loaded from interface.json.
+  return WORKSTATION_UNLOCK_REQUIREMENT[controllerType] ?? true;
 }

--- a/src/utils/controller.ts
+++ b/src/utils/controller.ts
@@ -1,0 +1,6 @@
+import type { ControllerType } from '@/types/interface';
+
+/** Whether the controller depends on the interactive Windows desktop. */
+export function requiresUnlockedWorkstation(controllerType?: ControllerType): boolean {
+  return controllerType === 'Win32' || controllerType === 'Gamepad';
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './jsonc';
 export * from './optionHelpers';
 export * from './resourcePath';
 export * from './paths';
+export * from './controller';


### PR DESCRIPTION
## 修改内容

- 将 Windows 锁屏检查移动到控制器解析之后
- 仅对依赖交互式桌面的 Win32 / Gamepad 控制器执行锁屏拦截
- 允许 ADB、WlRoots、PlayCover 及非视觉任务使用的 Dummy Controller 在锁屏状态下启动
- 提取控制器锁屏策略函数，避免启动流程硬编码类型判断

## 验证

- `pnpm build`
- `pnpm exec prettier --check src/components/Toolbar.tsx src/utils/index.ts src/utils/controller.ts`
- 控制器锁屏策略断言（Win32、Gamepad、ADB、WlRoots、PlayCover、undefined）
- `git diff --check`

Closes #300

## Summary by Sourcery

仅对依赖交互式桌面的控制器类型，在 Windows 锁屏状态下拦截控制器启动，从而允许非可视化及远程控制器在锁屏时仍可启动。

Bug Fixes:
- 防止 Win32 和 Gamepad 控制器在工作站被锁定时启动，同时仍允许 ADB、WlRoots、PlayCover 和 dummy 控制器用于非可视化任务时继续运行。
- 通过将锁屏策略集中到共享的实用工具助手中，避免在工具栏中对控制器类型进行硬编码检查。

Enhancements:
- 引入可复用的控制器锁屏策略助手，并从 utilities 模块中重新导出，以便在整个代码库中一致使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate controller startup on Windows lock screen status only for controller types that rely on the interactive desktop, allowing non-visual and remote controllers to start while locked.

Bug Fixes:
- Prevent Win32 and Gamepad controllers from starting while the workstation is locked, while still allowing ADB, WlRoots, PlayCover, and dummy controllers for non-visual tasks to run.
- Avoid hardcoded controller type checks in the toolbar by centralizing lock-screen policy in a shared utility helper.

Enhancements:
- Introduce a reusable controller lock-screen policy helper and re-export it from the utilities module for consistent use across the codebase.

</details>