### PR TITLE
fix: respect proxy when probing download URLs

### DIFF
--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -626,9 +626,21 @@ mod tests {
         let proxy_address = listener.local_addr().expect("get test proxy address");
         let proxy = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("accept proxied request");
-            let mut request = [0_u8; 2048];
-            let bytes_read = stream.read(&mut request).expect("read proxied request");
-            let request = String::from_utf8_lossy(&request[..bytes_read]);
+            let mut request = Vec::new();
+            loop {
+                let mut chunk = [0_u8; 2048];
+                let bytes_read = stream.read(&mut chunk).expect("read proxied request");
+                assert!(bytes_read > 0, "proxy closed before request headers");
+                request.extend_from_slice(&chunk[..bytes_read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+                assert!(
+                    request.len() <= 64 * 1024,
+                    "proxy request headers too large"
+                );
+            }
+            let request = String::from_utf8_lossy(&request);
             assert!(request.starts_with("HEAD http://example.invalid/update.zip HTTP/1.1"));
             stream
                 .write_all(

--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -59,6 +59,28 @@ static DOWNLOAD_CANCELLED: AtomicBool = AtomicBool::new(false);
 /// 当前下载的 session ID，用于区分不同的下载任务
 static CURRENT_DOWNLOAD_SESSION: AtomicU64 = AtomicU64::new(0);
 
+fn apply_proxy(
+    mut client_builder: reqwest::ClientBuilder,
+    proxy_url: Option<&str>,
+    log_prefix: &str,
+    target_url: &str,
+) -> Result<reqwest::ClientBuilder, String> {
+    if let Some(proxy) = proxy_url.filter(|proxy| !proxy.is_empty()) {
+        info!("[{}] 使用代理: {}", log_prefix, proxy);
+        info!("[{}] 目标: {}", log_prefix, target_url);
+        let reqwest_proxy = reqwest::Proxy::all(proxy).map_err(|e| {
+            error!("代理配置失败: {} (代理地址: {})", e, proxy);
+            format!(
+                "代理配置失败: {}。请检查代理格式是否正确（支持 http:// 或 socks5://）",
+                e
+            )
+        })?;
+        client_builder = client_builder.proxy(reqwest_proxy);
+    }
+
+    Ok(client_builder)
+}
+
 /// 根据版本号获取 GitHub Release URL
 ///
 /// 使用 GitHub API 获取指定版本的 Release 信息，支持使用 GitHub PAT 和代理
@@ -79,21 +101,7 @@ pub async fn get_github_release_by_version(
         .timeout(std::time::Duration::from_secs(10))
         .connect_timeout(std::time::Duration::from_secs(3));
 
-    // 添加代理配置（如果提供）
-    if let Some(ref proxy) = proxy_url {
-        if !proxy.is_empty() {
-            info!("[检查更新] 使用代理: {}", proxy);
-            info!("[检查更新] 目标: {}", url);
-            let reqwest_proxy = reqwest::Proxy::all(proxy).map_err(|e| {
-                error!("代理配置失败: {} (代理地址: {})", e, proxy);
-                format!(
-                    "代理配置失败: {}。请检查代理格式是否正确（支持 http:// 或 socks5://）",
-                    e
-                )
-            })?;
-            client_builder = client_builder.proxy(reqwest_proxy);
-        }
-    }
+    client_builder = apply_proxy(client_builder, proxy_url.as_deref(), "检查更新", &url)?;
 
     let client = client_builder
         .build()
@@ -142,6 +150,32 @@ pub async fn get_github_release_by_version(
     }
     warn!("未找到匹配的 Release: target_version={}", target_version);
     Ok(None)
+}
+
+/// 检查下载链接的 HTTP 状态码，支持使用代理
+#[tauri::command]
+pub async fn probe_download_url(url: String, proxy_url: Option<String>) -> Result<u16, String> {
+    let client_builder = reqwest::Client::builder()
+        .user_agent(build_user_agent())
+        .timeout(std::time::Duration::from_secs(10))
+        .connect_timeout(std::time::Duration::from_secs(3));
+    let client_builder = apply_proxy(
+        client_builder,
+        proxy_url.as_deref(),
+        "检查直接下载链接",
+        &url,
+    )?;
+    let client = client_builder
+        .build()
+        .map_err(|e| format!("创建 HTTP 客户端失败: {}", e))?;
+
+    let response = client
+        .head(&url)
+        .send()
+        .await
+        .map_err(|e| format!("请求失败: {}", e))?;
+
+    Ok(response.status().as_u16())
 }
 
 /// 流式下载文件，支持进度回调和取消
@@ -578,4 +612,43 @@ fn parse_content_disposition(header: &str) -> Option<String> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::probe_download_url;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    #[test]
+    fn probe_download_url_uses_explicit_proxy() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test proxy");
+        let proxy_address = listener.local_addr().expect("get test proxy address");
+        let proxy = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept proxied request");
+            let mut request = [0_u8; 2048];
+            let bytes_read = stream.read(&mut request).expect("read proxied request");
+            let request = String::from_utf8_lossy(&request[..bytes_read]);
+            assert!(request.starts_with("HEAD http://example.invalid/update.zip HTTP/1.1"));
+            stream
+                .write_all(
+                    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .expect("write proxy response");
+        });
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build Tokio runtime");
+        let status = runtime
+            .block_on(probe_download_url(
+                "http://example.invalid/update.zip".to_string(),
+                Some(format!("http://{}", proxy_address)),
+            ))
+            .expect("probe through proxy");
+
+        assert_eq!(status, 204);
+        proxy.join().expect("join test proxy");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -280,6 +280,7 @@ pub fn run() {
             commands::update::cleanup_update_artifacts,
             // 下载命令
             commands::download::get_github_release_by_version,
+            commands::download::probe_download_url,
             commands::download::download_file,
             commands::download::cancel_download,
             // 系统相关命令

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -577,6 +577,7 @@ async function tryDirectDownloadUrls(
   repo: string,
   projectName: string,
   version: string,
+  proxyUrl?: string,
 ): Promise<{ url: string; filename: string } | null> {
   const extensions = getDownloadExtensions();
   const arch = await getArch();
@@ -590,18 +591,13 @@ async function tryDirectDownloadUrls(
 
     try {
       log.info(`尝试直接下载链接: ${url}`);
-      const response = await tauriFetch(url, {
-        method: 'HEAD',
-        headers: {
-          'User-Agent': await buildUserAgent(),
-        },
-      });
+      const status = await invoke<number>('probe_download_url', { url, proxyUrl });
 
-      if (response.ok) {
+      if (status >= 200 && status < 300) {
         log.info(`直接下载链接可用: ${filename}`);
         return { url, filename };
       }
-      log.info(`直接下载链接不存在 (${response.status}): ${filename}`);
+      log.info(`直接下载链接不存在 (${status}): ${filename}`);
     } catch (error) {
       log.warn(`检查直接下载链接失败: ${filename}`, error);
     }
@@ -663,7 +659,7 @@ export interface GetGitHubDownloadUrlOptions {
   targetVersion: string; // Mirror酱返回的目标版本号
   githubPat?: string; // GitHub Personal Access Token (支持 classic 和 fine-grained)
   projectName?: string; // 项目名称，用于拼接直接下载链接（来自 interface.name）
-  proxyUrl?: string; // 代理 URL，用于 GitHub API 请求
+  proxyUrl?: string; // 代理 URL，用于 GitHub API 请求和直接下载链接探测
 }
 
 /**
@@ -705,7 +701,13 @@ export async function getGitHubDownloadUrl(
 
   // API 失败或未匹配到 asset，尝试直接拼接下载链接
   if (projectName) {
-    const directResult = await tryDirectDownloadUrls(owner, repo, projectName, targetVersion);
+    const directResult = await tryDirectDownloadUrls(
+      owner,
+      repo,
+      projectName,
+      targetVersion,
+      proxyUrl,
+    );
     if (directResult) {
       log.info(`使用直接下载链接: ${directResult.filename}`);
       return {


### PR DESCRIPTION
## Summary

- route fallback download URL probes through a proxy-aware Tauri command
- pass the configured update proxy to the GitHub `HEAD` probe
- reuse the existing reqwest proxy setup and add a regression test with a local proxy server

## Problem

The GitHub Release API request respects the app's update proxy, but its fallback path probes constructed release URLs with `tauriFetch`. That `HEAD` request does not receive the app-configured proxy, so users who rely on the update proxy can fail before the actual package download starts.

## Testing

- TypeScript compilation (`tsc`)
- Vite production build
- Prettier check for the changed TypeScript file
- Rust formatting check for the changed command
- Added `probe_download_url_uses_explicit_proxy` regression test

The Rust test could not be linked locally because MSVC `link.exe` is unavailable on this machine; the application code will be compiled by the repository's Windows CI.

## Sourcery 摘要

通过配置的代理路由备用下载 URL 探测，以支持在使用代理的环境中进行更新。

新功能：
- 添加支持代理的命令，用于探测直接下载 URL。

错误修复：
- 确保备用下载 URL 探测遵循配置的更新代理。

增强功能：
- 复用共享代理配置来处理 GitHub 发布请求和直接下载检查。

测试：
- 添加回归测试，验证直接 URL 探测会通过显式代理进行路由。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过配置的更新代理路由备用下载 URL 探测请求。

新功能：
- 添加支持代理的命令，用于探测直接下载 URL。

错误修复：
- 确保备用下载 URL 检查遵循配置的更新代理。

增强功能：
- GitHub release 请求和直接下载探测复用共享的代理配置。

测试：
- 添加回归测试，验证直接 URL 探测请求会通过显式代理进行路由。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route fallback download URL probes through the configured update proxy.

New Features:
- Add a proxy-aware command for probing direct download URLs.

Bug Fixes:
- Ensure fallback download URL checks honor the configured update proxy.

Enhancements:
- Reuse shared proxy configuration for GitHub release requests and direct download probes.

Tests:
- Add a regression test verifying that direct URL probes are routed through an explicit proxy.

</details>

</details>