### PR TITLE
perf: 清理日志时同时清理vision与on_error

### DIFF
--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -18,6 +18,8 @@ const ZIP_EOCD_BYTES: u64 = 22;
 const ZIP_CENTRAL_DIR_FIXED_BYTES: u64 = 46;
 /// 保留最近 N 次导出（含本次），多余的会在每次导出完成后清理。
 const MAX_EXPORTS_TO_KEEP: usize = 10;
+/// 需要随日志一起清空的调试产物子目录（内容由 MaaFW 的 save_on_error / save_draw 写入）。
+const DEBUG_ARTIFACT_DIRS: [&str; 2] = ["on_error", "vision"];
 
 #[derive(Clone)]
 struct ExportEntry {
@@ -294,7 +296,38 @@ pub fn get_data_dir() -> Result<String, String> {
     Ok(data_dir.to_string_lossy().to_string())
 }
 
-/// 删除 debug 目录中的 .log 文件，可选择排除一个当前正在使用的日志文件
+/// 清空调试产物目录内容，保留目录本身。返回成功删除的条目数。
+///
+/// 保留目录本身是因为 MaaFW 的 save_on_error 直接往 `on_error/` 写文件，父目录缺失会写入失败。
+fn clear_debug_artifact_dir(dir: &Path) -> u64 {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            log::debug!("Failed to read debug dir [{}]: {}", dir.display(), e);
+            return 0;
+        }
+    };
+
+    let mut deleted = 0_u64;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let result = if path.is_dir() {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+
+        match result {
+            Ok(()) => deleted = deleted.saturating_add(1),
+            Err(e) => log::debug!("Failed to delete debug entry [{}]: {}", path.display(), e),
+        }
+    }
+
+    deleted
+}
+
+/// 删除 debug 目录中的 .log 文件，并清空 on_error/、vision/ 内的调试产物（保留这两个目录本身）。
+/// 可选择排除一个当前正在使用的日志文件。返回删除的文件与调试产物总数。
 #[tauri::command]
 pub fn clear_log_files(exclude_file_name: Option<String>) -> Result<u64, String> {
     let debug_dir = get_app_data_dir()?.join("debug");
@@ -333,6 +366,14 @@ pub fn clear_log_files(exclude_file_name: Option<String>) -> Result<u64, String>
             Ok(()) => deleted = deleted.saturating_add(1),
             Err(e) => log::debug!("Failed to delete log file [{}]: {}", path.display(), e),
         }
+    }
+
+    for dir_name in DEBUG_ARTIFACT_DIRS {
+        let artifact_dir = debug_dir.join(dir_name);
+        if !artifact_dir.is_dir() {
+            continue;
+        }
+        deleted = deleted.saturating_add(clear_debug_artifact_dir(&artifact_dir));
     }
 
     Ok(deleted)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -736,7 +736,7 @@ function App() {
               const deleted = await invoke<number>('clear_log_files', {
                 excludeFileName: getCurrentLogFileName(),
               });
-              log.info('Auto-cleared log files on launch:', deleted);
+              log.info('Auto-cleared log files and debug artifacts on launch:', deleted);
             } catch {
               // ignore cleanup errors
             }

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -128,7 +128,7 @@ export default {
     resetWindowLayoutHint: 'Restore window size to default and center the window',
     autoClearLogsOnLaunch: 'Auto-clear Runtime Logs',
     autoClearLogsOnLaunchHint:
-      'Automatically clear runtime logs and delete old log files every time the project is launched',
+      'Automatically clear runtime logs and delete old log files along with debug screenshots in on_error and vision every time the project is launched',
   },
 
   // Special tasks

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -126,7 +126,7 @@ export default {
     resetWindowLayoutHint: 'ウィンドウサイズをデフォルトに戻し、中央に配置します',
     autoClearLogsOnLaunch: '実行ログの自動クリア',
     autoClearLogsOnLaunchHint:
-      'プロジェクトの起動時に自動で実行ログをクリアし、古いログファイルを削除します',
+      'プロジェクトの起動時に自動で実行ログをクリアし、古いログファイルと on_error・vision 内のデバッグスクリーンショットを削除します',
   },
 
   // 特殊タスク

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -124,7 +124,7 @@ export default {
     resetWindowLayoutHint: '창 크기를 기본값으로 복원하고 화면 중앙에 배치합니다',
     autoClearLogsOnLaunch: '로그 자동 지우기',
     autoClearLogsOnLaunchHint:
-      '프로젝트를 시작할 때 런타임 로그를 자동으로 지우고 이전 로그 파일을 삭제합니다',
+      '프로젝트를 시작할 때 런타임 로그를 자동으로 지우고 이전 로그 파일과 on_error, vision 폴더의 디버그 스크린샷을 삭제합니다',
   },
 
   // 특수 작업

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -122,7 +122,8 @@ export default {
     resetWindowLayout: '重置窗口布局',
     resetWindowLayoutHint: '将窗口大小恢复为默认值，并居中显示',
     autoClearLogsOnLaunch: '自动清理运行日志',
-    autoClearLogsOnLaunchHint: '每次启动项目时，自动清理运行日志并删除旧的日志文件',
+    autoClearLogsOnLaunchHint:
+      '每次启动项目时，自动清理运行日志，并删除旧的日志文件与 on_error、vision 目录下的调试截图',
   },
 
   // 特殊任务

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -121,7 +121,8 @@ export default {
     resetWindowLayout: '重設視窗佈局',
     resetWindowLayoutHint: '將視窗大小恢復為預設值，並置中顯示',
     autoClearLogsOnLaunch: '自動清理運行日誌',
-    autoClearLogsOnLaunchHint: '每次啟動項目時，自動清理運行日誌並刪除舊的日誌檔案',
+    autoClearLogsOnLaunchHint:
+      '每次啟動項目時，自動清理運行日誌，並刪除舊的日誌檔案與 on_error、vision 目錄下的除錯截圖',
   },
 
   // 特殊任務


### PR DESCRIPTION
close https://github.com/MaaEnd/MaaEnd/issues/4771
close https://github.com/MaaEnd/MaaEnd/issues/4531
opus5.0

## Summary by Sourcery

扩展日志清理功能，在保留目录结构的前提下清理调试工件目录

Enhancements:
- 增加支持在清理日志文件的同时，清理 `on_error` 和视觉调试工件目录
- 保留调试工件目录本身，以保持与 MaaFW 的 `save_on_error` 行为兼容
- 改进启动时自动清理日志的日志消息，以反映调试工件被删除的情况

Documentation:
- 更新所有受支持语言中的“自动清理运行时日志”设置说明，注明会清理 `on_error` 及视觉调试截图

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend log cleanup to also clear debug artifact directories while preserving their structure

Enhancements:
- Add support for clearing on_error and vision debug artifact directories alongside log files during cleanup
- Preserve debug artifact directories themselves to remain compatible with MaaFW save_on_error behavior
- Improve auto-clear logs on launch logging message to reflect deletion of debug artifacts

Documentation:
- Update auto-clear runtime logs setting description across all supported locales to mention cleanup of on_error and vision debug screenshots

</details>