### PR TITLE
feat(telemetry): add task failure diagnostics and attachments

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,6 +3,154 @@
 version = 4
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11004b0e9b44b4eb3d15e0c3132b96fb178c7e50a74758b2f17bb9cc9a7fb4f6"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "bitflags 2.10.0",
+ "bytes",
+ "bytestring",
+ "derive_more 2.1.1",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.12",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25da0441692de4ad67950cb7ed6c9ce4b669a6609525e547566c2e1ab4d695c"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8dcb6fa613d47c3b764a7dc672b4b31f25751dcbcf542f7b16f3e1f700044c"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbacab3593b6b4f7be815076fc52d60a83c873426824675417e2abdd229e2e36"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "derive_more 2.1.1",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +477,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,7 +510,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -374,7 +545,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -412,6 +583,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
@@ -575,11 +752,20 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -774,6 +960,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +1004,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1086,11 +1290,10 @@ checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1100,11 +1303,34 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1445,6 +1671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1726,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1946,7 +2184,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2027,6 +2265,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2042,7 +2291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2053,7 +2302,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -2087,7 +2336,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -2105,15 +2354,15 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2143,7 +2392,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -2314,6 +2563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,7 +2688,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2441,10 +2696,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "jobserver"
@@ -2510,6 +2814,12 @@ dependencies = [
  "indexmap 2.13.0",
  "selectors",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -2601,6 +2911,12 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -2773,6 +3089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2826,7 +3143,7 @@ dependencies = [
  "notify-rust",
  "os_info",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rust-embed",
  "semver",
  "sentry",
@@ -2862,10 +3179,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2877,7 +3194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.10.0",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "ndk-sys",
  "num_enum",
@@ -2897,7 +3214,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -2949,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -3298,6 +3615,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -3814,7 +4137,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.36",
+ "rustls",
  "socket2",
  "thiserror 2.0.17",
  "tokio",
@@ -3828,13 +4151,14 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.5",
  "ring",
  "rustc-hash",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -3905,9 +4229,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4098,6 +4422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,7 +4457,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4141,7 +4471,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.36",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4159,7 +4489,46 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.5",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4315,31 +4684,30 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.36"
+name = "rustls-native-certs"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "log",
- "once_cell",
- "ring",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
- "subtle",
- "zeroize",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -4353,15 +4721,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.102.8"
+name = "rustls-platform-verifier"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4369,6 +4753,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4481,6 +4866,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework-sys"
 version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,7 +4896,7 @@ checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
@@ -4520,40 +4918,54 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.34.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
+checksum = "63207365db50cb817402f0ec8097d6dad3d644ef3fffd6ba30c75b3077e514da"
 dependencies = [
+ "cfg_aliases",
  "httpdate",
- "reqwest",
- "rustls 0.22.4",
+ "reqwest 0.13.4",
+ "rustls",
+ "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "sentry-log",
  "sentry-panic",
  "sentry-tracing",
  "tokio",
  "ureq",
- "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sentry-actix"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0eb1ed18478fb48db007aeaa672a3de176055357feb768eee0c3471802d0ce"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "futures-util",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.34.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
+checksum = "e3bcc2497c2327998146207b7600599ef7592233920f4d4e1d41ddeeba0e4210"
 dependencies = [
  "backtrace",
- "once_cell",
  "regex",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-contexts"
-version = "0.34.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
+checksum = "1cb04cba225b38f59d08f9e3c29ab7259d9cc94fbb2c46d613a51cb0a4a7ee05"
 dependencies = [
  "hostname",
  "libc",
@@ -4565,22 +4977,33 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.34.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
+checksum = "48759bc392fb5e3b36b4efcb485f51074c0ba8479711cd5c8cf79e86f9f75d41"
 dependencies = [
- "once_cell",
- "rand 0.8.5",
+ "rand 0.9.5",
  "sentry-types",
  "serde",
  "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-log"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9553a2f0f75bc8550137ebc753e8d2161af63ff780ca59983935f8df8f01655"
+dependencies = [
+ "bitflags 2.10.0",
+ "log",
+ "sentry-core",
 ]
 
 [[package]]
 name = "sentry-panic"
-version = "0.34.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
+checksum = "a685d22f672b1562ebeff3f2affceb5960595648cc936dae73da3e1d6a55fbd1"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4588,10 +5011,11 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.34.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
+checksum = "8aa7d8e0db4cccddbac01ddabd5344ad03b7c2f954b3ff850cecb1d9cf5d4758"
 dependencies = [
+ "bitflags 2.10.0",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -4600,16 +5024,16 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.34.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
+checksum = "fab146d15a30ab4897a95fd15d6a038b8d7fbf2661c5f8b13738ce8df7a095b7"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.8.5",
+ "rand 0.9.5",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "time",
  "url",
  "uuid",
@@ -4845,6 +5269,16 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -5095,7 +5529,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "lazy_static",
  "libc",
  "log",
@@ -5168,9 +5602,9 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http",
+ "http 1.4.0",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5183,7 +5617,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5362,9 +5796,9 @@ dependencies = [
  "bytes",
  "cookie_store 0.21.1",
  "data-url",
- "http",
+ "http 1.4.0",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -5440,8 +5874,8 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http",
- "jni",
+ "http 1.4.0",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5463,8 +5897,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065"
 dependencies = [
  "gtk",
- "http",
- "jni",
+ "http 1.4.0",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5496,7 +5930,7 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever",
- "http",
+ "http 1.4.0",
  "infer",
  "json-patch",
  "kuchikiki",
@@ -5610,12 +6044,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "js-sys",
  "libc",
  "num-conv",
@@ -5628,15 +6061,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5676,7 +6109,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -5709,7 +6144,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls",
  "tokio",
 ]
 
@@ -5859,7 +6294,7 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "http-range-header",
@@ -5884,7 +6319,7 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "iri-string",
  "pin-project-lite",
@@ -5984,7 +6419,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -6091,6 +6526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6098,17 +6539,30 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "log",
- "once_cell",
- "rustls 0.23.36",
+ "percent-encoding",
+ "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -6153,6 +6607,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6405,12 +6865,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
+name = "webpki-root-certs"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
- "webpki-roots 1.0.5",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7027,9 +7487,9 @@ dependencies = [
  "gdkx11",
  "gtk",
  "html5ever",
- "http",
+ "http 1.4.0",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "kuchikiki",
  "libc",
  "ndk",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,19 +52,21 @@ maa-framework = { version = "1.22.0", features = ["dynamic"] }
 rust-embed = "8"
 clap = { version = "4", features = ["derive"] }
 # 匿名遥测（数据埋点）
-sentry = { version = "0.34", default-features = false, features = [
+sentry = { version = "0.49.1", default-features = false, features = [
     "backtrace",
     "contexts",
+    "logs",
     "panic",
     "reqwest",
     "rustls",
+    "release-health",
 ] }
 sysinfo = "0.32"
 machine-uid = "0.5"
 sha2 = "0.10"
 
 [dev-dependencies]
-sentry = { version = "0.34", default-features = false, features = ["test"] }
+sentry = { version = "0.49.1", default-features = false, features = ["logs", "test"] }
 
 [profile.release]
 # 保留调试符号以生成 PDB 文件，便于崩溃分析

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,9 @@ sysinfo = "0.32"
 machine-uid = "0.5"
 sha2 = "0.10"
 
+[dev-dependencies]
+sentry = { version = "0.34", default-features = false, features = ["test"] }
+
 [profile.release]
 # 保留调试符号以生成 PDB 文件，便于崩溃分析
 debug = true

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod maa_agent;
 pub mod maa_core;
 pub mod state;
 pub mod system;
+mod task_diagnostics;
 pub mod telemetry;
 pub mod tray;
 pub mod update;

--- a/src-tauri/src/commands/task_diagnostics.rs
+++ b/src-tauri/src/commands/task_diagnostics.rs
@@ -1,0 +1,538 @@
+//! Task-scoped diagnostic attachment construction.
+//!
+//! The caller records file boundaries when a MaaFramework SavedTask starts. If that
+//! task later fails, this module packages only bytes appended during the task (plus a
+//! small prelude) and images newly written to `on_error/`. It deliberately excludes
+//! configuration, `vision/`, crash dumps, and a standalone manifest.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use zip::write::SimpleFileOptions;
+use zip::ZipWriter;
+
+/// Include a little context immediately before the task-start offset.
+const LOG_PRELUDE_BYTES: u64 = 64 * 1024;
+/// Bound local work before compression. Oversized evidence is reported to Sentry
+/// without an attachment instead of being silently truncated.
+const MAX_SELECTED_RAW_BYTES: u64 = 64 * 1024 * 1024;
+/// The Rust Sentry SDK stores an attachment in a `Vec<u8>`, so keep the final
+/// allocation bounded independently from the source-directory size.
+const MAX_COMPRESSED_BYTES: usize = 10 * 1024 * 1024;
+/// Filesystems may expose a slightly older mtime than the task-start wall clock.
+const MTIME_TOLERANCE: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone)]
+pub struct TaskEvidenceStart {
+    root: PathBuf,
+    started_at: SystemTime,
+    log_lengths: BTreeMap<PathBuf, u64>,
+    existing_images: BTreeSet<PathBuf>,
+}
+
+#[derive(Debug)]
+pub struct TaskEvidenceSelection {
+    logs: Vec<LogSlice>,
+    images: Vec<ImageEntry>,
+    selected_raw_bytes: u64,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+struct LogSlice {
+    source: File,
+    source_path: PathBuf,
+    archive_name: String,
+    start: u64,
+    end: u64,
+}
+
+#[derive(Debug)]
+struct ImageEntry {
+    source: File,
+    source_path: PathBuf,
+    archive_name: String,
+    len: u64,
+}
+
+#[derive(Debug)]
+pub struct TaskBundle {
+    pub buffer: Vec<u8>,
+    pub filename: String,
+    pub log_count: usize,
+    pub image_count: usize,
+    pub selected_raw_bytes: u64,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum TaskBundleError {
+    NoEvidence,
+    TooLarge {
+        selected_raw_bytes: u64,
+        compressed_bytes: Option<usize>,
+    },
+    Io(String),
+}
+
+impl std::fmt::Display for TaskBundleError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoEvidence => formatter.write_str("no task-scoped evidence was found"),
+            Self::TooLarge {
+                selected_raw_bytes,
+                compressed_bytes,
+            } => write!(
+                formatter,
+                "task evidence is too large (raw={selected_raw_bytes}, compressed={})",
+                compressed_bytes
+                    .map(|size| size.to_string())
+                    .unwrap_or_else(|| "not-built".to_string())
+            ),
+            Self::Io(message) => formatter.write_str(message),
+        }
+    }
+}
+
+/// Snapshot task-relevant file boundaries. Discovery failures are intentionally
+/// best-effort: the eventual Sentry error event must still be sent without a bundle.
+pub fn capture_task_start(root: &Path) -> TaskEvidenceStart {
+    let mut log_lengths = BTreeMap::new();
+    let mut existing_images = BTreeSet::new();
+
+    for path in discover_files(root) {
+        let Some(relative) = safe_relative_path(root, &path) else {
+            continue;
+        };
+        if is_on_error_image(relative) {
+            existing_images.insert(relative.to_path_buf());
+        } else if is_log_file(relative) {
+            if let Ok(metadata) = path.metadata() {
+                log_lengths.insert(relative.to_path_buf(), metadata.len());
+            }
+        }
+    }
+
+    TaskEvidenceStart {
+        root: root.to_path_buf(),
+        started_at: SystemTime::now(),
+        log_lengths,
+        existing_images,
+    }
+}
+
+/// Freeze the end boundary as soon as the outer SavedTask reaches its terminal
+/// callback. Compression may happen later, but a following task cannot expand the
+/// selected ranges or add its screenshots to this attachment.
+pub fn capture_task_end(
+    start: TaskEvidenceStart,
+) -> Result<TaskEvidenceSelection, TaskBundleError> {
+    let (logs, images, warnings) = select_entries(&start);
+    if logs.is_empty() && images.is_empty() {
+        return Err(TaskBundleError::NoEvidence);
+    }
+
+    let selected_raw_bytes = logs
+        .iter()
+        .map(|entry| entry.end.saturating_sub(entry.start))
+        .chain(images.iter().map(|entry| entry.len))
+        .fold(0u64, u64::saturating_add);
+    if selected_raw_bytes > MAX_SELECTED_RAW_BYTES {
+        return Err(TaskBundleError::TooLarge {
+            selected_raw_bytes,
+            compressed_bytes: None,
+        });
+    }
+
+    Ok(TaskEvidenceSelection {
+        logs,
+        images,
+        selected_raw_bytes,
+        warnings,
+    })
+}
+
+/// Build one ZIP attachment from an already-frozen task selection.
+pub fn build_task_bundle(
+    mut selection: TaskEvidenceSelection,
+    run_id: &str,
+    maa_task_id: i64,
+) -> Result<TaskBundle, TaskBundleError> {
+    let cursor = Cursor::new(Vec::new());
+    let mut archive = ZipWriter::new(cursor);
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    for entry in &mut selection.logs {
+        write_log_slice(&mut archive, entry, options)?;
+    }
+    for entry in &mut selection.images {
+        write_image(&mut archive, entry, options)?;
+    }
+
+    let buffer = archive
+        .finish()
+        .map_err(|error| TaskBundleError::Io(format!("finish diagnostic ZIP: {error}")))?
+        .into_inner();
+    if buffer.len() > MAX_COMPRESSED_BYTES {
+        return Err(TaskBundleError::TooLarge {
+            selected_raw_bytes: selection.selected_raw_bytes,
+            compressed_bytes: Some(buffer.len()),
+        });
+    }
+
+    Ok(TaskBundle {
+        buffer,
+        filename: format!("mxu-task-failure-{run_id}-{maa_task_id}.zip"),
+        log_count: selection.logs.len(),
+        image_count: selection.images.len(),
+        selected_raw_bytes: selection.selected_raw_bytes,
+        warnings: selection.warnings,
+    })
+}
+
+fn select_entries(start: &TaskEvidenceStart) -> (Vec<LogSlice>, Vec<ImageEntry>, Vec<String>) {
+    let mut logs = Vec::new();
+    let mut images = Vec::new();
+    let mut warnings = Vec::new();
+
+    for path in discover_files(&start.root) {
+        let Some(relative) = safe_relative_path(&start.root, &path) else {
+            continue;
+        };
+        let Some(archive_name) = normalize_archive_path(relative) else {
+            continue;
+        };
+        // Open the selected generation at the terminal callback. The background
+        // compressor must never resolve this path again because rotation may make
+        // it point at a different file.
+        let Ok(source) = File::open(&path) else {
+            continue;
+        };
+        let Ok(metadata) = source.metadata() else {
+            continue;
+        };
+
+        if is_on_error_image(relative) {
+            if start.existing_images.contains(relative) || !modified_during_task(&metadata, start) {
+                continue;
+            }
+            images.push(ImageEntry {
+                source,
+                source_path: path,
+                archive_name,
+                len: metadata.len(),
+            });
+            continue;
+        }
+
+        if !is_log_file(relative) {
+            continue;
+        }
+
+        let end = metadata.len();
+        let Some(previous_len) = start.log_lengths.get(relative).copied() else {
+            if !modified_during_task(&metadata, start) || end == 0 {
+                continue;
+            }
+            warnings.push(format!("new_log_included_whole:{archive_name}"));
+            logs.push(LogSlice {
+                source,
+                source_path: path,
+                archive_name,
+                start: 0,
+                end,
+            });
+            continue;
+        };
+
+        if end > previous_len {
+            logs.push(LogSlice {
+                source,
+                source_path: path,
+                archive_name,
+                start: previous_len.saturating_sub(LOG_PRELUDE_BYTES),
+                end,
+            });
+        } else if end < previous_len && modified_during_task(&metadata, start) && end > 0 {
+            warnings.push(format!("rotated_log_included_whole:{archive_name}"));
+            logs.push(LogSlice {
+                source,
+                source_path: path,
+                archive_name,
+                start: 0,
+                end,
+            });
+        }
+    }
+
+    logs.sort_by(|left, right| left.archive_name.cmp(&right.archive_name));
+    images.sort_by(|left, right| left.archive_name.cmp(&right.archive_name));
+    (logs, images, warnings)
+}
+
+fn write_log_slice<W: Write + Seek>(
+    archive: &mut ZipWriter<W>,
+    entry: &mut LogSlice,
+    options: SimpleFileOptions,
+) -> Result<(), TaskBundleError> {
+    entry
+        .source
+        .seek(SeekFrom::Start(entry.start))
+        .map_err(|error| {
+            TaskBundleError::Io(format!(
+                "seek log [{}]: {error}",
+                entry.source_path.display()
+            ))
+        })?;
+    archive
+        .start_file(&entry.archive_name, options)
+        .map_err(|error| TaskBundleError::Io(format!("start ZIP entry: {error}")))?;
+    let mut selected = (&mut entry.source).take(entry.end.saturating_sub(entry.start));
+    io::copy(&mut selected, archive)
+        .map_err(|error| TaskBundleError::Io(format!("write log ZIP entry: {error}")))?;
+    Ok(())
+}
+
+fn write_image<W: Write + Seek>(
+    archive: &mut ZipWriter<W>,
+    entry: &mut ImageEntry,
+    options: SimpleFileOptions,
+) -> Result<(), TaskBundleError> {
+    archive
+        .start_file(&entry.archive_name, options)
+        .map_err(|error| TaskBundleError::Io(format!("start ZIP entry: {error}")))?;
+    let mut selected = (&mut entry.source).take(entry.len);
+    io::copy(&mut selected, archive).map_err(|error| {
+        TaskBundleError::Io(format!(
+            "write attachment [{}]: {error}",
+            entry.source_path.display()
+        ))
+    })?;
+    Ok(())
+}
+
+fn discover_files(root: &Path) -> Vec<PathBuf> {
+    if !root.is_dir() {
+        return Vec::new();
+    }
+
+    let mut files = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            let path = entry.path();
+            if file_type.is_dir() {
+                let relative = path.strip_prefix(root).unwrap_or(&path);
+                if first_component_is(relative, "vision") {
+                    continue;
+                }
+                pending.push(path);
+            } else if file_type.is_file() {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+fn safe_relative_path<'a>(root: &Path, path: &'a Path) -> Option<&'a Path> {
+    let relative = path.strip_prefix(root).ok()?;
+    if relative
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+    {
+        Some(relative)
+    } else {
+        None
+    }
+}
+
+fn normalize_archive_path(path: &Path) -> Option<String> {
+    let components: Option<Vec<String>> = path
+        .components()
+        .map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect();
+    let value = components?.join("/");
+    (!value.is_empty()).then_some(value)
+}
+
+fn first_component_is(path: &Path, expected: &str) -> bool {
+    path.components()
+        .next()
+        .and_then(|component| match component {
+            Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+}
+
+fn is_log_file(relative: &Path) -> bool {
+    if first_component_is(relative, "on_error") || first_component_is(relative, "vision") {
+        return false;
+    }
+    relative
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|name| name.ends_with(".log") || name.contains(".log."))
+}
+
+fn is_on_error_image(relative: &Path) -> bool {
+    if !first_component_is(relative, "on_error") {
+        return false;
+    }
+    relative
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|extension| matches!(extension.as_str(), "png" | "jpg" | "jpeg"))
+}
+
+fn modified_during_task(metadata: &std::fs::Metadata, start: &TaskEvidenceStart) -> bool {
+    metadata.modified().is_ok_and(|modified| {
+        modified
+            .checked_add(MTIME_TOLERANCE)
+            .is_some_and(|adjusted| adjusted >= start.started_at)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    fn test_root() -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mxu-task-diagnostics-{}",
+            sentry::types::random_uuid()
+        ));
+        std::fs::create_dir_all(root.join("on_error")).expect("create test directory");
+        root
+    }
+
+    fn zip_entries(buffer: Vec<u8>) -> BTreeMap<String, Vec<u8>> {
+        let mut archive = zip::ZipArchive::new(Cursor::new(buffer)).expect("open ZIP");
+        let mut entries = BTreeMap::new();
+        for index in 0..archive.len() {
+            let mut entry = archive.by_index(index).expect("read ZIP entry");
+            let mut body = Vec::new();
+            entry.read_to_end(&mut body).expect("read ZIP body");
+            entries.insert(entry.name().to_string(), body);
+        }
+        entries
+    }
+
+    #[test]
+    fn bundles_only_appended_logs_and_new_on_error_images() {
+        let root = test_root();
+        std::fs::write(root.join("maafw.log"), b"old-log\n").expect("write old log");
+        std::fs::write(root.join("on_error/old.png"), b"old-image").expect("write old image");
+        std::fs::create_dir_all(root.join("vision")).expect("create vision");
+        std::fs::write(root.join("vision/ignored.png"), b"vision").expect("write vision");
+
+        let start = capture_task_start(&root);
+        let mut log = std::fs::OpenOptions::new()
+            .append(true)
+            .open(root.join("maafw.log"))
+            .expect("open log");
+        log.write_all(b"task-log\n").expect("append task log");
+        std::fs::write(root.join("on_error/new.png"), b"new-image").expect("write image");
+
+        let selection = capture_task_end(start).expect("capture task end");
+        log.write_all(b"next-task-log\n")
+            .expect("append next task log");
+        std::fs::write(root.join("on_error/next.png"), b"next-image").expect("write next image");
+        let bundle = build_task_bundle(selection, "run", 42).expect("build bundle");
+        let entries = zip_entries(bundle.buffer);
+        assert_eq!(bundle.log_count, 1);
+        assert_eq!(bundle.image_count, 1);
+        assert!(entries["maafw.log"].ends_with(b"task-log\n"));
+        assert_eq!(entries["on_error/new.png"], b"new-image");
+        assert!(!entries["maafw.log"]
+            .windows(b"next-task-log".len())
+            .any(|window| window == b"next-task-log"));
+        assert!(!entries.contains_key("on_error/old.png"));
+        assert!(!entries.contains_key("on_error/next.png"));
+        assert!(!entries.contains_key("vision/ignored.png"));
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn includes_nested_agent_logs_but_not_config_or_dump_files() {
+        let root = test_root();
+        std::fs::create_dir_all(root.join("cpp-algo/debug")).expect("create nested directory");
+        std::fs::write(root.join("cpp-algo/debug/maafw.log"), b"before\n")
+            .expect("write nested log");
+        std::fs::write(root.join("config.json"), b"config").expect("write config");
+        std::fs::write(root.join("process.dmp"), b"dump").expect("write dump");
+
+        let start = capture_task_start(&root);
+        let mut nested = std::fs::OpenOptions::new()
+            .append(true)
+            .open(root.join("cpp-algo/debug/maafw.log"))
+            .expect("open nested log");
+        nested.write_all(b"failure\n").expect("append nested log");
+
+        let selection = capture_task_end(start).expect("capture task end");
+        let bundle = build_task_bundle(selection, "run", 7).expect("build bundle");
+        let entries = zip_entries(bundle.buffer);
+        assert!(entries.contains_key("cpp-algo/debug/maafw.log"));
+        assert!(!entries.contains_key("config.json"));
+        assert!(!entries.contains_key("process.dmp"));
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn keeps_selected_file_generations_when_paths_are_replaced() {
+        let root = test_root();
+        let log_path = root.join("maafw.log");
+        let image_path = root.join("on_error/failure.png");
+        std::fs::write(&log_path, b"before\n").expect("write initial log");
+
+        let start = capture_task_start(&root);
+        let mut log = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&log_path)
+            .expect("open log");
+        log.write_all(b"selected-failure\n")
+            .expect("append failure");
+        drop(log);
+        std::fs::write(&image_path, b"selected-image").expect("write selected image");
+
+        let selection = capture_task_end(start).expect("capture task end");
+        std::fs::rename(&log_path, root.join("maafw.log.1")).expect("rotate selected log");
+        std::fs::write(&log_path, b"replacement-generation\n").expect("write replacement log");
+        std::fs::rename(&image_path, root.join("on_error/failure-old.png"))
+            .expect("rotate selected image");
+        std::fs::write(&image_path, b"replacement-image").expect("write replacement image");
+
+        let bundle = build_task_bundle(selection, "run", 9).expect("build bundle");
+        let entries = zip_entries(bundle.buffer);
+        assert!(entries["maafw.log"]
+            .windows(b"selected-failure".len())
+            .any(|window| window == b"selected-failure"));
+        assert!(!entries["maafw.log"]
+            .windows(b"replacement-generation".len())
+            .any(|window| window == b"replacement-generation"));
+        assert_eq!(entries["on_error/failure.png"], b"selected-image");
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+}

--- a/src-tauri/src/commands/task_diagnostics.rs
+++ b/src-tauri/src/commands/task_diagnostics.rs
@@ -1,11 +1,11 @@
-//! Task-scoped diagnostic attachment construction.
+//! Task-scoped diagnostic evidence construction.
 //!
 //! The caller records file boundaries when a MaaFramework SavedTask starts. If that
-//! task later fails, this module packages only bytes appended during the task (plus a
-//! small prelude) and images newly written to `on_error/`. It deliberately excludes
+//! task later fails, this module reads bounded log tails for Sentry Logs and packages
+//! only images newly written to `on_error/` as an attachment. It deliberately excludes
 //! configuration, `vision/`, crash dumps, and a standalone manifest.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
@@ -16,12 +16,22 @@ use zip::ZipWriter;
 
 /// Include a little context immediately before the task-start offset.
 const LOG_PRELUDE_BYTES: u64 = 64 * 1024;
-/// Bound local work before compression. Oversized evidence is reported to Sentry
-/// without an attachment instead of being silently truncated.
-const MAX_SELECTED_RAW_BYTES: u64 = 64 * 1024 * 1024;
-/// The Rust Sentry SDK stores an attachment in a `Vec<u8>`, so keep the final
-/// allocation bounded independently from the source-directory size.
-const MAX_COMPRESSED_BYTES: usize = 10 * 1024 * 1024;
+/// Bound the selected screenshots before building an attachment. PNG and JPEG data
+/// is already compressed, so the ZIP stores entries verbatim and stays near this cap.
+const MAX_IMAGE_RAW_BYTES: u64 = 5 * 1024 * 1024;
+/// The Rust Sentry SDK stores an attachment in a `Vec<u8>`, so also bound the final
+/// ZIP allocation. ZIP metadata can push a raw selection just below the cap over it.
+const MAX_IMAGE_BUNDLE_BYTES: usize = 5 * 1024 * 1024;
+/// Structured diagnostic logs have their own bounded budget and are independent
+/// from screenshot attachment sampling.
+const MAX_LOG_RAW_BYTES: u64 = 1024 * 1024;
+const MAX_LOG_FILE_BYTES: u64 = 512 * 1024;
+const MAX_LOG_FILES: usize = 128;
+const MAX_IMAGE_FILES: usize = 128;
+/// Bound directory walking independently from file sizes. Limit hits are carried
+/// into the Sentry event as diagnostic warnings.
+const MAX_DISCOVERY_ENTRIES: usize = 8 * 1024;
+const MAX_DISCOVERY_DEPTH: usize = 16;
 /// Filesystems may expose a slightly older mtime than the task-start wall clock.
 const MTIME_TOLERANCE: Duration = Duration::from_secs(2);
 
@@ -30,21 +40,32 @@ pub struct TaskEvidenceStart {
     root: PathBuf,
     started_at: SystemTime,
     log_lengths: BTreeMap<PathBuf, u64>,
-    existing_images: BTreeSet<PathBuf>,
+    existing_images: BTreeMap<PathBuf, FileStamp>,
+    warnings: Vec<String>,
 }
 
 #[derive(Debug)]
 pub struct TaskEvidenceSelection {
     logs: Vec<LogSlice>,
     images: Vec<ImageEntry>,
-    selected_raw_bytes: u64,
+    warnings: Vec<String>,
+    image_root: PathBuf,
+    image_started_at: SystemTime,
+    existing_images: BTreeMap<PathBuf, FileStamp>,
+}
+
+/// A candidate screenshot refresh captured during the bounded post-failure settle
+/// window. The caller must verify that the task evidence epoch is still current
+/// before applying it.
+#[derive(Debug)]
+pub struct TaskImageRefresh {
+    images: Vec<ImageEntry>,
     warnings: Vec<String>,
 }
 
 #[derive(Debug)]
 struct LogSlice {
     source: File,
-    source_path: PathBuf,
     archive_name: String,
     start: u64,
     end: u64,
@@ -56,39 +77,61 @@ struct ImageEntry {
     source_path: PathBuf,
     archive_name: String,
     len: u64,
+    stamp: FileStamp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileStamp {
+    len: u64,
+    modified: Option<SystemTime>,
 }
 
 #[derive(Debug)]
-pub struct TaskBundle {
+pub struct DiagnosticLog {
+    pub source: String,
+    pub kind: &'static str,
+    pub content: String,
+    pub raw_bytes: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct DiagnosticLogs {
+    pub entries: Vec<DiagnosticLog>,
+    pub selected_raw_bytes: u64,
+    pub truncated: bool,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct ImageBundle {
     pub buffer: Vec<u8>,
     pub filename: String,
-    pub log_count: usize,
     pub image_count: usize,
     pub selected_raw_bytes: u64,
     pub warnings: Vec<String>,
 }
 
 #[derive(Debug)]
-pub enum TaskBundleError {
+pub enum ImageBundleError {
     NoEvidence,
     TooLarge {
         selected_raw_bytes: u64,
-        compressed_bytes: Option<usize>,
+        bundle_bytes: Option<usize>,
     },
     Io(String),
 }
 
-impl std::fmt::Display for TaskBundleError {
+impl std::fmt::Display for ImageBundleError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NoEvidence => formatter.write_str("no task-scoped evidence was found"),
             Self::TooLarge {
                 selected_raw_bytes,
-                compressed_bytes,
+                bundle_bytes,
             } => write!(
                 formatter,
-                "task evidence is too large (raw={selected_raw_bytes}, compressed={})",
-                compressed_bytes
+                "task screenshot evidence is too large (raw={selected_raw_bytes}, bundle={})",
+                bundle_bytes
                     .map(|size| size.to_string())
                     .unwrap_or_else(|| "not-built".to_string())
             ),
@@ -100,15 +143,28 @@ impl std::fmt::Display for TaskBundleError {
 /// Snapshot task-relevant file boundaries. Discovery failures are intentionally
 /// best-effort: the eventual Sentry error event must still be sent without a bundle.
 pub fn capture_task_start(root: &Path) -> TaskEvidenceStart {
+    // Record the wall-clock boundary before discovery. A fast failure may write an
+    // on_error image while the directory is being walked; it must not be treated as
+    // predating the task merely because discovery took time.
+    let started_at = SystemTime::now();
     let mut log_lengths = BTreeMap::new();
-    let mut existing_images = BTreeSet::new();
+    let mut existing_images = BTreeMap::new();
+    let (files, warnings) = discover_files(root);
 
-    for path in discover_files(root) {
+    for path in files {
         let Some(relative) = safe_relative_path(root, &path) else {
             continue;
         };
         if is_on_error_image(relative) {
-            existing_images.insert(relative.to_path_buf());
+            if let Ok(metadata) = path.metadata() {
+                let stamp = file_stamp(&metadata);
+                // A screenshot created while discovery is running belongs to this
+                // task, not the pre-task baseline. Unknown mtimes stay in the
+                // baseline because ownership cannot be proven safely.
+                if stamp.modified.is_none_or(|modified| modified < started_at) {
+                    existing_images.insert(relative.to_path_buf(), stamp);
+                }
+            }
         } else if is_log_file(relative) {
             if let Ok(metadata) = path.metadata() {
                 log_lengths.insert(relative.to_path_buf(), metadata.len());
@@ -118,87 +174,181 @@ pub fn capture_task_start(root: &Path) -> TaskEvidenceStart {
 
     TaskEvidenceStart {
         root: root.to_path_buf(),
-        started_at: SystemTime::now(),
+        started_at,
         log_lengths,
         existing_images,
+        warnings,
     }
 }
 
-/// Freeze the end boundary as soon as the outer SavedTask reaches its terminal
-/// callback. Compression may happen later, but a following task cannot expand the
-/// selected ranges or add its screenshots to this attachment.
-pub fn capture_task_end(
-    start: TaskEvidenceStart,
-) -> Result<TaskEvidenceSelection, TaskBundleError> {
+/// Freeze log boundaries and already-visible screenshots as soon as the outer
+/// SavedTask reaches its terminal callback. A bounded, epoch-checked screenshot
+/// refresh may replace or extend the image selection afterward.
+pub fn capture_task_end(start: TaskEvidenceStart) -> TaskEvidenceSelection {
     let (logs, images, warnings) = select_entries(&start);
-    if logs.is_empty() && images.is_empty() {
-        return Err(TaskBundleError::NoEvidence);
-    }
-
-    let selected_raw_bytes = logs
-        .iter()
-        .map(|entry| entry.end.saturating_sub(entry.start))
-        .chain(images.iter().map(|entry| entry.len))
-        .fold(0u64, u64::saturating_add);
-    if selected_raw_bytes > MAX_SELECTED_RAW_BYTES {
-        return Err(TaskBundleError::TooLarge {
-            selected_raw_bytes,
-            compressed_bytes: None,
-        });
-    }
-
-    Ok(TaskEvidenceSelection {
+    TaskEvidenceSelection {
         logs,
         images,
-        selected_raw_bytes,
         warnings,
-    })
+        image_root: start.root,
+        image_started_at: start.started_at,
+        existing_images: start.existing_images,
+    }
 }
 
-/// Build one ZIP attachment from an already-frozen task selection.
-pub fn build_task_bundle(
+/// Capture screenshots visible during the bounded post-failure settle window.
+///
+/// This function only opens stable file generations and returns them as an opaque
+/// candidate. The caller owns the task epoch check and must discard stale candidates.
+pub fn capture_task_image_refresh(selection: &TaskEvidenceSelection) -> TaskImageRefresh {
+    let (images, warnings) = select_images(
+        &selection.image_root,
+        selection.image_started_at,
+        &selection.existing_images,
+    );
+    TaskImageRefresh { images, warnings }
+}
+
+/// Merge a refresh only after its task epoch has been revalidated. Existing stable
+/// handles are retained when the observed generation did not change; growing or
+/// replaced files are upgraded to the newest safely opened generation.
+pub fn apply_task_image_refresh(selection: &mut TaskEvidenceSelection, refresh: TaskImageRefresh) {
+    for image in refresh.images {
+        if let Some(index) = selection
+            .images
+            .iter()
+            .position(|existing| existing.archive_name == image.archive_name)
+        {
+            if selection.images[index].stamp != image.stamp {
+                selection.images[index] = image;
+            }
+        } else {
+            selection.images.push(image);
+        }
+    }
+    selection
+        .images
+        .sort_by(|left, right| left.archive_name.cmp(&right.archive_name));
+    selection.warnings.extend(refresh.warnings);
+    selection.warnings.sort();
+    selection.warnings.dedup();
+}
+
+/// Read bounded log tails from an already-frozen task selection.
+///
+/// Each file contributes at most 512 KiB and all files share a 1 MiB budget. The
+/// tail of every selected range is retained because failure details are normally
+/// emitted last. Limit hits are exposed through `truncated`.
+pub fn build_diagnostic_logs(selection: &mut TaskEvidenceSelection) -> DiagnosticLogs {
+    selection.logs.sort_by(|left, right| {
+        log_priority(&left.archive_name)
+            .cmp(&log_priority(&right.archive_name))
+            .then_with(|| left.archive_name.cmp(&right.archive_name))
+    });
+
+    let mut result = DiagnosticLogs {
+        warnings: std::mem::take(&mut selection.warnings),
+        ..Default::default()
+    };
+    for entry in &mut selection.logs {
+        let remaining_budget = MAX_LOG_RAW_BYTES.saturating_sub(result.selected_raw_bytes);
+        if remaining_budget == 0 {
+            result.truncated = true;
+            break;
+        }
+
+        let selected_len = entry.end.saturating_sub(entry.start);
+        let read_len = selected_len.min(MAX_LOG_FILE_BYTES).min(remaining_budget);
+        if read_len == 0 {
+            continue;
+        }
+        let read_start = entry.end.saturating_sub(read_len);
+        match read_log_slice(entry, read_start, read_len) {
+            Ok(bytes) if !bytes.is_empty() => {
+                let content = String::from_utf8_lossy(&bytes)
+                    .trim_matches('\0')
+                    .to_string();
+                if content.trim().is_empty() {
+                    continue;
+                }
+                result.selected_raw_bytes =
+                    result.selected_raw_bytes.saturating_add(bytes.len() as u64);
+                result.truncated |= read_len < selected_len;
+                result.entries.push(DiagnosticLog {
+                    source: entry.archive_name.clone(),
+                    kind: log_kind(&entry.archive_name),
+                    content,
+                    raw_bytes: bytes.len() as u64,
+                });
+            }
+            Ok(_) => {}
+            Err(error) => result
+                .warnings
+                .push(format!("read_log_failed:{}:{error}", entry.archive_name)),
+        }
+    }
+    result
+}
+
+/// Build a screenshots-only ZIP attachment from an already-frozen task selection.
+pub fn build_image_bundle(
     mut selection: TaskEvidenceSelection,
     run_id: &str,
     maa_task_id: i64,
-) -> Result<TaskBundle, TaskBundleError> {
+) -> Result<ImageBundle, ImageBundleError> {
+    if selection.images.is_empty() {
+        return Err(ImageBundleError::NoEvidence);
+    }
+    let selected_raw_bytes = selection
+        .images
+        .iter()
+        .map(|entry| entry.len)
+        .fold(0u64, u64::saturating_add);
+    if selected_raw_bytes > MAX_IMAGE_RAW_BYTES {
+        return Err(ImageBundleError::TooLarge {
+            selected_raw_bytes,
+            bundle_bytes: None,
+        });
+    }
+
     let cursor = Cursor::new(Vec::new());
     let mut archive = ZipWriter::new(cursor);
-    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+    // PNG/JPEG payloads are already compressed. Deflating them again costs CPU and
+    // commonly makes screenshots slightly larger, while Sentry bills final bytes.
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
 
-    for entry in &mut selection.logs {
-        write_log_slice(&mut archive, entry, options)?;
-    }
     for entry in &mut selection.images {
         write_image(&mut archive, entry, options)?;
     }
 
     let buffer = archive
         .finish()
-        .map_err(|error| TaskBundleError::Io(format!("finish diagnostic ZIP: {error}")))?
+        .map_err(|error| ImageBundleError::Io(format!("finish screenshot ZIP: {error}")))?
         .into_inner();
-    if buffer.len() > MAX_COMPRESSED_BYTES {
-        return Err(TaskBundleError::TooLarge {
-            selected_raw_bytes: selection.selected_raw_bytes,
-            compressed_bytes: Some(buffer.len()),
+    if buffer.len() > MAX_IMAGE_BUNDLE_BYTES {
+        return Err(ImageBundleError::TooLarge {
+            selected_raw_bytes,
+            bundle_bytes: Some(buffer.len()),
         });
     }
 
-    Ok(TaskBundle {
+    Ok(ImageBundle {
         buffer,
-        filename: format!("mxu-task-failure-{run_id}-{maa_task_id}.zip"),
-        log_count: selection.logs.len(),
+        filename: format!("mxu-task-failure-{run_id}-{maa_task_id}-screenshots.zip"),
         image_count: selection.images.len(),
-        selected_raw_bytes: selection.selected_raw_bytes,
-        warnings: selection.warnings,
+        selected_raw_bytes,
+        warnings: Vec::new(),
     })
 }
 
 fn select_entries(start: &TaskEvidenceStart) -> (Vec<LogSlice>, Vec<ImageEntry>, Vec<String>) {
     let mut logs = Vec::new();
     let mut images = Vec::new();
-    let mut warnings = Vec::new();
+    let (files, discovery_warnings) = discover_files(&start.root);
+    let mut warnings = start.warnings.clone();
+    warnings.extend(discovery_warnings);
 
-    for path in discover_files(&start.root) {
+    for path in files {
         let Some(relative) = safe_relative_path(&start.root, &path) else {
             continue;
         };
@@ -216,19 +366,40 @@ fn select_entries(start: &TaskEvidenceStart) -> (Vec<LogSlice>, Vec<ImageEntry>,
         };
 
         if is_on_error_image(relative) {
-            if start.existing_images.contains(relative) || !modified_during_task(&metadata, start) {
+            if images.len() >= MAX_IMAGE_FILES {
+                push_warning(
+                    &mut warnings,
+                    &format!("image_file_limit_reached:{MAX_IMAGE_FILES}"),
+                );
                 continue;
             }
+            if !should_include_image(
+                relative,
+                &metadata,
+                start.started_at,
+                &start.existing_images,
+            ) {
+                continue;
+            }
+            let stamp = file_stamp(&metadata);
             images.push(ImageEntry {
                 source,
                 source_path: path,
                 archive_name,
-                len: metadata.len(),
+                len: stamp.len,
+                stamp,
             });
             continue;
         }
 
         if !is_log_file(relative) {
+            continue;
+        }
+        if logs.len() >= MAX_LOG_FILES {
+            push_warning(
+                &mut warnings,
+                &format!("log_file_limit_reached:{MAX_LOG_FILES}"),
+            );
             continue;
         }
 
@@ -240,7 +411,6 @@ fn select_entries(start: &TaskEvidenceStart) -> (Vec<LogSlice>, Vec<ImageEntry>,
             warnings.push(format!("new_log_included_whole:{archive_name}"));
             logs.push(LogSlice {
                 source,
-                source_path: path,
                 archive_name,
                 start: 0,
                 end,
@@ -251,16 +421,25 @@ fn select_entries(start: &TaskEvidenceStart) -> (Vec<LogSlice>, Vec<ImageEntry>,
         if end > previous_len {
             logs.push(LogSlice {
                 source,
-                source_path: path,
                 archive_name,
                 start: previous_len.saturating_sub(LOG_PRELUDE_BYTES),
+                end,
+            });
+        } else if end == previous_len && end > 0 && modified_during_task(&metadata, start) {
+            // The task may have emitted its complete failure log while the start
+            // snapshot was still walking the directory. Preserve a bounded tail
+            // instead of interpreting an unchanged post-snapshot length as empty.
+            warnings.push(format!("log_changed_during_start_snapshot:{archive_name}"));
+            logs.push(LogSlice {
+                source,
+                archive_name,
+                start: end.saturating_sub(LOG_PRELUDE_BYTES),
                 end,
             });
         } else if end < previous_len && modified_during_task(&metadata, start) && end > 0 {
             warnings.push(format!("rotated_log_included_whole:{archive_name}"));
             logs.push(LogSlice {
                 source,
-                source_path: path,
                 archive_name,
                 start: 0,
                 end,
@@ -270,43 +449,107 @@ fn select_entries(start: &TaskEvidenceStart) -> (Vec<LogSlice>, Vec<ImageEntry>,
 
     logs.sort_by(|left, right| left.archive_name.cmp(&right.archive_name));
     images.sort_by(|left, right| left.archive_name.cmp(&right.archive_name));
+    warnings.sort();
+    warnings.dedup();
     (logs, images, warnings)
 }
 
-fn write_log_slice<W: Write + Seek>(
-    archive: &mut ZipWriter<W>,
-    entry: &mut LogSlice,
-    options: SimpleFileOptions,
-) -> Result<(), TaskBundleError> {
-    entry
-        .source
-        .seek(SeekFrom::Start(entry.start))
-        .map_err(|error| {
-            TaskBundleError::Io(format!(
-                "seek log [{}]: {error}",
-                entry.source_path.display()
-            ))
-        })?;
-    archive
-        .start_file(&entry.archive_name, options)
-        .map_err(|error| TaskBundleError::Io(format!("start ZIP entry: {error}")))?;
-    let mut selected = (&mut entry.source).take(entry.end.saturating_sub(entry.start));
-    io::copy(&mut selected, archive)
-        .map_err(|error| TaskBundleError::Io(format!("write log ZIP entry: {error}")))?;
-    Ok(())
+fn select_images(
+    root: &Path,
+    started_at: SystemTime,
+    existing_images: &BTreeMap<PathBuf, FileStamp>,
+) -> (Vec<ImageEntry>, Vec<String>) {
+    let (files, mut warnings) = discover_files(root);
+    let mut images = Vec::new();
+    for path in files {
+        let Some(relative) = safe_relative_path(root, &path) else {
+            continue;
+        };
+        if !is_on_error_image(relative) {
+            continue;
+        }
+        let Some(archive_name) = normalize_archive_path(relative) else {
+            continue;
+        };
+        let source = match File::open(&path) {
+            Ok(source) => source,
+            Err(error) => {
+                warnings.push(format!("open_image_failed:{archive_name}:{error}"));
+                continue;
+            }
+        };
+        let metadata = match source.metadata() {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                warnings.push(format!("read_image_metadata_failed:{archive_name}:{error}"));
+                continue;
+            }
+        };
+        if !should_include_image(relative, &metadata, started_at, existing_images) {
+            continue;
+        }
+        if images.len() >= MAX_IMAGE_FILES {
+            push_warning(
+                &mut warnings,
+                &format!("image_file_limit_reached:{MAX_IMAGE_FILES}"),
+            );
+            break;
+        }
+        let stamp = file_stamp(&metadata);
+        images.push(ImageEntry {
+            source,
+            source_path: path,
+            archive_name,
+            len: stamp.len,
+            stamp,
+        });
+    }
+    images.sort_by(|left, right| left.archive_name.cmp(&right.archive_name));
+    warnings.sort();
+    warnings.dedup();
+    (images, warnings)
+}
+
+fn should_include_image(
+    relative: &Path,
+    metadata: &std::fs::Metadata,
+    started_at: SystemTime,
+    existing_images: &BTreeMap<PathBuf, FileStamp>,
+) -> bool {
+    if !modified_since(metadata, started_at) {
+        return false;
+    }
+    existing_images
+        .get(relative)
+        .is_none_or(|previous| *previous != file_stamp(metadata))
+}
+
+fn file_stamp(metadata: &std::fs::Metadata) -> FileStamp {
+    FileStamp {
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    }
+}
+
+fn read_log_slice(entry: &mut LogSlice, start: u64, len: u64) -> Result<Vec<u8>, io::Error> {
+    entry.source.seek(SeekFrom::Start(start))?;
+    let mut selected = (&mut entry.source).take(len);
+    let mut bytes = Vec::with_capacity(len.min(usize::MAX as u64) as usize);
+    selected.read_to_end(&mut bytes)?;
+    Ok(bytes)
 }
 
 fn write_image<W: Write + Seek>(
     archive: &mut ZipWriter<W>,
     entry: &mut ImageEntry,
     options: SimpleFileOptions,
-) -> Result<(), TaskBundleError> {
+) -> Result<(), ImageBundleError> {
     archive
         .start_file(&entry.archive_name, options)
-        .map_err(|error| TaskBundleError::Io(format!("start ZIP entry: {error}")))?;
+        .map_err(|error| ImageBundleError::Io(format!("start ZIP entry: {error}")))?;
     let mut selected = (&mut entry.source).take(entry.len);
     io::copy(&mut selected, archive).map_err(|error| {
-        TaskBundleError::Io(format!(
+        ImageBundleError::Io(format!(
             "write attachment [{}]: {error}",
             entry.source_path.display()
         ))
@@ -314,22 +557,49 @@ fn write_image<W: Write + Seek>(
     Ok(())
 }
 
-fn discover_files(root: &Path) -> Vec<PathBuf> {
+fn discover_files(root: &Path) -> (Vec<PathBuf>, Vec<String>) {
     if !root.is_dir() {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     }
 
     let mut files = Vec::new();
-    let mut pending = vec![root.to_path_buf()];
-    while let Some(directory) = pending.pop() {
-        let Ok(entries) = std::fs::read_dir(&directory) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let Ok(file_type) = entry.file_type() else {
+    let mut warnings = Vec::new();
+    let mut pending = vec![(root.to_path_buf(), 0usize)];
+    let mut visited_entries = 0usize;
+    'walk: while let Some((directory, depth)) = pending.pop() {
+        let entries = match std::fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(_) => {
+                push_warning(&mut warnings, "discovery_read_directory_failed");
                 continue;
+            }
+        };
+        for entry in entries {
+            if visited_entries >= MAX_DISCOVERY_ENTRIES {
+                push_warning(
+                    &mut warnings,
+                    &format!("discovery_entry_limit_reached:{MAX_DISCOVERY_ENTRIES}"),
+                );
+                break 'walk;
+            }
+            visited_entries += 1;
+
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => {
+                    push_warning(&mut warnings, "discovery_read_entry_failed");
+                    continue;
+                }
+            };
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => {
+                    push_warning(&mut warnings, "discovery_file_type_failed");
+                    continue;
+                }
             };
             if file_type.is_symlink() {
+                push_warning(&mut warnings, "discovery_symlink_skipped");
                 continue;
             }
             let path = entry.path();
@@ -338,13 +608,26 @@ fn discover_files(root: &Path) -> Vec<PathBuf> {
                 if first_component_is(relative, "vision") {
                     continue;
                 }
-                pending.push(path);
+                if depth >= MAX_DISCOVERY_DEPTH {
+                    push_warning(
+                        &mut warnings,
+                        &format!("discovery_depth_limit_reached:{MAX_DISCOVERY_DEPTH}"),
+                    );
+                    continue;
+                }
+                pending.push((path, depth + 1));
             } else if file_type.is_file() {
                 files.push(path);
             }
         }
     }
-    files
+    (files, warnings)
+}
+
+fn push_warning(warnings: &mut Vec<String>, warning: &str) {
+    if !warnings.iter().any(|existing| existing == warning) {
+        warnings.push(warning.to_string());
+    }
 }
 
 fn safe_relative_path<'a>(root: &Path, path: &'a Path) -> Option<&'a Path> {
@@ -392,6 +675,32 @@ fn is_log_file(relative: &Path) -> bool {
         .is_some_and(|name| name.ends_with(".log") || name.contains(".log."))
 }
 
+fn log_priority(path: &str) -> u8 {
+    let file_name = Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if file_name.starts_with("maafw.log") {
+        0
+    } else if file_name.starts_with("maa.log") {
+        1
+    } else if file_name.starts_with("mxu") || file_name.starts_with("log-") {
+        2
+    } else {
+        3
+    }
+}
+
+fn log_kind(path: &str) -> &'static str {
+    match log_priority(path) {
+        0 => "maafw",
+        1 => "maa",
+        2 => "mxu",
+        _ => "other",
+    }
+}
+
 fn is_on_error_image(relative: &Path) -> bool {
     if !first_component_is(relative, "on_error") {
         return false;
@@ -404,10 +713,14 @@ fn is_on_error_image(relative: &Path) -> bool {
 }
 
 fn modified_during_task(metadata: &std::fs::Metadata, start: &TaskEvidenceStart) -> bool {
+    modified_since(metadata, start.started_at)
+}
+
+fn modified_since(metadata: &std::fs::Metadata, started_at: SystemTime) -> bool {
     metadata.modified().is_ok_and(|modified| {
         modified
             .checked_add(MTIME_TOLERANCE)
-            .is_some_and(|adjusted| adjusted >= start.started_at)
+            .is_some_and(|adjusted| adjusted >= started_at)
     })
 }
 
@@ -437,6 +750,18 @@ mod tests {
         entries
     }
 
+    fn zip_compression_methods(buffer: &[u8]) -> Vec<zip::CompressionMethod> {
+        let mut archive = zip::ZipArchive::new(Cursor::new(buffer)).expect("open ZIP");
+        (0..archive.len())
+            .map(|index| {
+                archive
+                    .by_index(index)
+                    .expect("read ZIP entry")
+                    .compression()
+            })
+            .collect()
+    }
+
     #[test]
     fn bundles_only_appended_logs_and_new_on_error_images() {
         let root = test_root();
@@ -453,22 +778,59 @@ mod tests {
         log.write_all(b"task-log\n").expect("append task log");
         std::fs::write(root.join("on_error/new.png"), b"new-image").expect("write image");
 
-        let selection = capture_task_end(start).expect("capture task end");
+        let mut selection = capture_task_end(start);
         log.write_all(b"next-task-log\n")
             .expect("append next task log");
         std::fs::write(root.join("on_error/next.png"), b"next-image").expect("write next image");
-        let bundle = build_task_bundle(selection, "run", 42).expect("build bundle");
+        let logs = build_diagnostic_logs(&mut selection);
+        let bundle = build_image_bundle(selection, "run", 42).expect("build image bundle");
+        let compression_methods = zip_compression_methods(&bundle.buffer);
+        assert!(bundle.buffer.len() <= MAX_IMAGE_BUNDLE_BYTES);
         let entries = zip_entries(bundle.buffer);
-        assert_eq!(bundle.log_count, 1);
+        assert_eq!(logs.entries.len(), 1);
         assert_eq!(bundle.image_count, 1);
-        assert!(entries["maafw.log"].ends_with(b"task-log\n"));
+        assert!(logs.entries[0].content.ends_with("task-log\n"));
         assert_eq!(entries["on_error/new.png"], b"new-image");
-        assert!(!entries["maafw.log"]
-            .windows(b"next-task-log".len())
-            .any(|window| window == b"next-task-log"));
+        assert_eq!(compression_methods, vec![zip::CompressionMethod::Stored]);
+        assert!(!logs.entries[0].content.contains("next-task-log"));
+        assert!(!entries.contains_key("maafw.log"));
         assert!(!entries.contains_key("on_error/old.png"));
         assert!(!entries.contains_key("on_error/next.png"));
         assert!(!entries.contains_key("vision/ignored.png"));
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn includes_an_existing_screenshot_path_when_its_generation_changes() {
+        let root = test_root();
+        let image_path = root.join("on_error/failure.png");
+        std::fs::write(&image_path, b"old").expect("write old image");
+
+        let start = capture_task_start(&root);
+        std::fs::write(&image_path, b"new-image-generation").expect("overwrite image");
+
+        let selection = capture_task_end(start);
+        let bundle = build_image_bundle(selection, "run", 43).expect("build image bundle");
+        let entries = zip_entries(bundle.buffer);
+        assert_eq!(entries["on_error/failure.png"], b"new-image-generation");
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn late_screenshot_refresh_can_be_applied_after_an_empty_terminal_snapshot() {
+        let root = test_root();
+        let start = capture_task_start(&root);
+        let mut selection = capture_task_end(start);
+
+        std::fs::write(root.join("on_error/late.png"), b"late-image").expect("write late image");
+        let refresh = capture_task_image_refresh(&selection);
+        apply_task_image_refresh(&mut selection, refresh);
+
+        let bundle = build_image_bundle(selection, "run", 44).expect("build image bundle");
+        let entries = zip_entries(bundle.buffer);
+        assert_eq!(entries["on_error/late.png"], b"late-image");
 
         std::fs::remove_dir_all(&root).expect("remove test directory");
     }
@@ -489,12 +851,15 @@ mod tests {
             .expect("open nested log");
         nested.write_all(b"failure\n").expect("append nested log");
 
-        let selection = capture_task_end(start).expect("capture task end");
-        let bundle = build_task_bundle(selection, "run", 7).expect("build bundle");
-        let entries = zip_entries(bundle.buffer);
-        assert!(entries.contains_key("cpp-algo/debug/maafw.log"));
-        assert!(!entries.contains_key("config.json"));
-        assert!(!entries.contains_key("process.dmp"));
+        let mut selection = capture_task_end(start);
+        let logs = build_diagnostic_logs(&mut selection);
+        assert_eq!(logs.entries.len(), 1);
+        assert_eq!(logs.entries[0].source, "cpp-algo/debug/maafw.log");
+        assert!(logs.entries[0].content.contains("failure"));
+        assert!(matches!(
+            build_image_bundle(selection, "run", 7),
+            Err(ImageBundleError::NoEvidence)
+        ));
 
         std::fs::remove_dir_all(&root).expect("remove test directory");
     }
@@ -516,22 +881,143 @@ mod tests {
         drop(log);
         std::fs::write(&image_path, b"selected-image").expect("write selected image");
 
-        let selection = capture_task_end(start).expect("capture task end");
+        let mut selection = capture_task_end(start);
         std::fs::rename(&log_path, root.join("maafw.log.1")).expect("rotate selected log");
         std::fs::write(&log_path, b"replacement-generation\n").expect("write replacement log");
         std::fs::rename(&image_path, root.join("on_error/failure-old.png"))
             .expect("rotate selected image");
         std::fs::write(&image_path, b"replacement-image").expect("write replacement image");
 
-        let bundle = build_task_bundle(selection, "run", 9).expect("build bundle");
+        let logs = build_diagnostic_logs(&mut selection);
+        let bundle = build_image_bundle(selection, "run", 9).expect("build image bundle");
         let entries = zip_entries(bundle.buffer);
-        assert!(entries["maafw.log"]
-            .windows(b"selected-failure".len())
-            .any(|window| window == b"selected-failure"));
-        assert!(!entries["maafw.log"]
-            .windows(b"replacement-generation".len())
-            .any(|window| window == b"replacement-generation"));
+        assert!(logs.entries[0].content.contains("selected-failure"));
+        assert!(!logs.entries[0].content.contains("replacement-generation"));
+        assert!(!entries.contains_key("maafw.log"));
         assert_eq!(entries["on_error/failure.png"], b"selected-image");
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn bounds_structured_logs_per_file_and_in_total() {
+        let root = test_root();
+        let first = root.join("maafw.log");
+        let second = root.join("agent.log");
+        std::fs::write(&first, b"before\n").expect("write first log");
+        std::fs::write(&second, b"before\n").expect("write second log");
+
+        let start = capture_task_start(&root);
+        for path in [&first, &second] {
+            let mut log = std::fs::OpenOptions::new()
+                .append(true)
+                .open(path)
+                .expect("open log");
+            log.write_all(&vec![b'x'; 700 * 1024])
+                .expect("append oversized log");
+        }
+
+        let mut selection = capture_task_end(start);
+        let logs = build_diagnostic_logs(&mut selection);
+        assert_eq!(logs.entries.len(), 2);
+        assert_eq!(logs.selected_raw_bytes, MAX_LOG_RAW_BYTES);
+        assert!(logs
+            .entries
+            .iter()
+            .all(|entry| entry.raw_bytes <= MAX_LOG_FILE_BYTES));
+        assert!(logs.truncated);
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn retains_log_tail_written_during_the_start_snapshot() {
+        let root = test_root();
+        let log_path = root.join("maafw.log");
+        std::fs::write(&log_path, b"failure-before-snapshot-finished\n")
+            .expect("write early failure log");
+        let mut start = capture_task_start(&root);
+        // Model a snapshot whose wall-clock boundary preceded the write while its
+        // recorded file length already included it.
+        start.started_at = SystemTime::UNIX_EPOCH;
+
+        let mut selection = capture_task_end(start);
+        let logs = build_diagnostic_logs(&mut selection);
+        assert_eq!(logs.entries.len(), 1);
+        assert!(logs.entries[0]
+            .content
+            .contains("failure-before-snapshot-finished"));
+        assert!(logs
+            .warnings
+            .iter()
+            .any(|warning| warning.starts_with("log_changed_during_start_snapshot:")));
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn rejects_oversized_screenshot_sets_before_bundling() {
+        let root = test_root();
+        let start = capture_task_start(&root);
+        let image_path = root.join("on_error/oversized.png");
+        let image = File::create(&image_path).expect("create oversized image");
+        image
+            .set_len(MAX_IMAGE_RAW_BYTES + 1)
+            .expect("extend oversized image");
+
+        let mut selection = capture_task_end(start);
+        let logs = build_diagnostic_logs(&mut selection);
+        assert!(logs.entries.is_empty());
+        assert!(matches!(
+            build_image_bundle(selection, "run", 11),
+            Err(ImageBundleError::TooLarge {
+                selected_raw_bytes,
+                bundle_bytes: None,
+            }) if selected_raw_bytes == MAX_IMAGE_RAW_BYTES + 1
+        ));
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn rejects_zip_metadata_that_pushes_a_bundle_over_the_hard_limit() {
+        let root = test_root();
+        let start = capture_task_start(&root);
+        let image_path = root.join("on_error/at-limit.png");
+        let image = File::create(&image_path).expect("create at-limit image");
+        image
+            .set_len(MAX_IMAGE_RAW_BYTES)
+            .expect("extend at-limit image");
+
+        let selection = capture_task_end(start);
+        assert!(matches!(
+            build_image_bundle(selection, "run", 12),
+            Err(ImageBundleError::TooLarge {
+                selected_raw_bytes,
+                bundle_bytes: Some(bundle_bytes),
+            }) if selected_raw_bytes == MAX_IMAGE_RAW_BYTES
+                && bundle_bytes > MAX_IMAGE_BUNDLE_BYTES
+        ));
+
+        std::fs::remove_dir_all(&root).expect("remove test directory");
+    }
+
+    #[test]
+    fn reports_directory_depth_limit_as_diagnostic_warning() {
+        let root = test_root();
+        let mut directory = root.clone();
+        for index in 0..=MAX_DISCOVERY_DEPTH {
+            directory = directory.join(format!("level-{index}"));
+            std::fs::create_dir(&directory).expect("create nested directory");
+        }
+
+        let start = capture_task_start(&root);
+        let mut selection = capture_task_end(start);
+        let logs = build_diagnostic_logs(&mut selection);
+        assert!(logs.entries.is_empty());
+        assert!(logs.warnings.iter().any(|warning| {
+            warning == &format!("discovery_depth_limit_reached:{MAX_DISCOVERY_DEPTH}")
+        }));
 
         std::fs::remove_dir_all(&root).expect("remove test directory");
     }

--- a/src-tauri/src/commands/telemetry.rs
+++ b/src-tauri/src/commands/telemetry.rs
@@ -7,21 +7,26 @@
 //! - DSN 仅来自 interface.json 的 `telemetry.sentry.dsn`；空 DSN 或未开启时不初始化、不上报。
 //! - 初始化发生在 Tauri `setup()`（早于前端），使 WebView 起来之前的崩溃也能覆盖。
 //! - 用户开关（帮助改进软件）与构建期闸门（调试 / 开发版本）都在本模块判定。
-//! - 隐私：`send_default_pii = false`，仅上报哈希机器 ID、硬件摘要、版本、任务名、脱敏后的选项与结果。
+//! - `send_default_pii = false`；任务附件与现有“帮助改进软件”遥测开关共同启停。
 //! - 网络：SDK 后台异步发送、队列有界，不阻塞主流程；`shutdown_timeout` 设小值避免退出卡顿。
 //! - 事件模型：一次进程运行 = 一个 Session（Release Health），
 //!   一次整批运行 = 一个 Transaction，每个 SavedTask = 一个 child Span，
-//!   每个失败的 pipeline 节点 = 该任务 Span 下的一个 child Span。
+//!   每个失败的 pipeline 节点 = 该任务 Span 下的一个 child Span；外层 SavedTask
+//!   终态失败时再产生一条可聚类的 Error Event，并可附一份任务级诊断包。
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
+use super::task_diagnostics::{self, TaskBundle, TaskBundleError, TaskEvidenceStart};
 use super::types::ControllerInfo;
+use super::utils::get_logs_dir;
 use super::AppConfigState;
 
 /// Sentry 客户端守卫；持有期间遥测生效，置为 None 即关闭并 flush。
@@ -32,6 +37,14 @@ static TELEMETRY_CONFIG: Mutex<Option<TelemetryInitConfig>> = Mutex::new(None);
 static MACHINE_ID: OnceLock<String> = OnceLock::new();
 /// 进行中的运行遥测状态，按 instance_id 索引。
 static RUNS: Mutex<BTreeMap<String, RunState>> = Mutex::new(BTreeMap::new());
+/// 每次有实例开始整批运行时递增，用于发现任务证据区间内出现的其他运行实例。
+static EVIDENCE_EPOCH: AtomicU64 = AtomicU64::new(0);
+/// 退出或用户关闭遥测后不再接受新的附件 worker。
+static FAILURE_WORKERS_CLOSING: AtomicBool = AtomicBool::new(false);
+/// 串行化失败事件提交与 Sentry guard 的释放，避免退出竞态丢事件。
+static FAILURE_EVENT_SEND_LOCK: Mutex<()> = Mutex::new(());
+/// 待完成的附件 worker；退出时从这里生成无附件兜底事件。
+static PENDING_FAILURE_WORKERS: OnceLock<PendingFailureWorkers> = OnceLock::new();
 
 /// 前端传入的初始化配置（camelCase 对应 invoke 参数）。
 #[derive(Debug, Clone, Deserialize)]
@@ -49,6 +62,9 @@ pub struct TelemetryInitConfig {
     pub tracing: bool,
     /// 事务采样率 0~1。
     pub traces_sample_rate: f32,
+    /// 失败附件独立采样率 0~1；Error Event 本身不受此值影响。
+    #[serde(default = "default_sample_rate")]
+    pub failure_attachments_sample_rate: f32,
     /// 资源项目名（interface.name）。
     pub app_name: String,
     /// 资源项目版本（interface.version）。
@@ -59,6 +75,8 @@ pub struct TelemetryInitConfig {
 
 /// 单次整批运行的遥测状态。
 struct RunState {
+    /// 单次整批运行的随机关联 ID，同时写入本地日志与 Sentry。
+    run_id: String,
     /// 整批运行对应的 Transaction。
     transaction: sentry::TransactionOrSpan,
     /// 每个 SavedTask（maa_task_id）对应的 child Span。
@@ -69,6 +87,10 @@ struct RunState {
     last_steps: HashMap<i64, (i64, Instant)>,
     /// 各任务已上报的失败节点数（maa_task_id → 计数），用于限流。
     failed_nodes: HashMap<i64, u32>,
+    /// 各外层任务最后一个直接观测到的失败节点，用于终态失败事件的稳定分组。
+    failure_signals: HashMap<i64, FailureSignal>,
+    /// 各外层任务的运行时间和可选文件边界。
+    task_runtime: HashMap<i64, TaskRuntime>,
     /// 当前正在执行的外层 SavedTask id。
     ///
     /// Tasker 用单线程 AsyncRunner 串行执行 posted task，同一时刻至多一个，
@@ -78,6 +100,134 @@ struct RunState {
     tags: BTreeMap<String, String>,
     /// 是否已有任务失败。
     has_failed: bool,
+    /// 本次运行创建时的项目与附件配置，避免运行中切换项目导致事件错配。
+    event_config: FailureEventConfig,
+}
+
+#[derive(Debug, Clone, Default)]
+struct FailureEventConfig {
+    app_name: String,
+    app_version: String,
+    mxu_version: String,
+    failure_attachments_sample_rate: f32,
+}
+
+impl From<&TelemetryInitConfig> for FailureEventConfig {
+    fn from(config: &TelemetryInitConfig) -> Self {
+        Self {
+            app_name: config.app_name.clone(),
+            app_version: config.app_version.clone(),
+            mxu_version: config.mxu_version.clone(),
+            failure_attachments_sample_rate: config.failure_attachments_sample_rate.clamp(0.0, 1.0),
+        }
+    }
+}
+
+struct TaskRuntime {
+    started_at: Instant,
+    started_wall_time: SystemTime,
+    evidence_start: Option<TaskEvidenceStart>,
+    evidence_isolated: bool,
+    evidence_epoch: u64,
+}
+
+#[derive(Debug, Clone)]
+struct FailureSignal {
+    node: String,
+    stage: String,
+    source_task_id: i64,
+    node_id: Option<i64>,
+    duration_ms: Option<u64>,
+}
+
+#[derive(Clone)]
+struct TaskFailureReport {
+    run_id: String,
+    maa_task_id: i64,
+    task: TaskMeta,
+    duration_ms: Option<u64>,
+    started_wall_time: Option<SystemTime>,
+    failure: Option<FailureSignal>,
+    failed_node_count: u32,
+    trace_context: Option<sentry::protocol::TraceContext>,
+    tags: BTreeMap<String, String>,
+    event_config: FailureEventConfig,
+    evidence_start: Option<TaskEvidenceStart>,
+    evidence_isolated: bool,
+    evidence_epoch: u64,
+}
+
+struct PendingFailureWorkers {
+    next_id: AtomicU64,
+    reports: Mutex<BTreeMap<u64, TaskFailureReport>>,
+    idle: Condvar,
+}
+
+impl PendingFailureWorkers {
+    fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            reports: Mutex::new(BTreeMap::new()),
+            idle: Condvar::new(),
+        }
+    }
+
+    fn register(&self, report: TaskFailureReport) -> Option<u64> {
+        let mut reports = self
+            .reports
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if FAILURE_WORKERS_CLOSING.load(Ordering::SeqCst) {
+            return None;
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        reports.insert(id, report);
+        Some(id)
+    }
+
+    fn take(&self, id: u64) -> Option<TaskFailureReport> {
+        let report = self
+            .reports
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&id);
+        if report.is_some() {
+            self.idle.notify_all();
+        }
+        report
+    }
+
+    fn wait_until_idle(&self, timeout: Duration) -> bool {
+        let reports = self
+            .reports
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if reports.is_empty() {
+            return true;
+        }
+        let (reports, _) = self
+            .idle
+            .wait_timeout_while(reports, timeout, |reports| !reports.is_empty())
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reports.is_empty()
+    }
+
+    fn drain(&self) -> Vec<TaskFailureReport> {
+        let reports = std::mem::take(
+            &mut *self
+                .reports
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        );
+        if !reports.is_empty() {
+            self.idle.notify_all();
+        }
+        reports.into_values().collect()
+    }
+
+    fn cancel_all(&self) {
+        self.drain();
+    }
 }
 
 /// 单个任务最多上报的失败节点数。
@@ -85,6 +235,8 @@ struct RunState {
 /// SDK 对单个 Transaction 有 1000 个 Span 的硬上限且超出后静默丢弃，
 /// 这里主动限流是为了不让某个反复失败的长任务挤掉其他任务的 Span。
 const MAX_FAILED_NODES_PER_TASK: u32 = 32;
+/// 退出时给已经开始压缩的附件一个短暂完成窗口；超时则发送无附件兜底事件。
+const FAILURE_WORKER_DRAIN_TIMEOUT: Duration = Duration::from_millis(750);
 
 /// 单个 SavedTask 的遥测元数据，由前端在提交任务时给出。
 #[derive(Debug, Clone, Default)]
@@ -102,6 +254,14 @@ struct HardwareInfo {
     memory_total_mb: u64,
     gpu: String,
     os: String,
+}
+
+const fn default_sample_rate() -> f32 {
+    1.0
+}
+
+fn pending_failure_workers() -> &'static PendingFailureWorkers {
+    PENDING_FAILURE_WORKERS.get_or_init(PendingFailureWorkers::new)
 }
 
 /// 遥测是否处于激活状态（已初始化且客户端存在）。
@@ -199,6 +359,10 @@ fn build_startup_config(app_config: &AppConfigState) -> Option<TelemetryInitConf
             .unwrap_or(true),
         traces_sample_rate: sentry_cfg
             .get("traces_sample_rate")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(1.0) as f32,
+        failure_attachments_sample_rate: sentry_cfg
+            .get("failure_attachments_sample_rate")
             .and_then(|v| v.as_f64())
             .unwrap_or(1.0) as f32,
         app_name,
@@ -325,6 +489,12 @@ pub fn telemetry_set_enabled(enabled: bool) {
         return;
     }
 
+    FAILURE_WORKERS_CLOSING.store(true, Ordering::SeqCst);
+    let _send_guard = FAILURE_EVENT_SEND_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // 用户主动关闭后不得再发送排队中的事件或附件。
+    pending_failure_workers().cancel_all();
     // 先正常结束 Session，否则它会一直挂着并最终被判为 abnormal，拉低 crash-free 率
     if is_active() {
         sentry::end_session_with_status(sentry::protocol::SessionStatus::Exited);
@@ -347,6 +517,8 @@ pub fn on_app_exit() {
         return;
     }
 
+    FAILURE_WORKERS_CLOSING.store(true, Ordering::SeqCst);
+
     // 退出时仍在跑的整批运行按取消收尾，避免整条 Transaction 丢失
     let pending: Vec<String> = RUNS
         .lock()
@@ -356,13 +528,38 @@ pub fn on_app_exit() {
         finish_run(&instance_id, Some(sentry::protocol::SpanStatus::Cancelled));
     }
 
+    let workers = pending_failure_workers();
+    let workers_completed = workers.wait_until_idle(FAILURE_WORKER_DRAIN_TIMEOUT);
+    let _send_guard = FAILURE_EVENT_SEND_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Worker 超时后保留 Error Event，只有附件被省略。发送锁保证后台线程
+    // 无法在这里与 guard 释放交错，也不会产生重复事件。
+    let fallback_reports = workers.drain();
+    let fallback_count = fallback_reports.len();
+    for report in fallback_reports {
+        capture_failure_event(
+            report,
+            FailureAttachmentOutcome::Omitted {
+                status: "shutdown_fallback",
+                detail: "attachment worker did not finish before telemetry shutdown".to_string(),
+                selected_raw_bytes: None,
+                compressed_bytes: None,
+            },
+        );
+    }
+
     sentry::end_session_with_status(sentry::protocol::SessionStatus::Exited);
 
     // 丢弃守卫触发 flush（上限为 shutdown_timeout）
     if let Ok(mut slot) = TELEMETRY_GUARD.lock() {
         *slot = None;
     }
-    log::info!("[telemetry] 已结束 Session 并 flush");
+    log::info!(
+        "[telemetry] 已结束 Session 并 flush workers_completed={} fallback_events={}",
+        workers_completed,
+        fallback_count
+    );
 }
 
 /// 实际执行 Sentry 初始化并配置 scope。
@@ -380,6 +577,9 @@ fn do_init(config: &TelemetryInitConfig) {
     } else {
         0.0
     };
+
+    pending_failure_workers().cancel_all();
+    FAILURE_WORKERS_CLOSING.store(false, Ordering::SeqCst);
 
     let guard = sentry::init(sentry::ClientOptions {
         dsn: Some(dsn),
@@ -505,21 +705,38 @@ fn collect_gpu() -> String {
 
 // ============ 任务事件埋点 ============
 
+fn evidence_isolated_for_ids<'a>(
+    current_instance: &str,
+    mut running_instances: impl Iterator<Item = &'a str>,
+) -> bool {
+    !running_instances.any(|running_id| running_id != current_instance)
+}
+
 /// 整批运行开始：创建 Transaction，并记录本次使用的 controller。
 pub fn on_run_start(instance_id: &str, task_names: &[String], controller: Option<&ControllerInfo>) {
     if !is_active() {
         return;
     }
 
+    // A new run may write to the same process-wide debug directory. Active tasks
+    // compare this epoch at their terminal callback and omit ambiguous evidence.
+    EVIDENCE_EPOCH.fetch_add(1, Ordering::SeqCst);
+    let run_id = sentry::types::random_uuid().to_string();
+    let event_config = TELEMETRY_CONFIG
+        .lock()
+        .ok()
+        .and_then(|config| config.as_ref().map(FailureEventConfig::from))
+        .unwrap_or_default();
     let ctx = sentry::TransactionContext::new("mxu.task_run", "mxu.run");
     let transaction: sentry::TransactionOrSpan = sentry::start_transaction(ctx).into();
+    transaction.set_data("run_id", run_id.clone().into());
     transaction.set_data("task_count", (task_names.len() as u64).into());
     if !task_names.is_empty() {
         transaction.set_data("tasks", task_names.join(",").into());
     }
 
     // controller 既写 data（事件详情可见）又留作 tag（Sentry 中可搜索 / 分组）
-    let mut tags = BTreeMap::new();
+    let mut tags = BTreeMap::from([("run.id".to_string(), run_id.clone())]);
     if let Some(controller) = controller {
         for (key, value) in [
             ("controller.name", controller.name.as_deref()),
@@ -537,17 +754,22 @@ pub fn on_run_start(instance_id: &str, task_names: &[String], controller: Option
         runs.insert(
             instance_id.to_string(),
             RunState {
+                run_id: run_id.clone(),
                 transaction,
                 children: HashMap::new(),
                 metas: HashMap::new(),
                 last_steps: HashMap::new(),
                 failed_nodes: HashMap::new(),
+                failure_signals: HashMap::new(),
+                task_runtime: HashMap::new(),
                 active_task: None,
                 tags,
                 has_failed: false,
+                event_config,
             },
         );
     }
+    log::info!("[telemetry] run started run_id={run_id} instance_id={instance_id}");
 }
 
 /// 提交任务期间的元数据登记句柄，持有遥测状态锁。
@@ -594,18 +816,57 @@ pub fn on_task_start(instance_id: &str, maa_task_id: i64) {
         return;
     }
 
-    if let Ok(mut runs) = RUNS.lock() {
+    let capture_evidence = if let Ok(mut runs) = RUNS.lock() {
+        let evidence_isolated =
+            evidence_isolated_for_ids(instance_id, runs.keys().map(String::as_str));
+        let evidence_epoch = EVIDENCE_EPOCH.load(Ordering::SeqCst);
         if let Some(run) = runs.get_mut(instance_id) {
             let meta = run.metas.get(&maa_task_id).cloned().unwrap_or_default();
             let span: sentry::TransactionOrSpan =
                 run.transaction.start_child("mxu.task", &meta.name).into();
+            span.set_data("run_id", run.run_id.clone().into());
             span.set_data("task", meta.name.clone().into());
             span.set_data("task_id", maa_task_id.into());
             for (key, value) in &meta.options {
                 span.set_data(&format!("option.{key}"), value.clone().into());
             }
             run.children.insert(maa_task_id, span);
+            run.task_runtime.insert(
+                maa_task_id,
+                TaskRuntime {
+                    started_at: Instant::now(),
+                    started_wall_time: SystemTime::now(),
+                    evidence_start: None,
+                    evidence_isolated,
+                    evidence_epoch,
+                },
+            );
             run.active_task = Some(maa_task_id);
+            evidence_isolated
+                && should_sample_attachment(
+                    &run.run_id,
+                    maa_task_id,
+                    run.event_config.failure_attachments_sample_rate,
+                )
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    // Filesystem discovery can be slower than a state update, so do it without the
+    // telemetry-state lock. The prelude in the bundle builder covers lines written
+    // between the callback and this snapshot.
+    if capture_evidence {
+        let evidence_start = task_diagnostics::capture_task_start(&get_logs_dir());
+        if let Ok(mut runs) = RUNS.lock() {
+            if let Some(runtime) = runs
+                .get_mut(instance_id)
+                .and_then(|run| run.task_runtime.get_mut(&maa_task_id))
+            {
+                runtime.evidence_start = Some(evidence_start);
+            }
         }
     }
 }
@@ -713,6 +974,16 @@ fn record_failed_node(
 
     let count = run.failed_nodes.entry(owner_id).or_insert(0);
     *count += 1;
+    run.failure_signals.insert(
+        owner_id,
+        FailureSignal {
+            node: node.to_string(),
+            stage: stage.to_string(),
+            source_task_id: task_id,
+            node_id,
+            duration_ms: stuck_ms,
+        },
+    );
     if *count > MAX_FAILED_NODES_PER_TASK {
         return;
     }
@@ -744,17 +1015,23 @@ pub fn on_task_finished(instance_id: &str, maa_task_id: i64, success: bool) {
         return;
     }
 
-    if let Ok(mut runs) = RUNS.lock() {
+    let report = if let Ok(mut runs) = RUNS.lock() {
         if let Some(run) = runs.get_mut(instance_id) {
             if !success {
                 run.has_failed = true;
             }
-            run.metas.remove(&maa_task_id);
+            let task = run.metas.remove(&maa_task_id).unwrap_or_default();
+            let runtime = run.task_runtime.remove(&maa_task_id);
             run.last_steps.remove(&maa_task_id);
-            run.failed_nodes.remove(&maa_task_id);
+            let failed_node_count = run.failed_nodes.remove(&maa_task_id).unwrap_or(0);
+            let failure = run.failure_signals.remove(&maa_task_id);
             if run.active_task == Some(maa_task_id) {
                 run.active_task = None;
             }
+            let trace_context = run
+                .children
+                .get(&maa_task_id)
+                .map(|span| span.get_trace_context());
             if let Some(span) = run.children.remove(&maa_task_id) {
                 span.set_data("result", if success { "success" } else { "failure" }.into());
                 span.set_status(if success {
@@ -764,8 +1041,430 @@ pub fn on_task_finished(instance_id: &str, maa_task_id: i64, success: bool) {
                 });
                 span.finish();
             }
+
+            if success {
+                None
+            } else {
+                let (
+                    duration_ms,
+                    started_wall_time,
+                    evidence_start,
+                    evidence_isolated,
+                    evidence_epoch,
+                ) = runtime
+                    .map(|runtime| {
+                        (
+                            Some(runtime.started_at.elapsed().as_millis() as u64),
+                            Some(runtime.started_wall_time),
+                            runtime.evidence_start,
+                            runtime.evidence_isolated,
+                            runtime.evidence_epoch,
+                        )
+                    })
+                    .unwrap_or((
+                        None,
+                        None,
+                        None,
+                        true,
+                        EVIDENCE_EPOCH.load(Ordering::SeqCst),
+                    ));
+                Some(TaskFailureReport {
+                    run_id: run.run_id.clone(),
+                    maa_task_id,
+                    task,
+                    duration_ms,
+                    started_wall_time,
+                    failure,
+                    failed_node_count,
+                    trace_context,
+                    tags: run.tags.clone(),
+                    event_config: run.event_config.clone(),
+                    evidence_start,
+                    evidence_isolated,
+                    evidence_epoch,
+                })
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    if let Some(report) = report {
+        submit_failure_report(report);
+    }
+}
+
+enum FailureAttachmentOutcome {
+    NotSelected,
+    Attached(TaskBundle),
+    Omitted {
+        status: &'static str,
+        detail: String,
+        selected_raw_bytes: Option<u64>,
+        compressed_bytes: Option<usize>,
+    },
+}
+
+fn submit_failure_report(mut report: TaskFailureReport) {
+    if !report.evidence_isolated {
+        report.evidence_start = None;
+        send_failure_event(
+            report,
+            FailureAttachmentOutcome::Omitted {
+                status: "concurrent_instance",
+                detail: "another instance run overlapped this task evidence window".to_string(),
+                selected_raw_bytes: None,
+                compressed_bytes: None,
+            },
+        );
+        return;
+    }
+
+    let Some(evidence_start) = report.evidence_start.take() else {
+        send_failure_event(report, FailureAttachmentOutcome::NotSelected);
+        return;
+    };
+    let selection = match task_diagnostics::capture_task_end(evidence_start) {
+        Ok(selection) => selection,
+        Err(error) => {
+            send_failure_event(report, attachment_error_outcome(error));
+            return;
+        }
+    };
+    if EVIDENCE_EPOCH.load(Ordering::SeqCst) != report.evidence_epoch {
+        send_failure_event(
+            report,
+            FailureAttachmentOutcome::Omitted {
+                status: "concurrent_instance",
+                detail: "another instance run started before the evidence boundary was frozen"
+                    .to_string(),
+                selected_raw_bytes: None,
+                compressed_bytes: None,
+            },
+        );
+        return;
+    }
+
+    let workers = pending_failure_workers();
+    let Some(worker_id) = workers.register(report.clone()) else {
+        send_failure_event(
+            report,
+            FailureAttachmentOutcome::Omitted {
+                status: "shutdown_in_progress",
+                detail: "telemetry shutdown started before attachment compression".to_string(),
+                selected_raw_bytes: None,
+                compressed_bytes: None,
+            },
+        );
+        return;
+    };
+
+    // Preserve the configured client and top scope when crossing the thread boundary.
+    // Stable file handles and end offsets are already frozen; only compression runs
+    // in the background. The pending registry owns an event-only fallback for exit.
+    let hub = Arc::new(sentry::Hub::new_from_top(sentry::Hub::current()));
+    if let Err(error) = std::thread::Builder::new()
+        .name("mxu-failure-attachment".to_string())
+        .spawn(move || {
+            sentry::Hub::run(hub, || {
+                let outcome = match task_diagnostics::build_task_bundle(
+                    selection,
+                    &report.run_id,
+                    report.maa_task_id,
+                ) {
+                    Ok(bundle) => FailureAttachmentOutcome::Attached(bundle),
+                    Err(error) => attachment_error_outcome(error),
+                };
+                complete_failure_worker(worker_id, report, outcome);
+            });
+        })
+    {
+        log::warn!("[telemetry] failed to start attachment worker: {error}");
+        if let Some(report) = workers.take(worker_id) {
+            send_failure_event(
+                report,
+                FailureAttachmentOutcome::Omitted {
+                    status: "worker_unavailable",
+                    detail: error.to_string(),
+                    selected_raw_bytes: None,
+                    compressed_bytes: None,
+                },
+            );
         }
     }
+}
+
+fn complete_failure_worker(
+    worker_id: u64,
+    report: TaskFailureReport,
+    outcome: FailureAttachmentOutcome,
+) {
+    let _send_guard = FAILURE_EVENT_SEND_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Shutdown or an explicit opt-out may already have consumed/cancelled this
+    // worker's fallback. In that case the detached compressor must remain silent.
+    if pending_failure_workers().take(worker_id).is_some() && is_active() {
+        capture_failure_event(report, outcome);
+    }
+}
+
+fn send_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOutcome) {
+    let _send_guard = FAILURE_EVENT_SEND_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if is_active() {
+        capture_failure_event(report, outcome);
+    }
+}
+
+fn attachment_error_outcome(error: TaskBundleError) -> FailureAttachmentOutcome {
+    match error {
+        TaskBundleError::NoEvidence => FailureAttachmentOutcome::Omitted {
+            status: "no_evidence",
+            detail: TaskBundleError::NoEvidence.to_string(),
+            selected_raw_bytes: None,
+            compressed_bytes: None,
+        },
+        TaskBundleError::TooLarge {
+            selected_raw_bytes,
+            compressed_bytes,
+        } => FailureAttachmentOutcome::Omitted {
+            status: "too_large",
+            detail: TaskBundleError::TooLarge {
+                selected_raw_bytes,
+                compressed_bytes,
+            }
+            .to_string(),
+            selected_raw_bytes: Some(selected_raw_bytes),
+            compressed_bytes,
+        },
+        error => FailureAttachmentOutcome::Omitted {
+            status: "build_failed",
+            detail: error.to_string(),
+            selected_raw_bytes: None,
+            compressed_bytes: None,
+        },
+    }
+}
+
+fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOutcome) {
+    let task_name = if report.task.name.is_empty() {
+        "unknown-task".to_string()
+    } else {
+        report.task.name.clone()
+    };
+    let observed_node = report
+        .failure
+        .as_ref()
+        .map(|failure| failure.node.as_str())
+        .unwrap_or("terminal_failure");
+    let observed_stage = report
+        .failure
+        .as_ref()
+        .map(|failure| failure.stage.as_str())
+        .unwrap_or("unknown");
+
+    let mut event = sentry::protocol::Event {
+        message: Some(format!(
+            "Maa task failed: {task_name} at {observed_node} ({observed_stage})"
+        )),
+        logger: Some("mxu.task".to_string()),
+        transaction: Some("mxu.task.failure".to_string()),
+        fingerprint: Cow::Owned(vec![
+            Cow::Borrowed("mxu-task-failure"),
+            Cow::Owned(report.event_config.app_name.clone()),
+            Cow::Owned(task_name.clone()),
+            Cow::Owned(observed_node.to_string()),
+            Cow::Owned(observed_stage.to_string()),
+        ]),
+        ..Default::default()
+    };
+
+    event.tags = report.tags;
+    for (key, value) in [
+        ("app.name", report.event_config.app_name.as_str()),
+        ("app.version", report.event_config.app_version.as_str()),
+        ("mxu.version", report.event_config.mxu_version.as_str()),
+        ("task.name", task_name.as_str()),
+        ("failure.node", observed_node),
+        ("failure.stage", observed_stage),
+        ("result", "failure"),
+    ] {
+        if !value.is_empty() {
+            event.tags.insert(key.to_string(), tag_value(value));
+        }
+    }
+
+    event
+        .extra
+        .insert("run_id".to_string(), report.run_id.clone().into());
+    event
+        .extra
+        .insert("task_id".to_string(), report.maa_task_id.into());
+    event.extra.insert(
+        "failed_node_count".to_string(),
+        (report.failed_node_count as u64).into(),
+    );
+    if let Some(duration_ms) = report.duration_ms {
+        event
+            .extra
+            .insert("task_duration_ms".to_string(), duration_ms.into());
+    }
+    if let Some(started_at_ms) = report.started_wall_time.and_then(unix_time_ms) {
+        event
+            .extra
+            .insert("task_started_at_ms".to_string(), started_at_ms.into());
+    }
+    if let Some(failure) = &report.failure {
+        event.extra.insert(
+            "failure.source_task_id".to_string(),
+            failure.source_task_id.into(),
+        );
+        if let Some(node_id) = failure.node_id {
+            event
+                .extra
+                .insert("failure.node_id".to_string(), node_id.into());
+        }
+        if let Some(duration_ms) = failure.duration_ms {
+            event
+                .extra
+                .insert("failure.duration_ms".to_string(), duration_ms.into());
+        }
+    }
+    for (key, value) in report.task.options {
+        event.extra.insert(format!("option.{key}"), value.into());
+    }
+    if let Some(trace_context) = report.trace_context {
+        event.contexts.insert(
+            "trace".to_string(),
+            sentry::protocol::Context::Trace(Box::new(trace_context)),
+        );
+    }
+
+    let attachment = match outcome {
+        FailureAttachmentOutcome::NotSelected => {
+            event
+                .extra
+                .insert("attachment.status".to_string(), "not_selected".into());
+            None
+        }
+        FailureAttachmentOutcome::Attached(bundle) => {
+            event
+                .extra
+                .insert("attachment.status".to_string(), "attached".into());
+            event.extra.insert(
+                "attachment.log_count".to_string(),
+                (bundle.log_count as u64).into(),
+            );
+            event.extra.insert(
+                "attachment.image_count".to_string(),
+                (bundle.image_count as u64).into(),
+            );
+            event.extra.insert(
+                "attachment.selected_raw_bytes".to_string(),
+                bundle.selected_raw_bytes.into(),
+            );
+            event.extra.insert(
+                "attachment.compressed_bytes".to_string(),
+                (bundle.buffer.len() as u64).into(),
+            );
+            event.extra.insert(
+                "attachment.selection".to_string(),
+                "appended_bytes_with_64k_prelude".into(),
+            );
+            if !bundle.warnings.is_empty() {
+                event.extra.insert(
+                    "attachment.warnings".to_string(),
+                    bundle.warnings.join(",").into(),
+                );
+            }
+            Some(sentry::protocol::Attachment {
+                buffer: bundle.buffer,
+                filename: bundle.filename,
+                content_type: Some("application/zip".to_string()),
+                ..Default::default()
+            })
+        }
+        FailureAttachmentOutcome::Omitted {
+            status,
+            detail,
+            selected_raw_bytes,
+            compressed_bytes,
+        } => {
+            event
+                .extra
+                .insert("attachment.status".to_string(), status.into());
+            event
+                .extra
+                .insert("attachment.detail".to_string(), detail.into());
+            if let Some(size) = selected_raw_bytes {
+                event
+                    .extra
+                    .insert("attachment.selected_raw_bytes".to_string(), size.into());
+            }
+            if let Some(size) = compressed_bytes {
+                event.extra.insert(
+                    "attachment.compressed_bytes".to_string(),
+                    (size as u64).into(),
+                );
+            }
+            None
+        }
+    };
+
+    let expected_event_id = event.event_id;
+    let captured_event_id = if let Some(attachment) = attachment {
+        sentry::with_scope(
+            |scope| scope.add_attachment(attachment),
+            || sentry::capture_event(event),
+        )
+    } else {
+        sentry::capture_event(event)
+    };
+    let event_id = if captured_event_id.is_nil() {
+        expected_event_id
+    } else {
+        captured_event_id
+    };
+    log::info!(
+        "[telemetry] task failure event_id={} run_id={} task_id={} task={}",
+        event_id,
+        report.run_id,
+        report.maa_task_id,
+        task_name
+    );
+}
+
+fn should_sample_attachment(run_id: &str, maa_task_id: i64, sample_rate: f32) -> bool {
+    let sample_rate = sample_rate.clamp(0.0, 1.0);
+    if sample_rate <= 0.0 {
+        return false;
+    }
+    if sample_rate >= 1.0 {
+        return true;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"mxu-failure-attachment-v1:");
+    hasher.update(run_id.as_bytes());
+    hasher.update(maa_task_id.to_le_bytes());
+    let digest = hasher.finalize();
+    let bucket = u64::from_le_bytes(digest[..8].try_into().expect("SHA-256 has 8 bytes"));
+    let normalized = bucket as f64 / u64::MAX as f64;
+    normalized < sample_rate as f64
+}
+
+fn tag_value(value: &str) -> String {
+    value.chars().take(200).collect()
+}
+
+fn unix_time_ms(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_millis() as u64)
 }
 
 /// 整批运行结束：finish Transaction。
@@ -829,5 +1528,128 @@ fn finish_run(instance_id: &str, forced_status: Option<sentry::protocol::SpanSta
                 || transaction.finish(),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn failure_report() -> TaskFailureReport {
+        TaskFailureReport {
+            run_id: "run-123".to_string(),
+            maa_task_id: 42,
+            task: TaskMeta {
+                name: "DailyTask".to_string(),
+                options: BTreeMap::from([("mode".to_string(), "normal".to_string())]),
+            },
+            duration_ms: Some(1_500),
+            started_wall_time: Some(UNIX_EPOCH + Duration::from_secs(10)),
+            failure: Some(FailureSignal {
+                node: "EnterBattle".to_string(),
+                stage: "recognition".to_string(),
+                source_task_id: 43,
+                node_id: Some(7),
+                duration_ms: Some(800),
+            }),
+            failed_node_count: 3,
+            trace_context: None,
+            tags: BTreeMap::from([("run.id".to_string(), "run-123".to_string())]),
+            event_config: FailureEventConfig {
+                app_name: "MaaEnd".to_string(),
+                app_version: "2.0.0".to_string(),
+                mxu_version: "0.1.0".to_string(),
+                failure_attachments_sample_rate: 1.0,
+            },
+            evidence_start: None,
+            evidence_isolated: true,
+            evidence_epoch: 1,
+        }
+    }
+
+    #[test]
+    fn terminal_failure_creates_one_groupable_event_with_one_attachment() {
+        let envelopes = sentry::test::with_captured_envelopes(|| {
+            capture_failure_event(
+                failure_report(),
+                FailureAttachmentOutcome::Attached(TaskBundle {
+                    buffer: b"zip-body".to_vec(),
+                    filename: "failure.zip".to_string(),
+                    log_count: 2,
+                    image_count: 1,
+                    selected_raw_bytes: 1024,
+                    warnings: Vec::new(),
+                }),
+            );
+        });
+
+        assert_eq!(envelopes.len(), 1);
+        let items: Vec<_> = envelopes[0].items().collect();
+        assert_eq!(items.len(), 2);
+        let sentry::protocol::EnvelopeItem::Event(event) = items[0] else {
+            panic!("first envelope item should be an event");
+        };
+        assert_eq!(event.tags["task.name"], "DailyTask");
+        assert_eq!(event.tags["failure.node"], "EnterBattle");
+        assert_eq!(event.tags["failure.stage"], "recognition");
+        assert_eq!(event.fingerprint.len(), 5);
+        assert_eq!(event.fingerprint[0], "mxu-task-failure");
+        assert_eq!(event.fingerprint[2], "DailyTask");
+        assert_eq!(event.fingerprint[3], "EnterBattle");
+        let sentry::protocol::EnvelopeItem::Attachment(attachment) = items[1] else {
+            panic!("second envelope item should be an attachment");
+        };
+        assert_eq!(attachment.filename, "failure.zip");
+        assert_eq!(attachment.buffer, b"zip-body");
+    }
+
+    #[test]
+    fn attachment_sampling_has_stable_boundaries() {
+        assert!(!should_sample_attachment("run", 1, 0.0));
+        assert!(should_sample_attachment("run", 1, 1.0));
+        assert_eq!(
+            should_sample_attachment("run", 42, 0.5),
+            should_sample_attachment("run", 42, 0.5)
+        );
+    }
+
+    #[test]
+    fn missing_attachment_sample_rate_defaults_to_full_sampling() {
+        let config: TelemetryInitConfig = serde_json::from_value(serde_json::json!({
+            "dsn": "https://public@example.invalid/1",
+            "enabled": true,
+            "release": "MXU@1.0.0+App@1.0.0",
+            "environment": "test",
+            "tracing": true,
+            "tracesSampleRate": 1.0,
+            "appName": "App",
+            "appVersion": "1.0.0",
+            "mxuVersion": "1.0.0"
+        }))
+        .expect("deserialize telemetry config");
+
+        assert_eq!(config.failure_attachments_sample_rate, 1.0);
+    }
+
+    #[test]
+    fn evidence_is_omitted_when_another_instance_run_exists() {
+        assert!(evidence_isolated_for_ids("a", ["a"].into_iter()));
+        assert!(!evidence_isolated_for_ids("a", ["a", "b"].into_iter()));
+    }
+
+    #[test]
+    fn pending_failure_reports_can_be_drained_for_shutdown_fallback() {
+        FAILURE_WORKERS_CLOSING.store(false, Ordering::SeqCst);
+        let workers = PendingFailureWorkers::new();
+        let worker_id = workers
+            .register(failure_report())
+            .expect("register pending failure");
+        assert!(!workers.wait_until_idle(Duration::ZERO));
+
+        let fallback = workers.drain();
+        assert_eq!(fallback.len(), 1);
+        assert_eq!(fallback[0].maa_task_id, 42);
+        assert!(workers.take(worker_id).is_none());
+        assert!(workers.wait_until_idle(Duration::ZERO));
     }
 }

--- a/src-tauri/src/commands/telemetry.rs
+++ b/src-tauri/src/commands/telemetry.rs
@@ -7,7 +7,7 @@
 //! - DSN 仅来自 interface.json 的 `telemetry.sentry.dsn`；空 DSN 或未开启时不初始化、不上报。
 //! - 初始化发生在 Tauri `setup()`（早于前端），使 WebView 起来之前的崩溃也能覆盖。
 //! - 用户开关（帮助改进软件）与构建期闸门（调试 / 开发版本）都在本模块判定。
-//! - `send_default_pii = false`；任务附件与现有“帮助改进软件”遥测开关共同启停。
+//! - `send_default_pii = false`；结构化日志与截图附件均随现有“帮助改进软件”开关启停。
 //! - 网络：SDK 后台异步发送、队列有界，不阻塞主流程；`shutdown_timeout` 设小值避免退出卡顿。
 //! - 事件模型：一次进程运行 = 一个 Session（Release Health），
 //!   一次整批运行 = 一个 Transaction，每个 SavedTask = 一个 child Span，
@@ -26,7 +26,9 @@ use sentry::protocol::SpanStatus;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-use super::task_diagnostics::{self, TaskBundle, TaskBundleError, TaskEvidenceStart};
+use super::task_diagnostics::{
+    self, DiagnosticLogs, ImageBundle, ImageBundleError, TaskEvidenceStart,
+};
 use super::types::ControllerInfo;
 use super::utils::get_logs_dir;
 use super::AppConfigState;
@@ -39,7 +41,8 @@ static TELEMETRY_CONFIG: Mutex<Option<TelemetryInitConfig>> = Mutex::new(None);
 static MACHINE_ID: OnceLock<String> = OnceLock::new();
 /// 进行中的运行遥测状态，按 instance_id 索引。
 static RUNS: Mutex<BTreeMap<String, RunState>> = Mutex::new(BTreeMap::new());
-/// 每次有实例开始整批运行时递增，用于发现任务证据区间内出现的其他运行实例。
+/// 每次有运行或任务开始时递增。失败截图补采只允许在创建快照的 epoch
+/// 内发布结果，因此后续任务无法污染前一个任务的证据。
 static EVIDENCE_EPOCH: AtomicU64 = AtomicU64::new(0);
 /// 退出或用户关闭遥测后不再接受新的附件 worker。
 static FAILURE_WORKERS_CLOSING: AtomicBool = AtomicBool::new(false);
@@ -64,7 +67,7 @@ pub struct TelemetryInitConfig {
     pub tracing: bool,
     /// 事务采样率 0~1。
     pub traces_sample_rate: f32,
-    /// 失败附件独立采样率 0~1；Error Event 本身不受此值影响。
+    /// 失败截图附件独立采样率 0~1；Error Event 与结构化日志不受此值影响。
     #[serde(default = "default_sample_rate")]
     pub failure_attachments_sample_rate: f32,
     /// 资源项目名（interface.name）。
@@ -91,8 +94,10 @@ struct RunState {
     failed_nodes: HashMap<i64, u32>,
     /// 各任务已上报的节点数（maa_task_id → 计数），用于限流。
     traced_nodes: HashMap<i64, u32>,
-    /// 各外层任务最后一个直接观测到的失败节点，用于终态失败事件的稳定分组。
+    /// 各外层任务第一个直接观测到的失败节点，用于按根因稳定分组。
     failure_signals: HashMap<i64, FailureSignal>,
+    /// 各外层任务最后一个直接观测到的失败节点，作为终态上下文保留。
+    terminal_failure_signals: HashMap<i64, FailureSignal>,
     /// 各外层任务的运行时间和可选文件边界。
     task_runtime: HashMap<i64, TaskRuntime>,
     /// 当前正在执行的外层 SavedTask id。
@@ -104,7 +109,7 @@ struct RunState {
     tags: BTreeMap<String, String>,
     /// 是否已有任务失败。
     has_failed: bool,
-    /// 本次运行创建时的项目与附件配置，避免运行中切换项目导致事件错配。
+    /// 本次运行创建时的项目与截图附件配置，避免运行中切换项目导致事件错配。
     event_config: FailureEventConfig,
 }
 
@@ -135,7 +140,7 @@ struct TaskRuntime {
     evidence_epoch: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct FailureSignal {
     node: String,
     stage: String,
@@ -152,6 +157,7 @@ struct TaskFailureReport {
     duration_ms: Option<u64>,
     started_wall_time: Option<SystemTime>,
     failure: Option<FailureSignal>,
+    terminal_failure: Option<FailureSignal>,
     failed_node_count: u32,
     trace_context: Option<sentry::protocol::TraceContext>,
     tags: BTreeMap<String, String>,
@@ -241,6 +247,10 @@ impl PendingFailureWorkers {
 const MAX_TRACED_NODES_PER_TASK: u32 = 1000;
 /// 退出时给已经开始压缩的附件一个短暂完成窗口；超时则发送无附件兜底事件。
 const FAILURE_WORKER_DRAIN_TIMEOUT: Duration = Duration::from_millis(750);
+/// MaaFramework may finish writing an on_error screenshot shortly after the terminal
+/// callback. Poll only inside the task's evidence epoch and stop promptly on shutdown.
+const IMAGE_SETTLE_TIMEOUT: Duration = Duration::from_secs(1);
+const IMAGE_SETTLE_INTERVAL: Duration = Duration::from_millis(100);
 
 /// 单个 SavedTask 的遥测元数据，由前端在提交任务时给出。
 #[derive(Debug, Clone, Default)]
@@ -537,18 +547,19 @@ pub fn on_app_exit() {
     let _send_guard = FAILURE_EVENT_SEND_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    // Worker 超时后保留 Error Event，只有附件被省略。发送锁保证后台线程
+    // Worker 超时后保留 Error Event，日志与截图证据会明确标记为不可用。发送锁保证后台线程
     // 无法在这里与 guard 释放交错，也不会产生重复事件。
     let fallback_reports = workers.drain();
     let fallback_count = fallback_reports.len();
     for report in fallback_reports {
         capture_failure_event(
             report,
+            None,
             FailureAttachmentOutcome::Omitted {
                 status: "shutdown_fallback",
-                detail: "attachment worker did not finish before telemetry shutdown".to_string(),
+                detail: "evidence worker did not finish before telemetry shutdown".to_string(),
                 selected_raw_bytes: None,
-                compressed_bytes: None,
+                bundle_bytes: None,
             },
         );
     }
@@ -568,13 +579,10 @@ pub fn on_app_exit() {
 
 /// 实际执行 Sentry 初始化并配置 scope。
 fn do_init(config: &TelemetryInitConfig) {
-    let dsn: sentry::types::Dsn = match config.dsn.parse() {
-        Ok(dsn) => dsn,
-        Err(err) => {
-            log::warn!("[telemetry] DSN 解析失败: {err}");
-            return;
-        }
-    };
+    if let Err(err) = config.dsn.parse::<sentry::types::Dsn>() {
+        log::warn!("[telemetry] DSN 解析失败: {err}");
+        return;
+    }
 
     let traces_sample_rate = if config.tracing {
         config.traces_sample_rate.clamp(0.0, 1.0)
@@ -585,20 +593,21 @@ fn do_init(config: &TelemetryInitConfig) {
     pending_failure_workers().cancel_all();
     FAILURE_WORKERS_CLOSING.store(false, Ordering::SeqCst);
 
-    let guard = sentry::init(sentry::ClientOptions {
-        dsn: Some(dsn),
-        release: Some(config.release.clone().into()),
-        environment: Some(config.environment.clone().into()),
-        traces_sample_rate,
+    let options = sentry::ClientOptions::new()
+        .dsn(&config.dsn)
+        .release(config.release.clone())
+        .environment(config.environment.clone())
+        .traces_sample_rate(traces_sample_rate)
+        // 任务失败日志走 Sentry Logs；截图附件使用独立采样率。
+        .enable_logs(true)
         // 隐私：不采集用户 IP、请求头等 PII
-        send_default_pii: false,
+        .send_default_pii(false)
         // Session（Release Health）：一次进程运行一条，init 时自动开始
-        auto_session_tracking: true,
-        session_mode: sentry::SessionMode::Application,
+        .auto_session_tracking(true)
+        .session_mode(sentry::SessionMode::Application)
         // 网络差时退出不长时间阻塞（退出路径还要清理 agent 子进程）
-        shutdown_timeout: Duration::from_secs(1),
-        ..Default::default()
-    });
+        .shutdown_timeout(Duration::from_secs(1));
+    let guard = sentry::init(options);
 
     if let Ok(mut slot) = TELEMETRY_GUARD.lock() {
         *slot = Some(guard);
@@ -766,6 +775,7 @@ pub fn on_run_start(instance_id: &str, task_names: &[String], controller: Option
                 failed_nodes: HashMap::new(),
                 traced_nodes: HashMap::new(),
                 failure_signals: HashMap::new(),
+                terminal_failure_signals: HashMap::new(),
                 task_runtime: HashMap::new(),
                 active_task: None,
                 tags,
@@ -824,7 +834,11 @@ pub fn on_task_start(instance_id: &str, maa_task_id: i64) {
     let capture_evidence = if let Ok(mut runs) = RUNS.lock() {
         let evidence_isolated =
             evidence_isolated_for_ids(instance_id, runs.keys().map(String::as_str));
-        let evidence_epoch = EVIDENCE_EPOCH.load(Ordering::SeqCst);
+        // Starting any task supersedes every older screenshot settle window,
+        // including tasks belonging to another application instance.
+        let evidence_epoch = EVIDENCE_EPOCH
+            .fetch_add(1, Ordering::SeqCst)
+            .wrapping_add(1);
         if let Some(run) = runs.get_mut(instance_id) {
             let meta = run.metas.get(&maa_task_id).cloned().unwrap_or_default();
             let span: sentry::TransactionOrSpan =
@@ -847,12 +861,8 @@ pub fn on_task_start(instance_id: &str, maa_task_id: i64) {
                 },
             );
             run.active_task = Some(maa_task_id);
+            // 日志采集独立于截图附件采样；仅多实例并行时因证据无法可靠归属而跳过。
             evidence_isolated
-                && should_sample_attachment(
-                    &run.run_id,
-                    maa_task_id,
-                    run.event_config.failure_attachments_sample_rate,
-                )
         } else {
             false
         }
@@ -861,7 +871,7 @@ pub fn on_task_start(instance_id: &str, maa_task_id: i64) {
     };
 
     // Filesystem discovery can be slower than a state update, so do it without the
-    // telemetry-state lock. The prelude in the bundle builder covers lines written
+    // telemetry-state lock. The log prelude covers lines written
     // between the callback and this snapshot.
     if capture_evidence {
         let evidence_start = task_diagnostics::capture_task_start(&get_logs_dir());
@@ -1020,10 +1030,12 @@ fn record_node_event(
         .map(|meta| meta.name.clone())
         .unwrap_or_default();
 
-    // 失败事件摘要不依赖 trace Span 的数量预算；即使 Span 已达上限，仍保留最后一个失败信号。
+    // 失败事件摘要不依赖 trace Span 的数量预算；即使 Span 已达上限，仍保留根因和终态信号。
     if let Some(stage) = stage {
         *run.failed_nodes.entry(owner_id).or_insert(0) += 1;
-        run.failure_signals.insert(
+        retain_failure_signals(
+            &mut run.failure_signals,
+            &mut run.terminal_failure_signals,
             owner_id,
             FailureSignal {
                 node: node.to_string(),
@@ -1074,6 +1086,16 @@ fn record_node_event(
     span.finish();
 }
 
+fn retain_failure_signals(
+    roots: &mut HashMap<i64, FailureSignal>,
+    terminals: &mut HashMap<i64, FailureSignal>,
+    owner_id: i64,
+    signal: FailureSignal,
+) {
+    roots.entry(owner_id).or_insert_with(|| signal.clone());
+    terminals.insert(owner_id, signal);
+}
+
 /// 单个 SavedTask 结束：为 child Span 打结果并 finish。
 pub fn on_task_finished(instance_id: &str, maa_task_id: i64, success: bool) {
     if !is_active() {
@@ -1091,6 +1113,7 @@ pub fn on_task_finished(instance_id: &str, maa_task_id: i64, success: bool) {
             let failed_node_count = run.failed_nodes.remove(&maa_task_id).unwrap_or(0);
             run.traced_nodes.remove(&maa_task_id);
             let failure = run.failure_signals.remove(&maa_task_id);
+            let terminal_failure = run.terminal_failure_signals.remove(&maa_task_id);
             if run.active_task == Some(maa_task_id) {
                 run.active_task = None;
             }
@@ -1141,6 +1164,7 @@ pub fn on_task_finished(instance_id: &str, maa_task_id: i64, success: bool) {
                     duration_ms,
                     started_wall_time,
                     failure,
+                    terminal_failure,
                     failed_node_count,
                     trace_context,
                     tags: run.tags.clone(),
@@ -1164,12 +1188,12 @@ pub fn on_task_finished(instance_id: &str, maa_task_id: i64, success: bool) {
 
 enum FailureAttachmentOutcome {
     NotSelected,
-    Attached(TaskBundle),
+    Attached(ImageBundle),
     Omitted {
         status: &'static str,
         detail: String,
         selected_raw_bytes: Option<u64>,
-        compressed_bytes: Option<usize>,
+        bundle_bytes: Option<usize>,
     },
 }
 
@@ -1178,93 +1202,138 @@ fn submit_failure_report(mut report: TaskFailureReport) {
         report.evidence_start = None;
         send_failure_event(
             report,
+            None,
             FailureAttachmentOutcome::Omitted {
                 status: "concurrent_instance",
                 detail: "another instance run overlapped this task evidence window".to_string(),
                 selected_raw_bytes: None,
-                compressed_bytes: None,
+                bundle_bytes: None,
             },
         );
         return;
     }
 
     let Some(evidence_start) = report.evidence_start.take() else {
-        send_failure_event(report, FailureAttachmentOutcome::NotSelected);
+        send_failure_event(report, None, FailureAttachmentOutcome::NotSelected);
         return;
     };
-    let selection = match task_diagnostics::capture_task_end(evidence_start) {
-        Ok(selection) => selection,
-        Err(error) => {
-            send_failure_event(report, attachment_error_outcome(error));
-            return;
-        }
-    };
+    // Freeze logs and any already-visible screenshots immediately. An empty terminal
+    // selection remains eligible for the bounded late-screenshot settle window.
+    let selection = task_diagnostics::capture_task_end(evidence_start);
     if EVIDENCE_EPOCH.load(Ordering::SeqCst) != report.evidence_epoch {
         send_failure_event(
             report,
+            None,
             FailureAttachmentOutcome::Omitted {
                 status: "concurrent_instance",
                 detail: "another instance run started before the evidence boundary was frozen"
                     .to_string(),
                 selected_raw_bytes: None,
-                compressed_bytes: None,
+                bundle_bytes: None,
             },
         );
         return;
     }
 
     let workers = pending_failure_workers();
+    let include_images = should_sample_attachment(
+        &report.run_id,
+        report.maa_task_id,
+        report.event_config.failure_attachments_sample_rate,
+    );
     let Some(worker_id) = workers.register(report.clone()) else {
         send_failure_event(
             report,
+            None,
             FailureAttachmentOutcome::Omitted {
                 status: "shutdown_in_progress",
-                detail: "telemetry shutdown started before attachment compression".to_string(),
+                detail: "telemetry shutdown started before evidence processing".to_string(),
                 selected_raw_bytes: None,
-                compressed_bytes: None,
+                bundle_bytes: None,
             },
         );
         return;
     };
 
     // Preserve the configured client and top scope when crossing the thread boundary.
-    // Stable file handles and end offsets are already frozen; only compression runs
-    // in the background. The pending registry owns an event-only fallback for exit.
+    // Stable file handles and end offsets are already frozen; bounded log reads and
+    // optional screenshot compression run in the background. The pending registry
+    // owns an event-only fallback for exit.
     let hub = Arc::new(sentry::Hub::new_from_top(sentry::Hub::current()));
     if let Err(error) = std::thread::Builder::new()
-        .name("mxu-failure-attachment".to_string())
+        .name("mxu-failure-evidence".to_string())
         .spawn(move || {
             sentry::Hub::run(hub, || {
-                let outcome = match task_diagnostics::build_task_bundle(
-                    selection,
-                    &report.run_id,
-                    report.maa_task_id,
-                ) {
-                    Ok(bundle) => FailureAttachmentOutcome::Attached(bundle),
-                    Err(error) => attachment_error_outcome(error),
+                let mut selection = selection;
+                settle_task_images(&mut selection, report.evidence_epoch);
+                let logs = task_diagnostics::build_diagnostic_logs(&mut selection);
+                let outcome = if include_images {
+                    match task_diagnostics::build_image_bundle(
+                        selection,
+                        &report.run_id,
+                        report.maa_task_id,
+                    ) {
+                        Ok(bundle) => FailureAttachmentOutcome::Attached(bundle),
+                        Err(error) => attachment_error_outcome(error),
+                    }
+                } else {
+                    FailureAttachmentOutcome::NotSelected
                 };
-                complete_failure_worker(worker_id, report, outcome);
+                complete_failure_worker(worker_id, report, Some(logs), outcome);
             });
         })
     {
-        log::warn!("[telemetry] failed to start attachment worker: {error}");
+        log::warn!("[telemetry] failed to start evidence worker: {error}");
         if let Some(report) = workers.take(worker_id) {
             send_failure_event(
                 report,
+                None,
                 FailureAttachmentOutcome::Omitted {
                     status: "worker_unavailable",
                     detail: error.to_string(),
                     selected_raw_bytes: None,
-                    compressed_bytes: None,
+                    bundle_bytes: None,
                 },
             );
         }
     }
 }
 
+fn settle_task_images(
+    selection: &mut task_diagnostics::TaskEvidenceSelection,
+    expected_epoch: u64,
+) {
+    let deadline = Instant::now() + IMAGE_SETTLE_TIMEOUT;
+    loop {
+        if FAILURE_WORKERS_CLOSING.load(Ordering::SeqCst)
+            || EVIDENCE_EPOCH.load(Ordering::SeqCst) != expected_epoch
+        {
+            return;
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return;
+        }
+        std::thread::sleep(remaining.min(IMAGE_SETTLE_INTERVAL));
+
+        if FAILURE_WORKERS_CLOSING.load(Ordering::SeqCst)
+            || EVIDENCE_EPOCH.load(Ordering::SeqCst) != expected_epoch
+        {
+            return;
+        }
+        let refresh = task_diagnostics::capture_task_image_refresh(selection);
+        // A new task may have started during discovery. Never publish that stale scan.
+        if EVIDENCE_EPOCH.load(Ordering::SeqCst) != expected_epoch {
+            return;
+        }
+        task_diagnostics::apply_task_image_refresh(selection, refresh);
+    }
+}
+
 fn complete_failure_worker(
     worker_id: u64,
     report: TaskFailureReport,
+    logs: Option<DiagnosticLogs>,
     outcome: FailureAttachmentOutcome,
 ) {
     let _send_guard = FAILURE_EVENT_SEND_LOCK
@@ -1273,50 +1342,62 @@ fn complete_failure_worker(
     // Shutdown or an explicit opt-out may already have consumed/cancelled this
     // worker's fallback. In that case the detached compressor must remain silent.
     if pending_failure_workers().take(worker_id).is_some() && is_active() {
-        capture_failure_event(report, outcome);
+        capture_failure_event(report, logs, outcome);
     }
 }
 
-fn send_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOutcome) {
+fn send_failure_event(
+    report: TaskFailureReport,
+    logs: Option<DiagnosticLogs>,
+    outcome: FailureAttachmentOutcome,
+) {
     let _send_guard = FAILURE_EVENT_SEND_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     if is_active() {
-        capture_failure_event(report, outcome);
+        capture_failure_event(report, logs, outcome);
     }
 }
 
-fn attachment_error_outcome(error: TaskBundleError) -> FailureAttachmentOutcome {
+fn attachment_error_outcome(error: ImageBundleError) -> FailureAttachmentOutcome {
     match error {
-        TaskBundleError::NoEvidence => FailureAttachmentOutcome::Omitted {
+        ImageBundleError::NoEvidence => FailureAttachmentOutcome::Omitted {
             status: "no_evidence",
-            detail: TaskBundleError::NoEvidence.to_string(),
+            detail: ImageBundleError::NoEvidence.to_string(),
             selected_raw_bytes: None,
-            compressed_bytes: None,
+            bundle_bytes: None,
         },
-        TaskBundleError::TooLarge {
+        ImageBundleError::TooLarge {
             selected_raw_bytes,
-            compressed_bytes,
+            bundle_bytes,
         } => FailureAttachmentOutcome::Omitted {
-            status: "too_large",
-            detail: TaskBundleError::TooLarge {
+            status: if bundle_bytes.is_some() {
+                "bundle_too_large"
+            } else {
+                "raw_too_large"
+            },
+            detail: ImageBundleError::TooLarge {
                 selected_raw_bytes,
-                compressed_bytes,
+                bundle_bytes,
             }
             .to_string(),
             selected_raw_bytes: Some(selected_raw_bytes),
-            compressed_bytes,
+            bundle_bytes,
         },
         error => FailureAttachmentOutcome::Omitted {
             status: "build_failed",
             detail: error.to_string(),
             selected_raw_bytes: None,
-            compressed_bytes: None,
+            bundle_bytes: None,
         },
     }
 }
 
-fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOutcome) {
+fn capture_failure_event(
+    report: TaskFailureReport,
+    logs: Option<DiagnosticLogs>,
+    outcome: FailureAttachmentOutcome,
+) {
     let task_name = if report.task.name.is_empty() {
         "unknown-task".to_string()
     } else {
@@ -1332,6 +1413,11 @@ fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOu
         .as_ref()
         .map(|failure| failure.stage.as_str())
         .unwrap_or("unknown");
+    let trace_id = report
+        .trace_context
+        .as_ref()
+        .map(|context| context.trace_id);
+    let span_id = report.trace_context.as_ref().map(|context| context.span_id);
 
     let mut event = sentry::protocol::Event {
         message: Some(format!(
@@ -1366,39 +1452,33 @@ fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOu
 
     event
         .extra
-        .insert("run_id".to_string(), report.run_id.clone().into());
+        .insert("run.id".to_string(), report.run_id.clone().into());
     event
         .extra
-        .insert("task_id".to_string(), report.maa_task_id.into());
+        .insert("task.id".to_string(), report.maa_task_id.into());
     event.extra.insert(
-        "failed_node_count".to_string(),
+        "failure.count".to_string(),
         (report.failed_node_count as u64).into(),
     );
     if let Some(duration_ms) = report.duration_ms {
         event
             .extra
-            .insert("task_duration_ms".to_string(), duration_ms.into());
+            .insert("task.duration_ms".to_string(), duration_ms.into());
     }
     if let Some(started_at_ms) = report.started_wall_time.and_then(unix_time_ms) {
         event
             .extra
-            .insert("task_started_at_ms".to_string(), started_at_ms.into());
+            .insert("task.started_at_ms".to_string(), started_at_ms.into());
     }
     if let Some(failure) = &report.failure {
-        event.extra.insert(
-            "failure.source_task_id".to_string(),
-            failure.source_task_id.into(),
-        );
-        if let Some(node_id) = failure.node_id {
-            event
-                .extra
-                .insert("failure.node_id".to_string(), node_id.into());
-        }
-        if let Some(duration_ms) = failure.duration_ms {
-            event
-                .extra
-                .insert("failure.duration_ms".to_string(), duration_ms.into());
-        }
+        set_failure_extra(&mut event, "failure", failure);
+    }
+    if let Some(terminal) = report
+        .terminal_failure
+        .as_ref()
+        .filter(|terminal| report.failure.as_ref() != Some(*terminal))
+    {
+        set_failure_extra(&mut event, "terminal_failure", terminal);
     }
     for (key, value) in report.task.options {
         event.extra.insert(format!("option.{key}"), value.into());
@@ -1409,6 +1489,8 @@ fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOu
             sentry::protocol::Context::Trace(Box::new(trace_context)),
         );
     }
+
+    set_log_evidence_data(&mut event, logs.as_ref());
 
     let attachment = match outcome {
         FailureAttachmentOutcome::NotSelected => {
@@ -1422,10 +1504,6 @@ fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOu
                 .extra
                 .insert("attachment.status".to_string(), "attached".into());
             event.extra.insert(
-                "attachment.log_count".to_string(),
-                (bundle.log_count as u64).into(),
-            );
-            event.extra.insert(
                 "attachment.image_count".to_string(),
                 (bundle.image_count as u64).into(),
             );
@@ -1434,12 +1512,12 @@ fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOu
                 bundle.selected_raw_bytes.into(),
             );
             event.extra.insert(
-                "attachment.compressed_bytes".to_string(),
+                "attachment.bundle_bytes".to_string(),
                 (bundle.buffer.len() as u64).into(),
             );
             event.extra.insert(
                 "attachment.selection".to_string(),
-                "appended_bytes_with_64k_prelude".into(),
+                "new_on_error_screenshots".into(),
             );
             if !bundle.warnings.is_empty() {
                 event.extra.insert(
@@ -1458,7 +1536,7 @@ fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOu
             status,
             detail,
             selected_raw_bytes,
-            compressed_bytes,
+            bundle_bytes,
         } => {
             event
                 .extra
@@ -1471,17 +1549,30 @@ fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOu
                     .extra
                     .insert("attachment.selected_raw_bytes".to_string(), size.into());
             }
-            if let Some(size) = compressed_bytes {
-                event.extra.insert(
-                    "attachment.compressed_bytes".to_string(),
-                    (size as u64).into(),
-                );
+            if let Some(size) = bundle_bytes {
+                event
+                    .extra
+                    .insert("attachment.bundle_bytes".to_string(), (size as u64).into());
             }
             None
         }
     };
 
     let expected_event_id = event.event_id;
+    let expected_event_id_text = expected_event_id.to_string();
+    if let Some(logs) = &logs {
+        capture_diagnostic_logs(
+            logs,
+            &expected_event_id_text,
+            &report.run_id,
+            report.maa_task_id,
+            &task_name,
+            observed_node,
+            observed_stage,
+            trace_id,
+            span_id,
+        );
+    }
     let captured_event_id = if let Some(attachment) = attachment {
         sentry::with_scope(
             |scope| scope.add_attachment(attachment),
@@ -1502,6 +1593,277 @@ fn capture_failure_event(report: TaskFailureReport, outcome: FailureAttachmentOu
         report.maa_task_id,
         task_name
     );
+}
+
+fn set_failure_extra(
+    event: &mut sentry::protocol::Event<'_>,
+    prefix: &str,
+    failure: &FailureSignal,
+) {
+    event
+        .extra
+        .insert(format!("{prefix}.node"), failure.node.clone().into());
+    event
+        .extra
+        .insert(format!("{prefix}.stage"), failure.stage.clone().into());
+    event.extra.insert(
+        format!("{prefix}.source_task_id"),
+        failure.source_task_id.into(),
+    );
+    if let Some(node_id) = failure.node_id {
+        event
+            .extra
+            .insert(format!("{prefix}.node_id"), node_id.into());
+    }
+    if let Some(duration_ms) = failure.duration_ms {
+        event
+            .extra
+            .insert(format!("{prefix}.duration_ms"), duration_ms.into());
+    }
+}
+
+fn set_log_evidence_data(event: &mut sentry::protocol::Event<'_>, logs: Option<&DiagnosticLogs>) {
+    let Some(logs) = logs else {
+        event
+            .extra
+            .insert("logs.status".to_string(), "not_available".into());
+        return;
+    };
+
+    event.extra.insert(
+        "logs.status".to_string(),
+        if logs.entries.is_empty() {
+            "no_evidence"
+        } else {
+            "captured"
+        }
+        .into(),
+    );
+    event
+        .extra
+        .insert("logs.count".to_string(), (logs.entries.len() as u64).into());
+    event.extra.insert(
+        "logs.selected_raw_bytes".to_string(),
+        logs.selected_raw_bytes.into(),
+    );
+    event
+        .extra
+        .insert("logs.truncated".to_string(), logs.truncated.into());
+    if !logs.warnings.is_empty() {
+        event
+            .extra
+            .insert("logs.warnings".to_string(), logs.warnings.join(",").into());
+    }
+}
+
+/// Relay accepts at most 1 MiB for a logs envelope item, while sentry-rust batches
+/// up to 100 records without considering their byte size. Keeping each locally
+/// serialized record within 7 KiB leaves headroom for SDK-added attributes and the
+/// JSON array framing of a full batch.
+const MAX_SERIALIZED_DIAGNOSTIC_LOG_BYTES: usize = 7 * 1024;
+const MAX_DIAGNOSTIC_LOG_ATTRIBUTE_CHARACTERS: usize = 200;
+
+#[derive(Clone, Copy)]
+struct DiagnosticLogContext<'a> {
+    event_id: &'a str,
+    run_id: &'a str,
+    maa_task_id: i64,
+    task_name: &'a str,
+    failure_node: &'a str,
+    failure_stage: &'a str,
+    trace_id: Option<sentry::protocol::TraceId>,
+    span_id: Option<sentry::protocol::SpanId>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn capture_diagnostic_logs(
+    logs: &DiagnosticLogs,
+    event_id: &str,
+    run_id: &str,
+    maa_task_id: i64,
+    task_name: &str,
+    failure_node: &str,
+    failure_stage: &str,
+    trace_id: Option<sentry::protocol::TraceId>,
+    span_id: Option<sentry::protocol::SpanId>,
+) {
+    let context = DiagnosticLogContext {
+        event_id,
+        run_id,
+        maa_task_id,
+        task_name,
+        failure_node,
+        failure_stage,
+        trace_id,
+        span_id,
+    };
+    for source in &logs.entries {
+        for record in build_diagnostic_log_records(source, context) {
+            sentry::Hub::current().capture_log(record);
+        }
+    }
+}
+
+fn build_diagnostic_log_records(
+    source: &task_diagnostics::DiagnosticLog,
+    context: DiagnosticLogContext<'_>,
+) -> Vec<sentry::protocol::Log> {
+    let mut attributes = sentry::protocol::Map::new();
+    let mut attributes_truncated = false;
+    for (key, value) in [
+        ("diagnostic.reason", "task_failure"),
+        ("diagnostic.source", source.source.as_str()),
+        ("diagnostic.kind", source.kind),
+        ("sentry.event_id", context.event_id),
+        ("run.id", context.run_id),
+        ("task.name", context.task_name),
+        ("failure.node", context.failure_node),
+        ("failure.stage", context.failure_stage),
+    ] {
+        let bounded = bounded_log_attribute(value);
+        attributes_truncated |= bounded != value;
+        attributes.insert(key.to_string(), bounded.into());
+    }
+    attributes.insert("task.id".to_string(), context.maa_task_id.into());
+    attributes.insert("log.raw_bytes".to_string(), source.raw_bytes.into());
+    // Use the widest possible integers while sizing chunks. The real index/count
+    // values below can only make the final serialized records smaller.
+    attributes.insert("log.chunk_index".to_string(), u64::MAX.into());
+    attributes.insert("log.chunk_count".to_string(), u64::MAX.into());
+    if attributes_truncated {
+        attributes.insert("diagnostic.attributes_truncated".to_string(), true.into());
+    }
+    if let Some(trace_id) = context.trace_id {
+        attributes.insert("trace.id".to_string(), trace_id.to_string().into());
+    }
+    if let Some(span_id) = context.span_id {
+        attributes.insert("span.id".to_string(), span_id.to_string().into());
+    }
+
+    let timestamp = SystemTime::now();
+    let chunks = serialized_log_chunks(&source.content, &attributes, context.trace_id, timestamp);
+    let chunk_count = chunks.len() as u64;
+    chunks
+        .into_iter()
+        .enumerate()
+        .map(|(index, chunk)| {
+            let mut chunk_attributes = attributes.clone();
+            chunk_attributes.insert("log.chunk_index".to_string(), (index as u64).into());
+            chunk_attributes.insert("log.chunk_count".to_string(), chunk_count.into());
+            sentry::protocol::Log {
+                level: diagnostic_log_level(chunk),
+                body: chunk.to_string(),
+                trace_id: context.trace_id,
+                timestamp,
+                severity_number: None,
+                attributes: chunk_attributes,
+            }
+        })
+        .collect()
+}
+
+fn serialized_log_chunks<'a>(
+    value: &'a str,
+    attributes: &sentry::protocol::Map<String, sentry::protocol::LogAttribute>,
+    trace_id: Option<sentry::protocol::TraceId>,
+    timestamp: SystemTime,
+) -> Vec<&'a str> {
+    if value.is_empty() {
+        return Vec::new();
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < value.len() {
+        let mut candidate_end = value
+            .len()
+            .min(start.saturating_add(MAX_SERIALIZED_DIAGNOSTIC_LOG_BYTES));
+        while candidate_end > start && !value.is_char_boundary(candidate_end) {
+            candidate_end -= 1;
+        }
+        if candidate_end == start {
+            candidate_end += value[start..]
+                .chars()
+                .next()
+                .expect("start is before the string end")
+                .len_utf8();
+        }
+
+        let mut boundaries: Vec<usize> = value[start..candidate_end]
+            .char_indices()
+            .skip(1)
+            .map(|(offset, _)| start + offset)
+            .collect();
+        boundaries.push(candidate_end);
+
+        let mut low = 0;
+        let mut high = boundaries.len();
+        let mut best = None;
+        while low < high {
+            let middle = low + (high - low) / 2;
+            let end = boundaries[middle];
+            if diagnostic_log_fits(&value[start..end], attributes, trace_id, timestamp) {
+                best = Some(end);
+                low = middle + 1;
+            } else {
+                high = middle;
+            }
+        }
+
+        let end = best.expect("bounded diagnostic attributes leave room for one character");
+        chunks.push(&value[start..end]);
+        start = end;
+    }
+    chunks
+}
+
+fn diagnostic_log_fits(
+    body: &str,
+    attributes: &sentry::protocol::Map<String, sentry::protocol::LogAttribute>,
+    trace_id: Option<sentry::protocol::TraceId>,
+    timestamp: SystemTime,
+) -> bool {
+    let record = sentry::protocol::Log {
+        // Fatal is one of the longest serialized level names, so this is a safe
+        // sizing proxy for the level inferred after splitting.
+        level: sentry::protocol::LogLevel::Fatal,
+        body: body.to_string(),
+        trace_id,
+        timestamp,
+        severity_number: None,
+        attributes: attributes.clone(),
+    };
+    serde_json::to_vec(&record)
+        .is_ok_and(|serialized| serialized.len() <= MAX_SERIALIZED_DIAGNOSTIC_LOG_BYTES)
+}
+
+fn bounded_log_attribute(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                '\u{fffd}'
+            } else {
+                character
+            }
+        })
+        .take(MAX_DIAGNOSTIC_LOG_ATTRIBUTE_CHARACTERS)
+        .collect()
+}
+
+fn diagnostic_log_level(content: &str) -> sentry::protocol::LogLevel {
+    let upper = content.to_ascii_uppercase();
+    if upper.contains("[FTL]") || upper.contains("[FATAL]") {
+        sentry::protocol::LogLevel::Fatal
+    } else if upper.contains("[ERR]") || upper.contains("[ERROR]") {
+        sentry::protocol::LogLevel::Error
+    } else if upper.contains("[WRN]") || upper.contains("[WARN]") {
+        sentry::protocol::LogLevel::Warn
+    } else if upper.contains("[DBG]") || upper.contains("[DEBUG]") {
+        sentry::protocol::LogLevel::Debug
+    } else {
+        sentry::protocol::LogLevel::Info
+    }
 }
 
 fn should_sample_attachment(run_id: &str, maa_task_id: i64, sample_rate: f32) -> bool {
@@ -1615,6 +1977,13 @@ mod tests {
                 node_id: Some(7),
                 duration_ms: Some(800),
             }),
+            terminal_failure: Some(FailureSignal {
+                node: "FailureCollector".to_string(),
+                stage: "action".to_string(),
+                source_task_id: 42,
+                node_id: Some(9),
+                duration_ms: Some(20),
+            }),
             failed_node_count: 3,
             trace_context: None,
             tags: BTreeMap::from([("run.id".to_string(), "run-123".to_string())]),
@@ -1635,10 +2004,10 @@ mod tests {
         let envelopes = sentry::test::with_captured_envelopes(|| {
             capture_failure_event(
                 failure_report(),
-                FailureAttachmentOutcome::Attached(TaskBundle {
+                None,
+                FailureAttachmentOutcome::Attached(ImageBundle {
                     buffer: b"zip-body".to_vec(),
                     filename: "failure.zip".to_string(),
-                    log_count: 2,
                     image_count: 1,
                     selected_raw_bytes: 1024,
                     warnings: Vec::new(),
@@ -1654,6 +2023,15 @@ mod tests {
         };
         assert_eq!(event.tags["task.name"], "DailyTask");
         assert_eq!(event.tags["failure.node"], "EnterBattle");
+        assert_eq!(
+            event.extra["terminal_failure.node"],
+            sentry::protocol::Value::from("FailureCollector")
+        );
+        assert_eq!(
+            event.extra["run.id"],
+            sentry::protocol::Value::from("run-123")
+        );
+        assert_eq!(event.extra["task.id"], sentry::protocol::Value::from(42i64));
         assert_eq!(event.tags["failure.stage"], "recognition");
         assert_eq!(event.fingerprint.len(), 5);
         assert_eq!(event.fingerprint[0], "mxu-task-failure");
@@ -1667,6 +2045,167 @@ mod tests {
     }
 
     #[test]
+    fn diagnostic_logs_are_chunked_and_linked_to_the_failure_event() {
+        let content = format!("[ERR] {}", "界".repeat(16 * 1024 + 5));
+        let expected_content = content.clone();
+        let options = sentry::ClientOptions::new().enable_logs(true);
+        let envelopes = sentry::test::with_captured_envelopes_options(
+            || {
+                capture_failure_event(
+                    failure_report(),
+                    Some(DiagnosticLogs {
+                        entries: vec![task_diagnostics::DiagnosticLog {
+                            source: "maafw.log".to_string(),
+                            kind: "maafw",
+                            content,
+                            raw_bytes: expected_content.len() as u64,
+                        }],
+                        selected_raw_bytes: expected_content.len() as u64,
+                        truncated: false,
+                        warnings: Vec::new(),
+                    }),
+                    FailureAttachmentOutcome::NotSelected,
+                );
+            },
+            options,
+        );
+
+        let mut event_id = None;
+        let mut log_bodies = Vec::new();
+        let mut linked_event_ids = Vec::new();
+        for envelope in &envelopes {
+            for item in envelope.items() {
+                match item {
+                    sentry::protocol::EnvelopeItem::Event(event) => {
+                        event_id = Some(event.event_id.to_string());
+                        assert_eq!(
+                            event.extra["logs.status"],
+                            sentry::protocol::Value::String("captured".to_string())
+                        );
+                    }
+                    sentry::protocol::EnvelopeItem::ItemContainer(
+                        sentry::protocol::ItemContainer::Logs(logs),
+                    ) => {
+                        for log in logs.iter() {
+                            log_bodies.push(log.body.clone());
+                            linked_event_ids.push(
+                                log.attributes
+                                    .get("sentry.event_id")
+                                    .expect("linked failure event id")
+                                    .clone(),
+                            );
+                            assert_eq!(
+                                log.attributes["diagnostic.source"],
+                                sentry::protocol::LogAttribute::from("maafw.log")
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        assert!(log_bodies.len() > 2);
+        assert_eq!(log_bodies.concat(), expected_content);
+        let expected_event_id = sentry::protocol::LogAttribute::from(
+            event_id.expect("failure event should be captured"),
+        );
+        assert!(linked_event_ids
+            .iter()
+            .all(|linked| linked == &expected_event_id));
+    }
+
+    #[test]
+    fn serialized_log_chunking_preserves_unicode_and_bounds_every_record() {
+        let content = format!("{}{}", "界".repeat(8 * 1024), "\0".repeat(8 * 1024));
+        let source = task_diagnostics::DiagnosticLog {
+            source: "maafw.log".to_string(),
+            kind: "maafw",
+            content: content.clone(),
+            raw_bytes: content.len() as u64,
+        };
+        let records = build_diagnostic_log_records(
+            &source,
+            DiagnosticLogContext {
+                event_id: "00000000000000000000000000000000",
+                run_id: "run-123",
+                maa_task_id: 42,
+                task_name: "DailyTask",
+                failure_node: "EnterBattle",
+                failure_stage: "recognition",
+                trace_id: None,
+                span_id: None,
+            },
+        );
+
+        assert!(records.len() > 2);
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.body.as_str())
+                .collect::<String>(),
+            content
+        );
+        assert!(records.iter().all(|record| {
+            serde_json::to_vec(record)
+                .is_ok_and(|serialized| serialized.len() <= MAX_SERIALIZED_DIAGNOSTIC_LOG_BYTES)
+        }));
+    }
+
+    #[test]
+    fn sdk_log_batches_stay_below_the_relay_item_limit() {
+        const SENTRY_LOG_ITEM_LIMIT_BYTES: usize = 1024 * 1024;
+
+        // Control characters are a deliberate worst case: each byte expands to a
+        // six-byte JSON escape sequence and forces more than one 100-record batch.
+        let content = "\0".repeat(160 * 1024);
+        let expected_content = content.clone();
+        let options = sentry::ClientOptions::new().enable_logs(true);
+        let envelopes = sentry::test::with_captured_envelopes_options(
+            || {
+                capture_failure_event(
+                    failure_report(),
+                    Some(DiagnosticLogs {
+                        entries: vec![task_diagnostics::DiagnosticLog {
+                            source: "maafw.log".to_string(),
+                            kind: "maafw",
+                            content,
+                            raw_bytes: expected_content.len() as u64,
+                        }],
+                        selected_raw_bytes: expected_content.len() as u64,
+                        truncated: false,
+                        warnings: Vec::new(),
+                    }),
+                    FailureAttachmentOutcome::NotSelected,
+                );
+            },
+            options,
+        );
+
+        let mut batch_count = 0;
+        let mut bodies = Vec::new();
+        for envelope in &envelopes {
+            for item in envelope.items() {
+                if let sentry::protocol::EnvelopeItem::ItemContainer(
+                    sentry::protocol::ItemContainer::Logs(logs),
+                ) = item
+                {
+                    batch_count += 1;
+                    assert!(logs.len() <= 100);
+                    assert!(
+                        serde_json::to_vec(logs).expect("serialize logs item").len()
+                            < SENTRY_LOG_ITEM_LIMIT_BYTES
+                    );
+                    bodies.extend(logs.iter().map(|record| record.body.clone()));
+                }
+            }
+        }
+
+        assert!(batch_count > 1);
+        assert_eq!(bodies.concat(), expected_content);
+    }
+
+    #[test]
     fn attachment_sampling_has_stable_boundaries() {
         assert!(!should_sample_attachment("run", 1, 0.0));
         assert!(should_sample_attachment("run", 1, 1.0));
@@ -1674,6 +2213,32 @@ mod tests {
             should_sample_attachment("run", 42, 0.5),
             should_sample_attachment("run", 42, 0.5)
         );
+    }
+
+    #[test]
+    fn first_failure_is_retained_for_grouping_and_last_failure_is_preserved() {
+        let mut roots = HashMap::new();
+        let mut terminals = HashMap::new();
+        let root = FailureSignal {
+            node: "RootNode".to_string(),
+            stage: "recognition".to_string(),
+            source_task_id: 7,
+            node_id: Some(1),
+            duration_ms: Some(100),
+        };
+        let terminal = FailureSignal {
+            node: "Collector".to_string(),
+            stage: "action".to_string(),
+            source_task_id: 8,
+            node_id: Some(2),
+            duration_ms: Some(10),
+        };
+
+        retain_failure_signals(&mut roots, &mut terminals, 42, root.clone());
+        retain_failure_signals(&mut roots, &mut terminals, 42, terminal.clone());
+
+        assert_eq!(roots.get(&42), Some(&root));
+        assert_eq!(terminals.get(&42), Some(&terminal));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -630,6 +630,7 @@ function App() {
           environment: sentryCfg.environment ?? channel,
           tracing: sentryCfg.tracing ?? true,
           tracesSampleRate: sentryCfg.traces_sample_rate ?? 1.0,
+          failureAttachmentsSampleRate: sentryCfg.failure_attachments_sample_rate ?? 1.0,
           appName,
           appVersion,
           mxuVersion,

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -118,7 +118,7 @@ export default {
       'Show a confirmation dialog before delete/clear list and other dangerous actions.',
     helpImproveSoftware: 'Help Improve the Software',
     helpImproveSoftwareHint:
-      'Anonymously send crash reports and task statistics to help find common issues.',
+      'Anonymously send crash reports, task statistics, and relevant logs and error screenshots from failed tasks to help find common issues.',
     helpImproveSoftwareDisabledHint:
       'Anonymous data reporting is disabled in debug / development builds.',
     maxLogsPerInstance: 'Max logs per instance',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -118,7 +118,7 @@ export default {
     confirmBeforeDeleteHint: '削除/一覧クリア等の危険な操作の前に確認ダイアログを表示します',
     helpImproveSoftware: 'ソフトウェアの改善に協力',
     helpImproveSoftwareHint:
-      'クラッシュとタスク統計を匿名で送信し、よくある問題の発見に役立てます。',
+      'クラッシュ、タスク統計、失敗したタスクの関連ログとエラースクリーンショットを匿名で送信し、よくある問題の発見に役立てます。',
     helpImproveSoftwareDisabledHint: 'デバッグ / 開発版のため、匿名データ送信は無効になっています',
     maxLogsPerInstance: 'インスタンスあたりのログ上限',
     maxLogsPerInstanceHint: '上限を超えると古いログから自動的に破棄します（推奨 500～2000）',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -116,7 +116,7 @@ export default {
     confirmBeforeDeleteHint: '삭제/목록 비우기 등 위험한 작업 전에 확인 대화 상자를 표시합니다',
     helpImproveSoftware: '소프트웨어 개선에 참여',
     helpImproveSoftwareHint:
-      '충돌 및 작업 통계를 익명으로 전송하여 일반적인 문제를 찾는 데 도움을 줍니다.',
+      '충돌, 작업 통계, 실패한 작업의 관련 로그와 오류 스크린샷을 익명으로 전송하여 일반적인 문제를 찾는 데 도움을 줍니다.',
     helpImproveSoftwareDisabledHint: '디버그 / 개발 버전에서는 익명 데이터 전송이 비활성화됩니다',
     maxLogsPerInstance: '인스턴스당 로그 최대 개수',
     maxLogsPerInstanceHint: '한도를 초과하면 가장 오래된 로그가 자동으로 삭제됩니다(권장 500~2000)',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -115,7 +115,8 @@ export default {
     confirmBeforeDelete: '删除操作需要二次确认',
     confirmBeforeDeleteHint: '删除任务、清空列表等危险操作会先弹出确认对话框',
     helpImproveSoftware: '帮助改进软件',
-    helpImproveSoftwareHint: '匿名发送崩溃与任务统计，帮助发现常见问题',
+    helpImproveSoftwareHint:
+      '匿名发送崩溃、任务统计及失败任务的相关日志与错误截图，帮助发现常见问题',
     helpImproveSoftwareDisabledHint: '当前为调试 / 开发版本，已禁用匿名数据上报',
     maxLogsPerInstance: '每个实例保留的日志上限',
     maxLogsPerInstanceHint: '超过上限会自动丢弃最旧的日志（建议 500～2000）',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -114,7 +114,8 @@ export default {
     confirmBeforeDelete: '刪除操作需要二次確認',
     confirmBeforeDeleteHint: '刪除任務、清空列表等危險操作會先彈出確認對話框',
     helpImproveSoftware: '協助改進軟體',
-    helpImproveSoftwareHint: '匿名傳送崩潰與任務統計，協助發現常見問題',
+    helpImproveSoftwareHint:
+      '匿名傳送崩潰、任務統計及失敗任務的相關日誌與錯誤截圖，協助發現常見問題',
     helpImproveSoftwareDisabledHint: '目前為除錯 / 開發版本，已停用匿名資料回報',
     maxLogsPerInstance: '每個實例保留的日誌上限',
     maxLogsPerInstanceHint: '超出上限會自動丟棄最舊的日誌（建議 500～2000）',

--- a/src/services/telemetryService.ts
+++ b/src/services/telemetryService.ts
@@ -157,6 +157,8 @@ export interface TelemetryInitConfig {
   tracing: boolean;
   /** 事务采样率 0~1 */
   tracesSampleRate: number;
+  /** 失败附件独立采样率 0~1 */
+  failureAttachmentsSampleRate: number;
   /** 资源项目名（interface.name），用于 tag app.name */
   appName: string;
   /** 资源项目版本（interface.version），用于 tag app.version */

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -56,6 +56,8 @@ export interface SentryTelemetryConfig {
   tracing?: boolean;
   /** 事务采样率，取值 0~1。可选，默认 1.0。 */
   traces_sample_rate?: number;
+  /** 失败附件独立采样率，取值 0~1。Error Event 本身不受影响。可选，默认 1.0。 */
+  failure_attachments_sample_rate?: number;
   /** 环境标签（如 production、beta）。可选，缺省由 Client 决定。 */
   environment?: string;
 }


### PR DESCRIPTION
## Summary

- Report terminal Maa task failures as groupable Sentry Error Events, using the first observed failure as the root cause and retaining the final failure as terminal context.
- Send bounded task-scoped text diagnostics through Sentry Logs and correlate every record with the Error Event through sentry.event_id, run.id, and task.id.
- Attach only bounded on_error screenshots to the same Error Event as a stored ZIP; text logs no longer consume attachment quota.
- Upgrade sentry-rust to 0.49.1 with Logs and release-health support.
- Support the optional Project Interface failure_attachments_sample_rate setting independently from Error Events, Logs, and transaction sampling.

## Evidence boundaries

- Logs: 1 MiB total, 512 KiB per file; records are sized by serialized JSON and SDK batches are tested below the 1 MiB Logs item limit.
- Screenshots: 5 MiB raw and 5 MiB final bundle; PNG/JPEG entries use ZIP Stored rather than recompression.
- Discovery: at most 8192 entries, depth 16, 128 log files, and 128 screenshots; symlinks are skipped and limit hits are visible in event metadata.
- Stable file handles and frozen end offsets prevent rotation or later tasks from changing selected evidence.
- A bounded one-second screenshot settle window catches late MaaFramework writes, while a task epoch prevents the next task or another instance from publishing stale evidence.
- Same-path screenshot overwrites are detected by file metadata instead of being discarded as pre-existing.

## Project Interface proposal

The schema and documentation proposal for failure_attachments_sample_rate is MaaFramework PR #1461:
https://github.com/MaaXYZ/MaaFramework/pull/1461

The field is optional and defaults to 1.0. It controls screenshots only; Error Events and Sentry Logs remain independent.

## Verification

- cargo test --all-targets -j1 with CARGO_PROFILE_TEST_DEBUG=0: 34 passed
- cargo fmt --all -- --check: passed
- git diff --check: passed
- cargo clippy --all-targets -j1: passed with existing warnings outside the changed files