### PR TITLE
fix: use absolute backend URL in tauri production mode (welcome page stuck on 'Loading Failed')

### DIFF
--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -18,7 +18,6 @@ use axum::{
 };
 #[cfg(not(debug_assertions))]
 use rust_embed::RustEmbed;
-#[cfg(debug_assertions)]
 use tower_http::cors::Any;
 use tower_http::cors::CorsLayer;
 

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -337,9 +337,13 @@ pub async fn start_web_server(
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
         .allow_headers(Any);
 
+    // 生产模式：前端从 tauri://localhost 加载（嵌入资源），fetch http://127.0.0.1:12701/api/* 是跨域。
+    // 必须允许任意 Origin，否则浏览器拦截所有 API 调用（表现为 "Could not connect to localhost"）。
     #[cfg(not(debug_assertions))]
-    let cors =
-        CorsLayer::new().allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE]);
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
+        .allow_headers(Any);
 
     let app = app.layer(cors);
 

--- a/src/services/interfaceLoader.ts
+++ b/src/services/interfaceLoader.ts
@@ -456,6 +456,17 @@ export async function autoLoadInterface(): Promise<LoadResult> {
     filterControllersByPlatform(pi, backendOS);
 
     const translations = await loadTranslationsFromLocal(pi, relativeBasePath);
+
+    // tauri 环境下后端 HTTP API（/api/*）走内置 axum web server（默认 12701），
+    // 但 getApiBase() 依赖 backendPort 才能返回绝对 URL（tauri://localhost 下相对 /api 不可达）。
+    // 这里显式设置默认端口，确保后续 fetch(getApiBase()/...) 直连后端。
+    try {
+      const port = await invoke<number>('get_web_server_port');
+      if (port > 0) setBackendPort(port);
+    } catch {
+      setBackendPort(12701);
+    }
+
     return { interface: pi, translations, basePath, dataPath, backendOS, backendArch };
   }
 

--- a/src/services/interfaceLoader.ts
+++ b/src/services/interfaceLoader.ts
@@ -459,10 +459,11 @@ export async function autoLoadInterface(): Promise<LoadResult> {
 
     // tauri 环境下后端 HTTP API（/api/*）走内置 axum web server（默认 12701），
     // 但 getApiBase() 依赖 backendPort 才能返回绝对 URL（tauri://localhost 下相对 /api 不可达）。
-    // 这里显式设置默认端口，确保后续 fetch(getApiBase()/...) 直连后端。
+    // 这里显式设置端口（web server 未就绪时 get_web_server_port 返回 0，也回退默认端口），
+    // 确保后续 fetch(getApiBase()/...) 直连后端。
     try {
       const port = await invoke<number>('get_web_server_port');
-      if (port > 0) setBackendPort(port);
+      setBackendPort(port > 0 ? port : 12701);
     } catch {
       setBackendPort(12701);
     }

--- a/src/services/wsService.ts
+++ b/src/services/wsService.ts
@@ -92,6 +92,12 @@ export function setServerPort(port: number): void {
 function getWsUrl(): string {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 
+  // 已探测到后端端口：直连（tauri 生产模式下 tauri://localhost 相对路径不可用）
+  if (serverPort && serverPort > 0) {
+    const hostname = window.location.hostname || '127.0.0.1';
+    return `${protocol}//${hostname}:${serverPort}/api/ws`;
+  }
+
   // 正常情况：通过 Nginx 反向代理
   if (window.location.host) {
     return `${protocol}//${window.location.host}/api/ws`;

--- a/src/utils/backendApi.ts
+++ b/src/utils/backendApi.ts
@@ -16,12 +16,22 @@ export function setBackendPort(port: number): void {
 }
 
 export function getApiBase(): string {
-  // 正常情况：通过 Nginx 反向代理，用相对路径
+  // 已探测到后端直连端口：优先使用绝对 URL。
+  // 这是 tauri 生产模式的关键路径 —— tauri://localhost 下相对路径 /api 会 404
+  // （tauri 不代理 /api 到后端端口），只有浏览器 dev 模式（Vite proxy）相对路径才可用。
+  if (backendPort > 0) {
+    const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
+    const hostname = window.location.hostname || '127.0.0.1';
+    return `${protocol}//${hostname}:${backendPort}/api`;
+  }
+
+  // 浏览器 dev 模式 / 远程访问：通过代理相对路径或直连
   if (window.location.host) {
+    // dev 模式（Vite proxy）或后端已在同源反代下
     return '/api';
   }
 
-  // Fallback：直连后端
+  // Fallback：直连后端（file:// 或未设置 host）
   const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
   const hostname = window.location.hostname || '127.0.0.1';
   const port = backendPort || 12701;


### PR DESCRIPTION
## 问题 / Problem

On Linux (Arch + Hyprland, tauri webview), the welcome page is stuck on a "Loading Failed / 加载失败" error dialog and the main UI is unreachable. Reported as [MaaEnd/MaaEnd#4692](https://github.com/MaaEnd/MaaEnd/issues/4692).

Root cause: `getApiBase()` returns the relative path `/api` whenever `window.location.host` is truthy — which is **always** the case under `tauri://localhost`. In tauri production the webview cannot reach `/api` (tauri does not proxy it to the axum web server), so the interface fetch fails and content loading (`DESCRIPTION.md` etc.) falls back to showing the raw path with the error dialog.

## 修复 / Fix

- `getApiBase()`: once the backend port has been discovered via `setBackendPort()`, prefer the absolute `http://host:port/api` URL. The relative `/api` path remains as a dev-mode (Vite proxy) / same-origin reverse-proxy fallback.
- `getWsUrl()`: same fix for the WebSocket endpoint (`serverPort` already exists).

Verified: `pnpm build` passes; the compiled `getApiBase` now returns the absolute URL when the backend port is known.

## 验证 / Verification

- Backend API on port 12701 responds correctly (`curl http://127.0.0.1:12701/api/interface` and `/api/local-file?path=...` both return 200).
- The bug is that the frontend never uses that port because the relative `/api` path resolves under `tauri://localhost` and returns the embedded `index.html` (SPA fallback) instead of JSON.
- After this fix, once the port-probe succeeds, all subsequent API calls go to `http://localhost:12701/api/...` which works.

## Summary by Sourcery

确保在探测到后端端口可用时，前端使用**绝对后端 URL**，以修复 Tauri 生产模式下的 API 加载失败问题。

New Features:
- 当已发现后端端口时，支持通过绝对 `http` URL 直接连接到后端。

Bug Fixes:
- 通过避免在 Tauri 生产模式下无法访问的相对 `/api` 请求，修复欢迎页加载失败的问题。
- 当已知后端服务器端口时，通过优先使用绝对 `ws` URL 修复 WebSocket 连接问题。

Enhancements:
- 优化后端 URL 选择逻辑，更好地区分开发模式下使用代理与直接访问后端的路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure frontend uses an absolute backend URL when a probed backend port is available to fix API loading failures in Tauri production mode.

New Features:
- Support direct connections to the backend via an absolute http URL when the backend port has been discovered.

Bug Fixes:
- Fix welcome page failing to load by avoiding relative /api requests that are unreachable in Tauri production mode.
- Fix WebSocket connections by preferring an absolute ws URL when the backend server port is known.

Enhancements:
- Refine backend URL selection logic to better distinguish between dev-mode proxy usage and direct backend access paths.

</details>