### PR TITLE
fix: enable SOCKS5 support for update proxy

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ zip = "7.2.0"
 flate2 = "1.0"
 tar = "0.4"
 tokio = { version = "1", features = ["rt", "sync", "net", "rt-multi-thread"] }
-reqwest = { version = "0.12", features = ["stream", "blocking", "json"] }
+reqwest = { version = "0.12", features = ["stream", "blocking", "json", "socks"] }
 axum = { version = "0.7", features = ["ws"] }
 tower-http = { version = "0.5", features = ["cors", "fs"] }
 futures-util = "0.3"


### PR DESCRIPTION
## 问题
 
 更新设置允许填写 `socks5://` 代理，但实际请求无法通过 SOCKS5 代理连接。
 
 ## 原因
 
 MXU 使用 `reqwest::Proxy` 处理更新请求，但当前 `reqwest` 依赖没有启用 `socks` feature。界面和代理 URL 校验虽然接受 SOCKS5，Rust 客户端实际并未编译 SOCKS 支持。
 
 ## 修复
 
 为 `reqwest` 启用 `socks` feature，恢复 PR #16 所设计的 SOCKS5 代理支持。