### PR TITLE
feat: 支持子配置项收起/展开

### DIFF
--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -5,7 +5,16 @@ import { loadIconAsDataUrl, useResolvedContent } from '@/services/contentResolve
 import type { OptionValue, CaseItem, InputItem, OptionDefinition } from '@/types/interface';
 import { findMxuOptionByKey } from '@/types/specialTasks';
 import clsx from 'clsx';
-import { Info, AlertCircle, Loader2, FileText, Link, ChevronDown, Check } from 'lucide-react';
+import {
+  Info,
+  AlertCircle,
+  Loader2,
+  FileText,
+  Link,
+  ChevronDown,
+  Check,
+  ChevronRight,
+} from 'lucide-react';
 import { getInterfaceLangKey } from '@/i18n';
 import { findSwitchCase } from '@/utils/optionHelpers';
 import { SwitchButton, TextInput, FileInput, TimeInput, HotkeyInput } from './FormControls';
@@ -16,6 +25,41 @@ export function switchHasNestedOptions(optionDef: OptionDefinition): boolean {
   if (optionDef.type !== 'switch') return false;
   // SwitchOption 的 cases 是 [CaseItem, CaseItem]，始终有两个元素
   return optionDef.cases.some((c: CaseItem) => c.option && c.option.length > 0);
+}
+
+/** 子选项折叠箭头：复用任务标题的 ChevronRight 样式，位于开关/下拉框左侧 */
+function OptionCollapseArrow({
+  collapsed,
+  onToggle,
+  disabled = false,
+}: {
+  collapsed: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        // 所在行整体点击会切换开关/下拉框，必须阻止冒泡
+        e.stopPropagation();
+        onToggle();
+      }}
+      disabled={disabled}
+      aria-expanded={!collapsed}
+      aria-label={collapsed ? t('optionEditor.expandOptions') : t('optionEditor.collapseOptions')}
+      title={collapsed ? t('optionEditor.expandOptions') : t('optionEditor.collapseOptions')}
+      className="p-1 rounded hover:bg-bg-hover flex-shrink-0 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      <ChevronRight
+        className={clsx(
+          'w-4 h-4 text-text-secondary transition-transform duration-150 ease-out',
+          !collapsed && 'rotate-90',
+        )}
+      />
+    </button>
+  );
 }
 
 /** 异步加载图标组件 */
