### PR TITLE
feat: 日志打包支持dmp文件

### DIFF
--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -115,7 +115,7 @@ fn estimate_compressed_upper_bound(path: &Path, file_size: u64) -> u64 {
         .unwrap_or("")
         .to_lowercase();
     match ext.as_str() {
-        "png" | "jpg" | "jpeg" => file_size, // 已压缩，DEFLATE 无效
+        "png" | "jpg" | "jpeg" | "dmp" => file_size, // 已压缩或二进制，DEFLATE 无效
         "log" | "json" | "txt" | "toml" | "yaml" | "yml" | "xml" | "csv" => {
             file_size.saturating_div(4) // 实测 10-25x，4x 留有足够余量
         }
@@ -596,7 +596,7 @@ fn export_logs_blocking(
 
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
-    // ─── 1. 收集常规文件（log / config / 子目录下的 log/json） ───
+    // ─── 1. 收集常规文件（log / dmp / config / 子目录下的 log/json/dmp） ───
     let mut regular_entries: Vec<ExportEntry> = Vec::new();
 
     let entries = std::fs::read_dir(&debug_dir).map_err(|e| format!("读取日志目录失败: {}", e))?;
@@ -605,7 +605,7 @@ fn export_logs_blocking(
         if !path.is_file() {
             continue;
         }
-        if path.extension().map(|e| e != "log").unwrap_or(true) {
+        if !has_extension(&path, &["log", "dmp"]) {
             continue;
         }
         let Some(archive_name) = path.file_name().map(|n| n.to_string_lossy().to_string()) else {
@@ -620,7 +620,7 @@ fn export_logs_blocking(
 
     let config_dir = data_dir.join("config");
     regular_entries.extend(collect_files_recursively(&config_dir, "config")?);
-    regular_entries.extend(collect_debug_subdir_files(&debug_dir, &["log", "json"])?);
+    regular_entries.extend(collect_debug_subdir_files(&debug_dir, &["log", "json", "dmp"])?);
 
     // ─── 2. 收集图片（on_error + vision，按 mtime 新→旧） ───
     let on_error_images = collect_debug_images(&debug_dir.join("on_error"), "on_error");


### PR DESCRIPTION
<img width="1582" height="1021" alt="image" src="https://github.com/user-attachments/assets/52652fc5-285d-4ccf-9692-79071f14ebda" />

## Summary by Sourcery

扩展日志导出功能，在现有日志工件的基础上包含 `.dmp` 崩溃转储文件。

新特性：
- 在日志导出归档中包含来自调试目录及其子目录的 `.dmp` 文件。

增强项：
- 在估算用于日志打包的 ZIP 大小时，将 `.dmp` 文件视为不可压缩文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend log export to include .dmp crash dump files alongside existing log artifacts.

New Features:
- Include .dmp files in exported log archives from the debug directory and its subdirectories.

Enhancements:
- Treat .dmp files as non-compressible when estimating ZIP size for log packaging.

</details>