### PR TITLE
fix: 增加config备份、恢复

### DIFF
--- a/src-tauri/src/commands/app_config.rs
+++ b/src-tauri/src/commands/app_config.rs
@@ -3,10 +3,43 @@
 //! 为 HTTP 服务器提供 interface.json 和配置文件的内存缓存，
 //! 与现有 MaaState 并列，由 `app.manage()` 注入。
 
+use chrono::{Local, NaiveDateTime};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tauri::State;
+
+/// 备份目录（位于 `{data_path}/cache/` 下）
+const BACKUP_SUBDIR: &str = "config_backup";
+/// 备份文件名与 `.corrupt-` 后缀共用的时间戳格式
+const BACKUP_TIMESTAMP_FORMAT: &str = "%Y%m%d-%H%M%S";
+/// 滚动备份最小间隔：距上一份备份不足 1 天则跳过本次备份
+const BACKUP_MIN_INTERVAL_SECS: i64 = 24 * 60 * 60;
+/// 备份池保留份数。
+///
+/// 按份数而非天数裁剪：按天数会在长期不使用后把备份池清空到 0 份，
+/// 而自愈完全依赖这个池里还有候选可用。
+const BACKUP_KEEP_COUNT: usize = 10;
+
+/// 配置损坏自愈的结果类型
+#[derive(Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigRecoveryKind {
+    /// 已从某份备份恢复
+    Restored,
+    /// 没有可用备份，已重置为默认配置
+    Reset,
+}
+
+/// 配置损坏后的自愈结果，供前端提示用户
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigRecoveryNotice {
+    pub kind: ConfigRecoveryKind,
+    /// kind 为 Restored 时，被采用的那份备份的时间（用于展示）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backup_time: Option<String>,
+}
 
 /// 应用配置状态（供 HTTP server 使用）
 #[derive(Default)]