@@ -360,6 +404,14 @@ export function OptionEditor({
     () => instances.find((item) => item.id === instanceId),
     [instances, instanceId],
   );
+  // 子选项折叠状态：任务作用域存 store（随配置持久化）；全局作用域用本地 state 兜底
+  const collapsedOptions = useMemo(() => {
+    if (globalScope) return undefined;
+    const instance = instances.find((i) => i.id === instanceId);
+    const task = instance?.selectedTasks.find((t) => t.id === taskId);
+    return task?.collapsedOptions;
+  }, [globalScope, instances, instanceId, taskId]);
+  const [localCollapsed, setLocalCollapsed] = useState(false);
 
   if (!optionDef) return null;
 
@@ -428,6 +480,17 @@ export function OptionEditor({
   const selectedCase = getSelectedCase();
   const nestedOptionKeys = selectedCase?.option || [];
 
+  // 当前选项的子选项是否处于折叠状态（缺省展开）
+  const isCollapsed = globalScope ? localCollapsed : !!collapsedOptions?.[optionKey];
+  const handleToggleCollapsed = () => {
+    if (effectiveDisabled) return;
+    if (globalScope) {
+      setLocalCollapsed((prev) => !prev);
+    } else {
+      useAppStore.getState().toggleOptionCollapsed(instanceId, taskId, optionKey);
+    }
+  };
+
   // Switch 类型
   if (optionDef.type === 'switch') {
     const isChecked = effectiveValue?.type === 'switch' ? effectiveValue.value : false;
@@ -478,6 +541,13 @@ export function OptionEditor({
               translations={translations}
             />
           </div>
+          {nestedOptionKeys.length > 0 && (
+            <OptionCollapseArrow
+              collapsed={isCollapsed}
+              onToggle={handleToggleCollapsed}
+              disabled={effectiveDisabled}
+            />
+          )}
           <div className="pointer-events-none flex-shrink-0" aria-hidden="true">
             <SwitchButton
               value={isChecked}
@@ -487,23 +557,30 @@ export function OptionEditor({
             />
           </div>
         </div>
-        {/* 渲染嵌套选项 */}
+        {/* 渲染嵌套选项（可折叠，复用任务标题的 grid 展开动画） */}
         {nestedOptionKeys.length > 0 && (
-          <div className="space-y-3">
-            {nestedOptionKeys.map((nestedKey) => (
-              <OptionEditor
-                key={nestedKey}
-                instanceId={instanceId}
-                taskId={taskId}
-                optionKey={nestedKey}
-                value={allOptionValues[nestedKey]}
-                depth={depth + 1}
-                disabled={effectiveDisabled}
-                globalScope={globalScope}
-                controllerIncompatible={isOptionIncompatible}
-                parentIncompatibilityReason={incompatibleReasonType}
-              />
-            ))}
+          <div
+            className="grid transition-[grid-template-rows] duration-150 ease-out"
+            style={{ gridTemplateRows: isCollapsed ? '0fr' : '1fr' }}
+          >
+            <div className={clsx('min-h-0', isCollapsed ? 'overflow-hidden' : 'overflow-visible')}>
+              <div className="space-y-3">
+                {nestedOptionKeys.map((nestedKey) => (
+                  <OptionEditor
+                    key={nestedKey}
+                    instanceId={instanceId}
+                    taskId={taskId}
+                    optionKey={nestedKey}
+                    value={allOptionValues[nestedKey]}
+                    depth={depth + 1}
+                    disabled={effectiveDisabled}
+                    globalScope={globalScope}
+                    controllerIncompatible={isOptionIncompatible}
+                    parentIncompatibilityReason={incompatibleReasonType}
+                  />
+                ))}
+              </div>
+            </div>
           </div>
         )}
       </div>
@@ -673,6 +750,13 @@ export function OptionEditor({
             translations={translations}
           />
         </div>
+        {nestedOptionKeys.length > 0 && (
+          <OptionCollapseArrow
+            collapsed={isCollapsed}
+            onToggle={handleToggleCollapsed}
+            disabled={effectiveDisabled}
+          />
+        )}
         <SelectComponent
           className="w-[30%] flex-shrink-0 ml-auto"
           value={selectedCaseName}
@@ -697,23 +781,30 @@ export function OptionEditor({
           }}
         />
       </div>
-      {/* 渲染嵌套选项 */}
+      {/* 渲染嵌套选项（可折叠，复用任务标题的 grid 展开动画） */}
       {nestedOptionKeys.length > 0 && (
-        <div className="space-y-3">
-          {nestedOptionKeys.map((nestedKey) => (
-            <OptionEditor
-              key={nestedKey}
-              instanceId={instanceId}
-              taskId={taskId}
-              optionKey={nestedKey}
-              value={allOptionValues[nestedKey]}
-              depth={depth + 1}
-              disabled={effectiveDisabled}
-              globalScope={globalScope}
-              controllerIncompatible={isOptionIncompatible}
-              parentIncompatibilityReason={incompatibleReasonType}
-            />
-          ))}
+        <div
+          className="grid transition-[grid-template-rows] duration-150 ease-out"
+          style={{ gridTemplateRows: isCollapsed ? '0fr' : '1fr' }}
+        >
+          <div className={clsx('min-h-0', isCollapsed ? 'overflow-hidden' : 'overflow-visible')}>
+            <div className="space-y-3">
+              {nestedOptionKeys.map((nestedKey) => (
+                <OptionEditor
+                  key={nestedKey}
+                  instanceId={instanceId}
+                  taskId={taskId}
+                  optionKey={nestedKey}
+                  value={allOptionValues[nestedKey]}
+                  depth={depth + 1}
+                  disabled={effectiveDisabled}
+                  globalScope={globalScope}
+                  controllerIncompatible={isOptionIncompatible}
+                  parentIncompatibilityReason={incompatibleReasonType}
+                />
+              ))}
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -50,7 +50,9 @@ function OptionCollapseArrow({
       aria-expanded={!collapsed}
       aria-label={collapsed ? t('optionEditor.expandOptions') : t('optionEditor.collapseOptions')}
       title={collapsed ? t('optionEditor.expandOptions') : t('optionEditor.collapseOptions')}
-      className="p-1 rounded hover:bg-bg-hover flex-shrink-0 disabled:cursor-not-allowed disabled:opacity-50"
+      // ml-auto：吸收行内剩余空白（label 受 max-w-[60%] 限制无法全部吸收），
+      // 让箭头紧贴开关/下拉框，空隙只留在箭头左侧
+      className="p-1 rounded hover:bg-bg-hover flex-shrink-0 ml-auto disabled:cursor-not-allowed disabled:opacity-50"
     >
       <ChevronRight
         className={clsx(
@@ -758,7 +760,8 @@ export function OptionEditor({
           />
         )}
         <SelectComponent
-          className="w-[30%] flex-shrink-0 ml-auto"
+          // 有子选项时由箭头承担 ml-auto 贴右；无子选项时下拉框自身贴右
+          className={clsx('w-[30%] flex-shrink-0', nestedOptionKeys.length === 0 && 'ml-auto')}
           value={selectedCaseName}
           disabled={effectiveDisabled}
           basePath={basePath}

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -356,6 +356,8 @@ export default {
     incompatibleResource: 'Not supported by current resource',
     hotkeyPlaceholder: 'Click to record shortcut',
     hotkeyCapturing: 'Press keys...',
+    expandOptions: 'Expand sub-options',
+    collapseOptions: 'Collapse sub-options',
   },
 
   // Preset

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -351,6 +351,8 @@ export default {
     incompatibleResource: '現在のリソースパックに対応していません',
     hotkeyPlaceholder: 'クリックしてショートカットを記録',
     hotkeyCapturing: 'キーを押してください...',
+    expandOptions: '子オプションを展開',
+    collapseOptions: '子オプションを折りたたむ',
   },
 
   // プリセット

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -347,6 +347,8 @@ export default {
     incompatibleResource: '현재 리소스 팩에서 지원되지 않음',
     hotkeyPlaceholder: '클릭하여 단축키 입력',
     hotkeyCapturing: '키를 누르세요...',
+    expandOptions: '하위 옵션 펼치기',
+    collapseOptions: '하위 옵션 접기',
   },
 
   // 프리셋

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -344,6 +344,8 @@ export default {
     incompatibleResource: '不支持当前资源包',
     hotkeyPlaceholder: '点击录入快捷键',
     hotkeyCapturing: '按下快捷键...',
+    expandOptions: '展开子选项',
+    collapseOptions: '收起子选项',
   },
 
   // 预设配置

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -340,6 +340,8 @@ export default {
     incompatibleResource: '不支援目前資源包',
     hotkeyPlaceholder: '點擊錄入快捷鍵',
     hotkeyCapturing: '按下快捷鍵...',
+    expandOptions: '展開子選項',
+    collapseOptions: '收起子選項',
   },
 
   // 預設設定

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -772,7 +772,7 @@ export const useAppStore = create<AppState>()(
                     ? {
                         ...t,
                         collapsedOptions: {
-                          ...t.collapsedOptions,
+                          ...(t.collapsedOptions ?? {}),
                           [optionKey]: !t.collapsedOptions?.[optionKey],
                         },
                       }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -761,6 +761,28 @@ export const useAppStore = create<AppState>()(
         ),
       })),
 
+    toggleOptionCollapsed: (instanceId, taskId, optionKey) =>
+      set((state) => ({
+        instances: state.instances.map((i) =>
+          i.id === instanceId
+            ? {
+                ...i,
+                selectedTasks: i.selectedTasks.map((t) =>
+                  t.id === taskId
+                    ? {
+                        ...t,
+                        collapsedOptions: {
+                          ...t.collapsedOptions,
+                          [optionKey]: !t.collapsedOptions?.[optionKey],
+                        },
+                      }
+                    : t,
+                ),
+              }
+            : i,
+        ),
+      })),
+
     setTaskOptionValue: (instanceId, taskId, optionKey, value) => {
       const pi = get().projectInterface;
 

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -192,6 +192,7 @@ export interface AppState {
   reorderTasks: (instanceId: string, oldIndex: number, newIndex: number) => void;
   toggleTaskEnabled: (instanceId: string, taskId: string) => void;
   toggleTaskExpanded: (instanceId: string, taskId: string) => void;
+  toggleOptionCollapsed: (instanceId: string, taskId: string, optionKey: string) => void;
   setTaskOptionValue: (
     instanceId: string,
     taskId: string,

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -318,6 +318,8 @@ export interface SelectedTask {
   enabledByController?: Record<string, boolean>;
   optionValues: Record<string, OptionValue>;
   expanded: boolean;
+  /** 各选项的子选项折叠状态（optionKey → 是否折叠）；缺省 = 展开，向后兼容 */
+  collapsedOptions?: Record<string, boolean>;
 }
 
 export type OptionValue =


### PR DESCRIPTION
## 概述

为带嵌套选项（switch / 下拉框）的配置项增加收起/展开功能，减少界面视觉噪音。

## 变更内容

- 新增 `OptionCollapseArrow` 组件，位于开关/下拉框左侧，支持键盘与无障碍属性（`aria-expanded`、`aria-label`）
- switch 与 select 类型的嵌套选项支持折叠，复用任务标题的 `grid-template-rows` 展开动画
- 折叠状态按任务持久化到 store（`SelectedTask.collapsedOptions`，缺省展开、向后兼容）；全局作用域（globalScope）用本地 state 兜底
- 新增 `toggleOptionCollapsed` store action 及类型定义
- 补充 5 种语言（en / ja / ko / zh-CN / zh-TW）的文案
- 箭头添加 `ml-auto` 吸收行内空白，紧贴开关/下拉框；select 类型无子选项时由下拉框自身贴右

## 演示

<img width="1918" height="1018" alt="QQ20260803-163837-HD" src="https://github.com/user-attachments/assets/7608f2a0-c24a-418c-8737-c823e650dfed" />

## 涉及文件

- `src/components/OptionEditor.tsx`
- `src/stores/appStore.ts`、`src/stores/types.ts`
- `src/types/interface.ts`
- `src/i18n/locales/{en-US,ja-JP,ko-KR,zh-CN,zh-TW}.ts`

## 涉及 issue [#180 支持子选项折叠](https://github.com/MistEO/MXU/issues/180)

~本 PR 更改代码由 DeepSeek V4 Flash (effort:Max) 生成，构建和本地测试均通过，[转到演示 mxu 版本](https://github.com/WindDrift/MXU/actions/runs/30796466643/job/91631233147)~

## Summary by Sourcery

为开关（switch）和选择（select）配置项添加可折叠的子选项，支持按任务持久化折叠状态，并提供兼容无障碍访问的 UI 控件。

新功能：
- 引入 `OptionCollapseArrow` UI 控件，用于在开关和选择输入旁切换嵌套选项的可见性。
- 使开关和选择类型的嵌套选项可以通过动画过渡进行折叠/展开。
- 在 store 中按任务持久化选项子树的折叠状态，并为全局作用域提供本地回退方案。
- 为展开和折叠子选项在所有受支持语言中添加本地化标签。

增强：
- 调整布局，使折叠箭头或选择控件根据是否存在嵌套选项对齐到右侧边缘。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add collapsible sub-options for switch and select configuration items, with persisted per-task collapse state and accessibility-aware UI controls.

New Features:
- Introduce an OptionCollapseArrow UI control to toggle visibility of nested options beside switch and select inputs.
- Enable nested options for switch and select types to be collapsed/expanded with animated transitions.
- Persist per-task collapsed state for option subtrees in the store, with a local fallback for global scope.
- Add localized labels for expanding and collapsing sub-options in all supported languages.

Enhancements:
- Adjust layout so the collapse arrow or select control aligns to the right edge depending on whether nested options exist.

</details>