@@ -23,6 +56,10 @@ pub struct AppConfigState {
     pub project_name: Mutex<Option<String>>,
     /// 当前 MXU 配置（原始 JSON，启动时从磁盘加载，变更时写回）
     pub config: Mutex<serde_json::Value>,
+    /// 配置损坏自愈的结果，等前端取走后清空
+    pub recovery_notice: Mutex<Option<ConfigRecoveryNotice>>,
+    /// 下一次允许尝试滚动备份的时刻，仅作为廉价的提前返回缓存
+    pub next_backup_allowed_at: Mutex<Option<NaiveDateTime>>,
 }
 
 impl AppConfigState {
@@ -86,19 +123,37 @@ impl AppConfigState {
 
         if config_path.exists() {
             match std::fs::read_to_string(&config_path) {
-                Ok(content) => match serde_json::from_str::<serde_json::Value>(&content) {
-                    Ok(config) => {
-                        log::info!("AppConfigState: config loaded from {:?}", config_path);
-                        *self.config.lock().unwrap() = config;
-                        return;
+                Ok(content) => {
+                    if is_corrupt_content(&content) {
+                        log::error!("AppConfigState: config is corrupt (empty or all-NUL bytes)");
+                    } else {
+                        match serde_json::from_str::<serde_json::Value>(&content) {
+                            Ok(config) if is_valid_mxu_config(&config) => {
+                                log::info!("AppConfigState: config loaded from {:?}", config_path);
+                                *self.config.lock().unwrap() = config;
+                                return;
+                            }
+                            Ok(_) => {
+                                log::error!("AppConfigState: config structure is invalid");
+                            }
+                            Err(e) => {
+                                log::error!("AppConfigState: failed to parse config: {}", e);
+                            }
+                        }
                     }
-                    Err(e) => {
-                        log::warn!("AppConfigState: failed to parse config: {}", e);
-                    }
-                },
-                Err(e) => {
-                    log::warn!("AppConfigState: failed to read config: {}", e);
                 }
+                Err(e) => {
+                    log::error!("AppConfigState: failed to read config: {}", e);
+                }
+            }
+
+            // 文件存在但不可用：尝试从备份自愈。
+            // 文件不存在时不做恢复，那是全新安装或用户主动移走了配置。
+            if let Some(recovered) =
+                self.try_recover_config(data_dir, &config_filename, &config_path)
+            {
+                *self.config.lock().unwrap() = recovered;
+                return;
             }
         } else {
             log::info!(
@@ -108,14 +163,150 @@ impl AppConfigState {
         }
 
         // 默认配置（第一次使用时）
-        *self.config.lock().unwrap() = serde_json::json!({
-            "version": "1.0",
-            "instances": [],
-            "settings": {
-                "theme": "system",
-                "language": "system"
+        *self.config.lock().unwrap() = default_config();
+    }
+
+    /// 配置损坏时尝试从备份池恢复，成功返回恢复出的配置。
+    ///
+    /// 按时间从新到旧逐个校验，取第一份有效的。必须能继续往前退——同一次崩溃很可能
+    /// 把最新那份备份也一起打成全零。
+    fn try_recover_config(
+        &self,
+        data_path: &Path,
+        config_filename: &str,
+        config_path: &Path,
+    ) -> Option<serde_json::Value> {
+        // 保留损坏文件，便于事后排查与提 issue
+        if config_path.exists() {
+            let corrupt_path = config_path.with_file_name(format!(
+                "{}.corrupt-{}",
+                config_filename,
+                Local::now().format(BACKUP_TIMESTAMP_FORMAT)
+            ));
+            match std::fs::rename(config_path, &corrupt_path) {
+                Ok(()) => log::warn!("AppConfigState: kept corrupt config at {:?}", corrupt_path),
+                Err(e) => log::warn!("AppConfigState: failed to keep corrupt config: {}", e),
             }
+        }
+
+        for backup in list_backups_newest_first(data_path, config_filename) {
+            let content = match std::fs::read_to_string(&backup.path) {
+                Ok(c) => c,
+                Err(e) => {
+                    log::warn!(
+                        "AppConfigState: backup {} unreadable, trying an older one: {}",
+                        backup.name,
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            if is_corrupt_content(&content) {
+                log::warn!(
+                    "AppConfigState: backup {} is corrupt, trying an older one",
+                    backup.name
+                );
+                continue;
+            }
+
+            let parsed = match serde_json::from_str::<serde_json::Value>(&content) {
+                Ok(v) if is_valid_mxu_config(&v) => v,
+                _ => {
+                    log::warn!(
+                        "AppConfigState: backup {} is invalid, trying an older one",
+                        backup.name
+                    );
+                    continue;
+                }
+            };
+
+            // 写回磁盘，让随后读盘的前端直接拿到好文件；写失败也仍然可以用内存里这份
+            if let Err(e) = std::fs::write(config_path, &content) {
+                log::error!("AppConfigState: failed to restore config to disk: {}", e);
+            }
+
+            *self.recovery_notice.lock().unwrap() = Some(ConfigRecoveryNotice {
+                kind: ConfigRecoveryKind::Restored,
+                backup_time: Some(format_backup_display_time(backup.time)),
+            });
+            log::info!(
+                "AppConfigState: config restored from backup {}",
+                backup.name
+            );
+            return Some(parsed);
+        }
+
+        *self.recovery_notice.lock().unwrap() = Some(ConfigRecoveryNotice {
+            kind: ConfigRecoveryKind::Reset,
+            backup_time: None,
         });
+        log::error!("AppConfigState: no usable backup, config will be reset to default");
+        None
+    }
+
+    /// 滚动备份：把磁盘上的当前配置（即上一代内容）复制进备份池。
+    ///
+    /// 备份旧文件而不是即将写入的新内容——旧文件写入更早、数据大概率已经落盘，
+    /// 拿来当备份更可靠。当前文件本身已损坏时跳过，避免把损坏内容灌进备份池。
+    ///
+    /// 间隔的权威来源是备份目录里最新那份的文件名时间戳。只靠内存变量的话每次启动
+    /// 都会归零，用户一天开关几次程序就会各备份一次，1 天的间隔约束等于失效。
+    fn rolling_backup(&self, data_path: &Path, config_filename: &str, config_path: &Path) {
+        let now = Local::now().naive_local();
+        let interval = chrono::Duration::seconds(BACKUP_MIN_INTERVAL_SECS);
+
+        if let Some(allowed_at) = *self.next_backup_allowed_at.lock().unwrap() {
+            if now < allowed_at {
+                return;
+            }
+        }
+
+        let backups = list_backups_newest_first(data_path, config_filename);
+        let newest = backups.first();
+
+        if let Some(newest) = newest {
+            if now.signed_duration_since(newest.time) < interval {
+                *self.next_backup_allowed_at.lock().unwrap() = Some(newest.time + interval);
+                return;
+            }
+        }
+
+        // 还没有配置文件可备份
+        let Ok(content) = std::fs::read_to_string(config_path) else {
+            return;
+        };
+
+        let usable = !is_corrupt_content(&content)
+            && serde_json::from_str::<serde_json::Value>(&content)
+                .map(|v| is_valid_mxu_config(&v))
+                .unwrap_or(false);
+        if !usable {
+            log::warn!("AppConfigState: current config is unusable, skipping rolling backup");
+            return;
+        }
+
+        // 与最新一份备份内容相同时没有备份价值；推迟下次尝试，避免每次保存都重复读盘
+        if let Some(newest) = newest {
+            if std::fs::read_to_string(&newest.path).ok().as_deref() == Some(content.as_str()) {
+                *self.next_backup_allowed_at.lock().unwrap() = Some(now + interval);
+                return;
+            }
+        }
+
+        match write_backup(data_path, config_filename, &content) {
+            Ok(name) => {
+                *self.next_backup_allowed_at.lock().unwrap() = Some(now + interval);
+                log::info!("AppConfigState: rolling backup written {}", name);
+                prune_backups(data_path, config_filename);
+            }
+            Err(e) => {
+                log::warn!(
+                    "AppConfigState: rolling backup failed (save continues): {}",
+                    e
+                );
+            }
+        }
     }
 
     /// 保存配置到磁盘并更新内存
@@ -159,6 +350,10 @@ impl AppConfigState {
                 }
             }
         }
+
+        // 滚动备份：把磁盘上的上一代配置存进备份池。
+        // 内含 1 天间隔判定，绝大多数保存会在这里直接返回。
+        self.rolling_backup(Path::new(&data_path), &config_filename, &config_path);
 
         let content =
             serde_json::to_string_pretty(&config).map_err(|e| format!("序列化配置失败: {}", e))?;
@@ -207,9 +402,137 @@ pub fn notify_config_changed(
     Ok(())
 }
 
+/// 取走并清空配置自愈通知（前端启动时调用一次）
+#[tauri::command]
+pub fn take_config_recovery_notice(
+    state: State<Arc<AppConfigState>>,
+) -> Result<Option<ConfigRecoveryNotice>, String> {
+    Ok(state
+        .recovery_notice
+        .lock()
+        .map_err(|e| e.to_string())?
+        .take())
+}
+
 // ============================================================================
 // 内部辅助函数
 // ============================================================================
+
+fn default_config() -> serde_json::Value {
+    serde_json::json!({
+        "version": "1.0",
+        "instances": [],
+        "settings": {
+            "theme": "system",
+            "language": "system"
+        }
+    })
+}
+
+/// 判断读到的配置内容是否已损坏。
+///
+/// 断电 / 蓝屏后 NTFS 会保留文件长度但把数据读成全 0（文件大小走 journal 落了盘，
+/// 数据没落盘）。NUL 是合法 UTF-8，`read_to_string` 不会失败，所以这种「等长全零」
+/// 必须显式识别出来。空文件同样视为损坏。
+fn is_corrupt_content(content: &str) -> bool {
+    content.chars().all(|c| c == '\0' || c.is_whitespace())
+}
+
+/// 判断 JSON 是否是结构上可用的 MXU 配置（与前端 `isValidMxuConfig` 保持一致）
+fn is_valid_mxu_config(value: &serde_json::Value) -> bool {
+    value.get("version").and_then(|v| v.as_str()).is_some()
+        && value.get("instances").and_then(|v| v.as_array()).is_some()
+        && value.get("settings").and_then(|v| v.as_object()).is_some()
+}
+
+struct BackupEntry {
+    name: String,
+    path: PathBuf,
+    time: NaiveDateTime,
+}
+
+fn backup_dir(data_path: &Path) -> PathBuf {
+    data_path.join("cache").join(BACKUP_SUBDIR)
+}
+
+/// 备份文件名前缀，例如 `mxu-MaaEnd-`
+fn make_backup_prefix(config_filename: &str) -> String {
+    format!(
+        "{}-",
+        config_filename
+            .strip_suffix(".json")
+            .unwrap_or(config_filename)
+    )
+}
+
+fn parse_backup_timestamp(filename: &str, prefix: &str) -> Option<NaiveDateTime> {
+    let stem = filename.strip_prefix(prefix)?.strip_suffix(".json")?;
+    NaiveDateTime::parse_from_str(stem, BACKUP_TIMESTAMP_FORMAT).ok()
+}
+
+/// 供前端展示的备份时间
+fn format_backup_display_time(time: NaiveDateTime) -> String {
+    time.format("%Y-%m-%d %H:%M").to_string()
+}
+
+/// 列出该项目的所有备份，按时间从新到旧排序
+fn list_backups_newest_first(data_path: &Path, config_filename: &str) -> Vec<BackupEntry> {
+    let dir = backup_dir(data_path);
+    let prefix = make_backup_prefix(config_filename);
+
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    let mut backups: Vec<BackupEntry> = entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+            let time = parse_backup_timestamp(&name, &prefix)?;
+            Some(BackupEntry {
+                path: dir.join(&name),
+                name,
+                time,
+            })
+        })
+        .collect();
+
+    backups.sort_by_key(|b| std::cmp::Reverse(b.time));
+    backups
+}
+
+/// 把内容写入备份池，返回备份文件名
+fn write_backup(
+    data_path: &Path,
+    config_filename: &str,
+    content: &str,
+) -> Result<String, std::io::Error> {
+    let dir = backup_dir(data_path);
+    std::fs::create_dir_all(&dir)?;
+
+    let name = format!(
+        "{}{}.json",
+        make_backup_prefix(config_filename),
+        Local::now().format(BACKUP_TIMESTAMP_FORMAT)
+    );
+    std::fs::write(dir.join(&name), content)?;
+    Ok(name)
+}
+
+/// 按份数裁剪备份池，只保留最近 `BACKUP_KEEP_COUNT` 份
+fn prune_backups(data_path: &Path, config_filename: &str) {
+    let backups = list_backups_newest_first(data_path, config_filename);
+    for stale in backups.iter().skip(BACKUP_KEEP_COUNT) {
+        match std::fs::remove_file(&stale.path) {
+            Ok(()) => log::info!("AppConfigState: removed old backup {}", stale.name),
+            Err(e) => log::warn!(
+                "AppConfigState: failed to remove old backup {}: {}",
+                stale.name,
+                e
+            ),
+        }
+    }
+}
 
 fn make_config_filename(project_name: Option<&str>) -> String {
     match project_name {
@@ -461,4 +784,268 @@ fn strip_jsonc_comments(content: &str) -> String {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_temp_dir(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("mxu-config-test-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_config_file(data_path: &Path, content: &str) -> PathBuf {
+        let config_dir = data_path.join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("mxu-MaaEnd.json");
+        std::fs::write(&config_path, content).unwrap();
+        config_path
+    }
+
+    fn sample_config_json() -> String {
+        serde_json::to_string(&serde_json::json!({
+            "version": "1.0",
+            "instances": [{ "id": "a" }],
+            "settings": { "theme": "dark" }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn corrupt_content_detects_all_zero_and_blank() {
+        // issue #4710 的真实样本形态：71578 字节全 0x00
+        assert!(is_corrupt_content(&"\0".repeat(71578)));
+        assert!(is_corrupt_content(""));
+        assert!(is_corrupt_content("  \r\n\t "));
+        assert!(is_corrupt_content("\0\0 \n\0"));
+        assert!(!is_corrupt_content("{}"));
+        assert!(!is_corrupt_content(&sample_config_json()));
+    }
+
+    #[test]
+    fn valid_mxu_config_requires_core_fields() {
+        assert!(is_valid_mxu_config(&default_config()));
+
+        assert!(!is_valid_mxu_config(&serde_json::json!(null)));
+        assert!(!is_valid_mxu_config(&serde_json::json!([])));
+        assert!(!is_valid_mxu_config(
+            &serde_json::json!({ "instances": [], "settings": {} })
+        ));
+        assert!(!is_valid_mxu_config(
+            &serde_json::json!({ "version": 1, "instances": [], "settings": {} })
+        ));
+        assert!(!is_valid_mxu_config(
+            &serde_json::json!({ "version": "1.0", "instances": {}, "settings": {} })
+        ));
+        assert!(!is_valid_mxu_config(
+            &serde_json::json!({ "version": "1.0", "instances": [], "settings": [] })
+        ));
+    }
+
+    #[test]
+    fn backup_listing_is_newest_first_and_project_scoped() {
+        let data_path = make_temp_dir("listing");
+        let dir = backup_dir(&data_path);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        for name in [
+            "mxu-MaaEnd-20260101-000000.json",
+            "mxu-MaaEnd-20260103-120000.json",
+            "mxu-MaaEnd-20260102-000000.json",
+            // 属于其他项目，不应出现在结果里
+            "mxu-Other-20260104-000000.json",
+            // 文件名里没有合法时间戳，不是备份
+            "mxu-MaaEnd-notatimestamp.json",
+        ] {
+            std::fs::write(dir.join(name), "{}").unwrap();
+        }
+
+        let names: Vec<String> = list_backups_newest_first(&data_path, "mxu-MaaEnd.json")
+            .into_iter()
+            .map(|b| b.name)
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "mxu-MaaEnd-20260103-120000.json",
+                "mxu-MaaEnd-20260102-000000.json",
+                "mxu-MaaEnd-20260101-000000.json",
+            ]
+        );
+
+        std::fs::remove_dir_all(&data_path).unwrap();
+    }
+
+    #[test]
+    fn prune_keeps_only_the_newest_backups() {
+        let data_path = make_temp_dir("prune");
+        let dir = backup_dir(&data_path);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let total = BACKUP_KEEP_COUNT + 3;
+        for day in 1..=total {
+            std::fs::write(
+                dir.join(format!("mxu-MaaEnd-202601{:02}-000000.json", day)),
+                "{}",
+            )
+            .unwrap();
+        }
+
+        prune_backups(&data_path, "mxu-MaaEnd.json");
+
+        let remaining = list_backups_newest_first(&data_path, "mxu-MaaEnd.json");
+        assert_eq!(remaining.len(), BACKUP_KEEP_COUNT);
+        assert_eq!(
+            remaining[0].name,
+            format!("mxu-MaaEnd-202601{:02}-000000.json", total)
+        );
+
+        std::fs::remove_dir_all(&data_path).unwrap();
+    }
+
+    #[test]
+    fn recovery_falls_back_to_older_backup_and_keeps_evidence() {
+        let data_path = make_temp_dir("recover");
+        let config_path = write_config_file(&data_path, &"\0".repeat(128));
+
+        let dir = backup_dir(&data_path);
+        std::fs::create_dir_all(&dir).unwrap();
+        // 最新那份备份被同一次崩溃一起打成全零，必须能继续往前退
+        std::fs::write(dir.join("mxu-MaaEnd-20260103-000000.json"), "\0".repeat(64)).unwrap();
+        let good = sample_config_json();
+        std::fs::write(dir.join("mxu-MaaEnd-20260102-000000.json"), &good).unwrap();
+
+        let state = AppConfigState::default();
+        let recovered = state
+            .try_recover_config(&data_path, "mxu-MaaEnd.json", &config_path)
+            .expect("应回退到更早的那份有效备份");
+
+        assert_eq!(recovered["settings"]["theme"], "dark");
+        // 磁盘上的配置也被真正恢复，随后读盘的前端能直接拿到好文件
+        assert_eq!(std::fs::read_to_string(&config_path).unwrap(), good);
+
+        let evidence_kept = std::fs::read_dir(data_path.join("config"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".corrupt-"));
+        assert!(evidence_kept, "损坏文件应被改名保留");
+
+        assert!(matches!(
+            state
+                .recovery_notice
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|n| n.kind),
+            Some(ConfigRecoveryKind::Restored)
+        ));
+
+        std::fs::remove_dir_all(&data_path).unwrap();
+    }
+
+    #[test]
+    fn recovery_without_usable_backup_reports_reset() {
+        let data_path = make_temp_dir("reset");
+        let config_path = write_config_file(&data_path, &"\0".repeat(32));
+
+        let state = AppConfigState::default();
+        assert!(state
+            .try_recover_config(&data_path, "mxu-MaaEnd.json", &config_path)
+            .is_none());
+        assert!(matches!(
+            state
+                .recovery_notice
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|n| n.kind),
+            Some(ConfigRecoveryKind::Reset)
+        ));
+
+        std::fs::remove_dir_all(&data_path).unwrap();
+    }
+
+    #[test]
+    fn rolling_backup_respects_daily_interval() {
+        let data_path = make_temp_dir("rolling");
+        let content = sample_config_json();
+        let config_path = write_config_file(&data_path, &content);
+
+        let dir = backup_dir(&data_path);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // 刚刚备份过，本次应直接跳过
+        let just_now = Local::now().naive_local().format(BACKUP_TIMESTAMP_FORMAT);
+        std::fs::write(dir.join(format!("mxu-MaaEnd-{}.json", just_now)), "{}").unwrap();
+
+        AppConfigState::default().rolling_backup(&data_path, "mxu-MaaEnd.json", &config_path);
+        assert_eq!(
+            list_backups_newest_first(&data_path, "mxu-MaaEnd.json").len(),
+            1
+        );
+
+        // 上一份备份已是两天前，应写入新备份
+        std::fs::remove_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
+        let two_days_ago = (Local::now().naive_local() - chrono::Duration::days(2))
+            .format(BACKUP_TIMESTAMP_FORMAT);
+        std::fs::write(dir.join(format!("mxu-MaaEnd-{}.json", two_days_ago)), "{}").unwrap();
+
+        AppConfigState::default().rolling_backup(&data_path, "mxu-MaaEnd.json", &config_path);
+        let backups = list_backups_newest_first(&data_path, "mxu-MaaEnd.json");
+        assert_eq!(backups.len(), 2);
+        // 备份的是磁盘上的当前配置，而不是 "{}"
+        assert_eq!(std::fs::read_to_string(&backups[0].path).unwrap(), content);
+
+        std::fs::remove_dir_all(&data_path).unwrap();
+    }
+
+    /// 覆盖启动时的完整自愈路径：磁盘上的损坏配置被换成备份内容，
+    /// 内存里拿到的也是恢复后的配置，通知的序列化形状与前端类型一致。
+    #[test]
+    fn load_config_heals_corrupt_file_on_startup() {
+        let data_path = make_temp_dir("startup-heal");
+        // 与 issue #4710 的真实样本同形态：71578 字节全 0x00
+        let config_path = write_config_file(&data_path, &"\0".repeat(71578));
+
+        let dir = backup_dir(&data_path);
+        std::fs::create_dir_all(&dir).unwrap();
+        let good = sample_config_json();
+        std::fs::write(dir.join("mxu-MaaEnd-20260801-120000.json"), &good).unwrap();
+
+        let state = AppConfigState::default();
+        // 真实启动顺序里 load_interface 先跑，project_name 已就位
+        *state.project_name.lock().unwrap() = Some("MaaEnd".to_string());
+        state.load_config(&data_path);
+
+        assert_eq!(state.config.lock().unwrap()["settings"]["theme"], "dark");
+        assert_eq!(std::fs::read_to_string(&config_path).unwrap(), good);
+
+        let notice = state.recovery_notice.lock().unwrap().take().unwrap();
+        assert_eq!(
+            serde_json::to_string(&notice).unwrap(),
+            r#"{"kind":"restored","backupTime":"2026-08-01 12:00"}"#
+        );
+
+        std::fs::remove_dir_all(&data_path).unwrap();
+    }
+
+    #[test]
+    fn rolling_backup_skips_corrupt_current_config() {
+        let data_path = make_temp_dir("rolling-corrupt");
+        let config_path = write_config_file(&data_path, &"\0".repeat(256));
+
+        AppConfigState::default().rolling_backup(&data_path, "mxu-MaaEnd.json", &config_path);
+
+        assert!(
+            list_backups_newest_first(&data_path, "mxu-MaaEnd.json").is_empty(),
+            "损坏内容不应被灌进备份池"
+        );
+
+        std::fs::remove_dir_all(&data_path).unwrap();
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -313,6 +313,7 @@ pub fn run() {
             commands::tray::update_tray_tooltip,
             // 配置同步命令（WebUI 实时同步）
             commands::app_config::notify_config_changed,
+            commands::app_config::take_config_recovery_notice,
             // 匿名遥测命令
             commands::telemetry::telemetry_init,
             commands::telemetry::telemetry_set_enabled,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   loadConfig,
   loadConfigFromStorage,
   consumeSelfSave,
+  consumeConfigRecoveryNotice,
   markSelfSave,
   resolveI18nText,
   checkAndPrepareDownload,
@@ -29,6 +30,7 @@ import {
   proxySettingsForUpdateDownload,
   stopInstanceTasksAndExitApp,
 } from '@/services';
+import type { ConfigRecoveryNotice } from '@/services';
 import { loadIconAsDataUrl } from '@/services/contentResolver';
 import * as wsService from '@/services/wsService';
 import {
@@ -59,7 +61,7 @@ import { getAllLogsFromBackend } from '@/utils/logStdout';
 import { useMaaCallbackLogger, useMaaAgentLogger } from '@/utils/useMaaCallbackLogger';
 import { getInterfaceLangKey } from '@/i18n';
 import { applyTheme, resolveThemeMode, registerCustomAccent, clearCustomAccents } from '@/themes';
-import { Toaster } from 'sonner';
+import { Toaster, toast } from 'sonner';
 import { loadWebUIAppearance, loadWebUILayout } from '@/services/appearanceStorage';
 import {
   clearPersistedRuntimeLogs,
@@ -86,7 +88,7 @@ import { WebUIBetaBanner } from './components/app/WebUIBetaBanner';
 import { startGlobalCallbackListener } from './components/connection/callbackCache';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { ScrollText } from 'lucide-react';
-import { defaultWindowSize } from '@/types/config';
+import { defaultConfig, defaultWindowSize, isValidMxuConfig } from '@/types/config';
 
 const log = loggers.app;
 
@@ -601,6 +603,32 @@ function App() {
       // 加载用户配置（mxu-{项目名}.json）- 从数据目录加载
       const projectName = result.interface.name;
       let config = await loadConfig(result.dataPath, projectName);
+
+      // loadConfig 已保证返回结构有效，这里再兜一层，避免任何路径把非法值传到下游
+      if (!isValidMxuConfig(config)) {
+        log.error('配置结构异常，回退到默认配置');
+        config = defaultConfig;
+      }
+
+      // 配置损坏自愈提示。Rust 侧在启动早期就会先尝试修复磁盘上的文件，
+      // 前端读盘时也可能自行触发，两侧的通知都取走后只提示一次。
+      const tsRecovery = consumeConfigRecoveryNotice();
+      let backendRecovery: ConfigRecoveryNotice | null = null;
+      if (isTauri()) {
+        try {
+          backendRecovery = await invoke<ConfigRecoveryNotice | null>(
+            'take_config_recovery_notice',
+          );
+        } catch (err) {
+          log.debug('获取后端配置自愈通知失败:', err);
+        }
+      }
+      const recovery = tsRecovery ?? backendRecovery;
+      if (recovery?.kind === 'restored') {
+        toast.warning(t('config.recoveredFromBackup', { time: recovery.backupTime ?? '' }));
+      } else if (recovery?.kind === 'reset') {
+        toast.error(t('config.recoveryFailed'));
+      }
 
       // 浏览器环境下，如果没有从 public 目录加载到配置，尝试从 localStorage 加载
       if (config.instances.length === 0) {

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -594,6 +594,14 @@ export default {
     webServerAddress: 'Web Server Address',
   },
 
+  // Config self-heal notices
+  config: {
+    recoveredFromBackup:
+      'The config file was corrupted and has been restored from the {{time}} backup',
+    recoveryFailed:
+      'The config file was corrupted and no usable backup was found, so it has been reset to defaults',
+  },
+
   // Welcome dialog
   welcome: {
     dismiss: 'Got it',

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -592,6 +592,14 @@ export default {
     webServerAddress: 'Web サーバーアドレス',
   },
 
+  // 設定の自動修復通知
+  config: {
+    recoveredFromBackup:
+      '設定ファイルが破損していたため、{{time}} のバックアップから自動的に復元しました',
+    recoveryFailed:
+      '設定ファイルが破損しており、利用可能なバックアップもないため、既定の設定にリセットしました',
+  },
+
   // ウェルカムダイアログ
   welcome: {
     dismiss: '了解しました',

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -583,6 +583,13 @@ export default {
     webServerAddress: 'Web 서버 주소',
   },
 
+  // 설정 자동 복구 알림
+  config: {
+    recoveredFromBackup: '설정 파일이 손상되어 {{time}} 백업에서 자동으로 복원했습니다',
+    recoveryFailed:
+      '설정 파일이 손상되었고 사용할 수 있는 백업이 없어 기본 설정으로 초기화했습니다',
+  },
+
   // 환영 대화상자
   welcome: {
     dismiss: '확인했습니다',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -571,6 +571,12 @@ export default {
     webServerAddress: 'Web 服务地址',
   },
 
+  // 配置自愈提示
+  config: {
+    recoveredFromBackup: '配置文件已损坏，已自动恢复到 {{time}} 的备份',
+    recoveryFailed: '配置文件已损坏且没有可用备份，已重置为默认配置',
+  },
+
   // 欢迎弹窗
   welcome: {
     dismiss: '我知道了',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -567,6 +567,12 @@ export default {
     webServerAddress: 'Web 服務地址',
   },
 
+  // 設定自我修復提示
+  config: {
+    recoveredFromBackup: '設定檔已損壞，已自動還原到 {{time}} 的備份',
+    recoveryFailed: '設定檔已損壞且沒有可用的備份，已重設為預設設定',
+  },
+
   // 欢迎彈窗
   welcome: {
     dismiss: '我知道了',

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -1,5 +1,5 @@
 import type { MxuConfig } from '@/types/config';
-import { defaultConfig } from '@/types/config';
+import { defaultConfig, isValidMxuConfig } from '@/types/config';
 import { loggers } from '@/utils/logger';
 import { parseJsonc } from '@/utils/jsonc';
 import { joinPath, isTauri, getCacheDir } from '@/utils/paths';
@@ -29,7 +29,42 @@ export function consumeSelfSave(): boolean {
 // 配置文件子目录
 const CONFIG_DIR = 'config';
 const BACKUP_SUBDIR = 'config_backup';
-const BACKUP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+/** 滚动备份最小间隔：距上一份备份不足 1 天则跳过本次备份 */
+const BACKUP_MIN_INTERVAL_MS = 24 * 60 * 60 * 1000;
+/**
+ * 备份池保留份数。
+ *
+ * 按份数而非按天数裁剪：按天数会在长期不使用后把备份池清空到 0 份，
+ * 而自愈完全依赖这个池里还有候选可用。
+ */
+const BACKUP_KEEP_COUNT = 10;
+
+/** 配置损坏后的自愈结果，供 UI 提示用户 */
+export interface ConfigRecoveryNotice {
+  kind: 'restored' | 'reset';
+  /** kind 为 restored 时，被采用的那份备份的时间（用于展示） */
+  backupTime?: string;
+}
+
+let _recoveryNotice: ConfigRecoveryNotice | null = null;
+
+/** 取走并清空自愈通知（与 markSelfSave / consumeSelfSave 同一模式） */
+export function consumeConfigRecoveryNotice(): ConfigRecoveryNotice | null {
+  const notice = _recoveryNotice;
+  _recoveryNotice = null;
+  return notice;
+}
+
+/**
+ * 判断读到的配置内容是否已损坏。
+ *
+ * 断电 / 蓝屏后 NTFS 会保留文件长度但把数据读成全 0（文件大小走 journal 落了盘，
+ * 数据没落盘）。NUL 是合法 UTF-8，`readTextFile` 不会失败，`parseJsonc` 也只打警告，
+ * 所以这种「等长全零」必须显式识别出来。
+ */
+function isCorruptContent(content: string): boolean {
+  return content.replace(/[\0\s]/g, '') === '';
+}
 
 /** 生成配置文件名 */
 function getConfigFileName(projectName?: string): string {
@@ -60,15 +95,33 @@ export async function loadConfig(basePath: string, projectName?: string): Promis
     const { readTextFile, exists } = await import('@tauri-apps/plugin-fs');
 
     if (await exists(configPath)) {
+      let content: string | null = null;
       try {
-        const content = await readTextFile(configPath);
-        const config = parseJsonc<MxuConfig>(content, configPath);
-        log.info('配置加载成功');
-        return config;
+        content = await readTextFile(configPath);
       } catch (err) {
-        log.warn('读取配置文件失败，使用默认配置:', err);
-        return defaultConfig;
+        log.warn('读取配置文件失败:', err);
       }
+
+      if (content !== null) {
+        if (isCorruptContent(content)) {
+          log.error('配置文件已损坏：内容为空或全为 NUL 字节');
+        } else {
+          // parseJsonc 解析失败时返回 undefined 而不抛异常，必须校验后再返回，
+          // 否则 undefined 会一路传到调用方访问 config.instances 时才炸。
+          const parsed = parseJsonc<MxuConfig>(content, configPath);
+          if (isValidMxuConfig(parsed)) {
+            log.info('配置加载成功');
+            return parsed;
+          }
+          log.error('配置文件结构无效');
+        }
+      }
+
+      // 文件存在但不可用：尝试从备份自愈。
+      // 文件不存在时不做恢复，那是全新安装或用户主动移走了配置。
+      const recovered = await tryRecoverConfig(basePath, projectName);
+      if (recovered) return recovered;
+      return defaultConfig;
     } else {
       log.info('配置文件不存在，使用默认配置');
     }
@@ -76,7 +129,7 @@ export async function loadConfig(basePath: string, projectName?: string): Promis
     // 浏览器环境：优先从后端 HTTP API 获取（Tauri 进程运行时提供权威配置）
     try {
       const config = await apiGet<MxuConfig>('/config');
-      if (config && config.version) {
+      if (isValidMxuConfig(config)) {
         log.info('配置加载成功（后端 HTTP API）');
         return config;
       }
@@ -95,8 +148,10 @@ export async function loadConfig(basePath: string, projectName?: string): Promis
         if (contentType?.includes('application/json')) {
           const content = await response.text();
           const config = parseJsonc<MxuConfig>(content, fetchPath);
-          log.info('配置加载成功（浏览器环境静态文件）');
-          return config;
+          if (isValidMxuConfig(config)) {
+            log.info('配置加载成功（浏览器环境静态文件）');
+            return config;
+          }
         }
       }
     } catch {
@@ -173,6 +228,10 @@ export async function saveConfig(
         return false;
       }
     }
+
+    // 滚动备份：把磁盘上的上一代配置存进备份池。
+    // 内含 1 天间隔判定，绝大多数保存会在这里直接返回。
+    await rollingBackup(basePath, projectName);
 
     const content = JSON.stringify(config, null, 2);
     // 原子写：先写到 .tmp，再 rename 覆盖正式文件。
@@ -251,8 +310,202 @@ function parseTimestampFromFilename(filename: string): Date | null {
   );
 }
 
+/** 供 toast 展示的备份时间 */
+function formatBackupDisplayTime(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+interface BackupEntry {
+  name: string;
+  path: string;
+  time: Date;
+}
+
+/** 备份文件名前缀，例如 mxu-MaaEnd- */
+function getBackupPrefix(projectName?: string): string {
+  return `${getConfigFileName(projectName).replace(/\.json$/, '')}-`;
+}
+
+async function getBackupDir(): Promise<string> {
+  return joinPath(await getCacheDir(), BACKUP_SUBDIR);
+}
+
+/** 列出该项目的所有备份，按时间从新到旧排序 */
+async function listBackupsNewestFirst(projectName?: string): Promise<BackupEntry[]> {
+  const { exists, readDir } = await import('@tauri-apps/plugin-fs');
+
+  const backupDir = await getBackupDir();
+  if (!(await exists(backupDir))) return [];
+
+  const prefix = getBackupPrefix(projectName);
+  const entries = await readDir(backupDir);
+  const backups: BackupEntry[] = [];
+
+  for (const entry of entries) {
+    if (!entry.name || entry.isDirectory) continue;
+    if (!entry.name.startsWith(prefix)) continue;
+    const time = parseTimestampFromFilename(entry.name);
+    if (!time) continue;
+    backups.push({ name: entry.name, path: joinPath(backupDir, entry.name), time });
+  }
+
+  backups.sort((a, b) => b.time.getTime() - a.time.getTime());
+  return backups;
+}
+
+/** 把内容写入备份池，返回备份文件名 */
+async function writeBackup(content: string, projectName?: string): Promise<string> {
+  const { exists, writeTextFile, mkdir } = await import('@tauri-apps/plugin-fs');
+
+  const backupDir = await getBackupDir();
+  if (!(await exists(backupDir))) {
+    await mkdir(backupDir, { recursive: true });
+  }
+
+  const backupFileName = `${getBackupPrefix(projectName)}${formatTimestamp(new Date())}.json`;
+  await writeTextFile(joinPath(backupDir, backupFileName), content);
+  return backupFileName;
+}
+
+/** 按份数裁剪备份池，只保留最近 BACKUP_KEEP_COUNT 份 */
+async function pruneBackups(projectName?: string): Promise<void> {
+  const backups = await listBackupsNewestFirst(projectName);
+  if (backups.length <= BACKUP_KEEP_COUNT) return;
+
+  const { remove } = await import('@tauri-apps/plugin-fs');
+  for (const stale of backups.slice(BACKUP_KEEP_COUNT)) {
+    try {
+      await remove(stale.path);
+      log.info(`已删除旧备份: ${stale.name}`);
+    } catch (err) {
+      log.warn(`删除旧备份失败: ${stale.path}`, err);
+    }
+  }
+}
+
 /**
- * 在更新前备份配置文件到 cache/config_backup/，同时清理超过一周的旧备份
+ * 下一次允许尝试滚动备份的时刻，纯粹作为廉价的提前返回缓存。
+ *
+ * 间隔的权威来源始终是备份目录里最新那份的文件名时间戳——只靠内存变量的话，
+ * 每次启动都会归零，用户一天开关几次程序就会各备份一次，1 天的间隔约束等于失效。
+ */
+let nextBackupAllowedAt: number | null = null;
+
+/**
+ * 滚动备份：把磁盘上的当前配置（即上一代内容）复制进备份池。
+ *
+ * 备份旧文件而不是即将写入的新内容——旧文件写入更早，数据大概率已经落盘，
+ * 拿来当备份更可靠。当前文件本身已损坏时跳过，避免把损坏内容灌进备份池。
+ */
+async function rollingBackup(basePath: string, projectName?: string): Promise<void> {
+  try {
+    const now = Date.now();
+    if (nextBackupAllowedAt !== null && now < nextBackupAllowedAt) return;
+
+    const backups = await listBackupsNewestFirst(projectName);
+    const newest = backups[0];
+    if (newest && now - newest.time.getTime() < BACKUP_MIN_INTERVAL_MS) {
+      nextBackupAllowedAt = newest.time.getTime() + BACKUP_MIN_INTERVAL_MS;
+      return;
+    }
+
+    const { exists, readTextFile } = await import('@tauri-apps/plugin-fs');
+    const configPath = getConfigPathSync(basePath, projectName);
+    if (!(await exists(configPath))) return;
+
+    const content = await readTextFile(configPath);
+    if (
+      isCorruptContent(content) ||
+      !isValidMxuConfig(parseJsonc<MxuConfig>(content, configPath))
+    ) {
+      log.warn('当前配置文件不可用，跳过滚动备份');
+      return;
+    }
+
+    // 与最新一份备份内容完全相同时没有备份价值；推迟下次尝试，避免每次保存都重复读盘
+    if (newest) {
+      try {
+        if ((await readTextFile(newest.path)) === content) {
+          nextBackupAllowedAt = now + BACKUP_MIN_INTERVAL_MS;
+          return;
+        }
+      } catch {
+        // 最新备份读不出来，当作需要重新备份
+      }
+    }
+
+    const backupFileName = await writeBackup(content, projectName);
+    nextBackupAllowedAt = Date.now() + BACKUP_MIN_INTERVAL_MS;
+    log.info(`配置已滚动备份: ${backupFileName}`);
+
+    await pruneBackups(projectName);
+  } catch (err) {
+    // 备份失败不能影响配置保存本身
+    log.warn('滚动备份失败（不影响配置保存）:', err);
+  }
+}
+
+/**
+ * 配置损坏时尝试从备份池恢复，成功返回恢复出的配置。
+ *
+ * 按时间从新到旧逐个校验，取第一份有效的。必须能继续往前退——同一次崩溃很可能
+ * 把最新那份备份也一起打成全零。
+ */
+async function tryRecoverConfig(basePath: string, projectName?: string): Promise<MxuConfig | null> {
+  const { exists, readTextFile, writeTextFile, rename } = await import('@tauri-apps/plugin-fs');
+  const configPath = getConfigPathSync(basePath, projectName);
+
+  // 保留损坏文件，便于事后排查与提 issue
+  try {
+    if (await exists(configPath)) {
+      const corruptPath = `${configPath}.corrupt-${formatTimestamp(new Date())}`;
+      await rename(configPath, corruptPath);
+      log.warn(`已保留损坏的配置文件: ${corruptPath}`);
+    }
+  } catch (err) {
+    log.warn('保留损坏配置文件失败（继续尝试恢复）:', err);
+  }
+
+  let backups: BackupEntry[] = [];
+  try {
+    backups = await listBackupsNewestFirst(projectName);
+  } catch (err) {
+    log.error('读取备份目录失败:', err);
+  }
+
+  for (const backup of backups) {
+    try {
+      const content = await readTextFile(backup.path);
+      if (isCorruptContent(content)) {
+        log.warn(`备份已损坏，尝试更早的一份: ${backup.name}`);
+        continue;
+      }
+      const parsed = parseJsonc<MxuConfig>(content, backup.path);
+      if (!isValidMxuConfig(parsed)) {
+        log.warn(`备份结构无效，尝试更早的一份: ${backup.name}`);
+        continue;
+      }
+
+      await writeTextFile(configPath, content);
+      _recoveryNotice = { kind: 'restored', backupTime: formatBackupDisplayTime(backup.time) };
+      log.info(`配置已从备份恢复: ${backup.name}`);
+      return parsed;
+    } catch (err) {
+      log.warn(`备份不可用，尝试更早的一份: ${backup.name}`, err);
+    }
+  }
+
+  _recoveryNotice = { kind: 'reset' };
+  log.error('没有可用备份，配置将重置为默认值');
+  return null;
+}
+
+/**
+ * 在更新前备份配置文件到 cache/config_backup/。
+ *
+ * 更新是高风险操作，这里不受滚动备份的 1 天间隔限制，每次都写；
+ * 多出来的同日条目由按份数裁剪消化。
  */
 export async function backupConfigBeforeUpdate(
   basePath: string,
@@ -263,45 +516,24 @@ export async function backupConfigBeforeUpdate(
   const configPath = getConfigPathSync(basePath, projectName);
 
   try {
-    const { exists, readTextFile, writeTextFile, mkdir, readDir, remove } =
-      await import('@tauri-apps/plugin-fs');
+    const { exists, readTextFile } = await import('@tauri-apps/plugin-fs');
 
     if (!(await exists(configPath))) {
       log.info('配置文件不存在，跳过备份');
       return;
     }
 
-    const cacheDir = await getCacheDir();
-    const backupDir = joinPath(cacheDir, BACKUP_SUBDIR);
-
-    if (!(await exists(backupDir))) {
-      await mkdir(backupDir, { recursive: true });
-    }
-
-    const configFileName = getConfigFileName(projectName);
-    const baseName = configFileName.replace(/\.json$/, '');
-    const timestamp = formatTimestamp(new Date());
-    const backupFileName = `${baseName}-${timestamp}.json`;
-    const backupPath = joinPath(backupDir, backupFileName);
-
     const content = await readTextFile(configPath);
-    await writeTextFile(backupPath, content);
-    log.info(`配置文件已备份: ${backupPath}`);
-
-    // 清理超过一周的旧备份
-    const now = Date.now();
-    const entries = await readDir(backupDir);
-    for (const entry of entries) {
-      if (!entry.name || entry.isDirectory) continue;
-      const fileDate = parseTimestampFromFilename(entry.name);
-      if (fileDate && now - fileDate.getTime() > BACKUP_MAX_AGE_MS) {
-        const oldPath = joinPath(backupDir, entry.name);
-        await remove(oldPath).catch((e: unknown) => {
-          log.warn(`删除过期备份失败: ${oldPath}`, e);
-        });
-        log.info(`已删除过期备份: ${entry.name}`);
-      }
+    if (isCorruptContent(content)) {
+      log.warn('当前配置文件已损坏，跳过更新前备份');
+      return;
     }
+
+    const backupFileName = await writeBackup(content, projectName);
+    nextBackupAllowedAt = Date.now() + BACKUP_MIN_INTERVAL_MS;
+    log.info(`配置文件已备份: ${backupFileName}`);
+
+    await pruneBackups(projectName);
   } catch (error) {
     log.warn('备份配置文件失败（不影响更新流程）:', error);
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -243,3 +243,23 @@ export const defaultConfig: MxuConfig = {
     helpImproveSoftware: true,
   },
 };
+
+/**
+ * 判断任意值是否是结构上可用的 MxuConfig。
+ *
+ * `parseJsonc` 解析失败时不抛异常而是返回 undefined，若不校验就会把 undefined
+ * 当成配置一路传下去，直到访问 `config.instances` 时才炸。所有读盘路径都必须先过这里。
+ */
+export function isValidMxuConfig(value: unknown): value is MxuConfig {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Partial<MxuConfig>;
+  return (
+    typeof candidate.version === 'string' &&
+    Array.isArray(candidate.instances) &&
+    typeof candidate.settings === 'object' &&
+    candidate.settings !== null &&
+    !Array.isArray(candidate.settings)
+  );
+}


### PR DESCRIPTION
close https://github.com/MaaEnd/MaaEnd/issues/3421
close https://github.com/MaaEnd/MaaEnd/issues/4710
修改点
1、触发保存config 且 距离上一次备份大于1天时，备份config文件，最多10个
2、当加载配置文件失败时，从备份恢复

opus5.0

<img width="1206" height="531" alt="image" src="https://github.com/user-attachments/assets/79acd4ee-3545-4bc0-9d14-eba4467d62fa" />


## Summary by Sourcery

在后端和前端中新增自动配置备份和损坏自我修复功能，并通过用户可见的通知进行反馈。

新功能：
- 引入滚动配置备份机制，将备份存储在专用的缓存子目录中，最多保留 10 个快照，且自动备份之间至少间隔一天。
- 在启动或加载时，如果检测到配置文件损坏，会自动尝试从备份池中恢复；当不存在有效备份时则回退到默认配置，并通过恢复通知和 toast 在 UI 中展示结果。

增强改进：
- 在后端和前端新增共享的校验辅助工具，用于在使用前检测配置内容是否损坏或结构无效，确保调用方始终获得有效的 `MxuConfig`。
- 优化更新时的备份逻辑，改为复用共享的备份池和保留策略，而不是基于时间的清理方式。
- 暴露一个 Tauri 命令并在前端接线，以便在每次启动时消费后端的恢复通知，并将相关用户提示信息本地化为多种语言。

测试：
- 在 Rust 端新增全面的单元测试，覆盖配置损坏检测、备份列表与清理、滚动备份行为，以及从备份或重置路径进行恢复的完整流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic config backup and corruption self-healing with user-facing notifications across backend and frontend.

New Features:
- Introduce rolling config backups stored under a dedicated cache subdirectory with up to 10 retained snapshots and a minimum one-day interval between automatic backups.
- Automatically attempt to recover corrupted config files from the backup pool on startup or load, falling back to default config when no valid backup exists, and surface the outcome to the UI via a recovery notice and toasts.

Enhancements:
- Add shared validation helpers on both backend and frontend to detect corrupt or structurally invalid config content before use, ensuring callers always receive a valid MxuConfig.
- Refine update-time backup logic to reuse the shared backup pool and retention policy instead of age-based pruning.
- Expose a Tauri command and frontend wiring to consume backend recovery notices once per launch and localize the associated user messages in multiple languages.

Tests:
- Add comprehensive unit tests around config corruption detection, backup listing and pruning, rolling backup behavior, and recovery flows from backups or reset paths on the Rust side.

</details>