### PR TITLE
fix: agent 生命周期管理，复用进程避免重复 spawn 与 sink 重复注册

### DIFF
--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -513,9 +513,7 @@ async fn start_single_agent(
     }).await.map_err(|e| e.to_string())?
 }
 
-/// 确保 agent 进程存活且与 tasker 同步。
-/// 幂等：如果已有存活且同步的 agent，直接返回。
-/// 三态：复用（存活+同步）→ 重挂（存活+代际不符）→ 重建（有进程已退出/空）
+/// 幂等确保 agent 存活：存活且同步则复用，代际不符则重挂或重建。
 async fn ensure_agents(
     app: &tauri::AppHandle,
     maa_state: &Arc<MaaState>,
@@ -550,7 +548,6 @@ async fn ensure_agents(
         let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
         let instance = instances.get_mut(instance_id).ok_or("Instance not found")?;
 
-        // 没有 agent_configs 或为空 → 停止旧 agent 并返回
         if agent_configs.is_empty() {
             drop(instances);
             debug!("[ensure_agents] Agent configs is empty, stopping old agents");
@@ -581,10 +578,8 @@ async fn ensure_agents(
         return Ok(());
     }
 
-    // === Resource 变更：保留进程，只做 re-bind + re-connect + re-register ===
-    // AgentClient::bind(new_resource) 会先 clear_custom_registration() 再换 bound_res_，
-    // 然后 connect() 发送 StartUpRequest 让 AgentServer 重新上报 custom 列表，
-    // 最后 register_sinks() 迁移事件 sink。全程不调用 disconnect()，避免发送 ShutDownRequest。
+    // === Resource 变更：保留进程重挂（bind+connect 让 agent 重报 custom，再迁移 sink）===
+    // 不能调用 disconnect()，否则会发送 ShutDownRequest 使进程退出
     if all_alive && !resource_ok {
         info!("[ensure_agents] Resource changed, re-binding agents...");
 
@@ -668,7 +663,6 @@ async fn ensure_agents(
             }
         }
 
-        // 存回 instance
         {
             let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
             if let Some(instance) = instances.get_mut(instance_id) {
@@ -686,8 +680,7 @@ async fn ensure_agents(
         return Ok(());
     }
 
-    // === 仅 tasker 代际不符（resource 没变、进程存活）→ 只重挂 sink ===
-    // 注意：此时 resource_ok 为 true、all_alive 为 true，只有 tasker_ok 为 false
+    // === 仅 tasker 代际不符 → 只重挂 sink ===
     info!("[ensure_agents] Agents alive, tasker changed, re-registering sinks");
 
     {
@@ -820,10 +813,7 @@ pub async fn start_tasks_impl(
         return Err("Tasker not properly initialized".to_string());
     }
 
-    // 确保 agent 存活并同步（幂等：存活且同步则直接复用）
-    // 统一处理 None / Some([]) / Some(non-empty) 三种情况：
-    // - 空配置 → ensure_agents 内部自动调用 stop_agent_impl 清理旧进程
-    // - 有配置 → 正常复用或重建
+    // 空配置也会走 ensure_agents：其内部会调用 stop_agent_impl 清理旧进程
     debug!("[start_tasks] Checking agent configs...");
     let pi_envs = pi_envs.unwrap_or_default();
     let configs = agent_configs.unwrap_or_default();
@@ -977,11 +967,8 @@ pub async fn maa_start_tasks(
 
 /// 停止所有 Agent（Tauri invoke 和 HTTP handler 共享）。
 ///
-/// 注意：disconnect() 必须在这里**同步**执行完毕再返回——
-/// AgentClient 在 drop 时会清理其注册的 custom action/recognition，
-/// 若把 disconnect 放到后台线程，旧 agent 的反注册可能晚于新 agent 的注册，
-/// 把新 agent 的同名 custom 条目删掉（insert_or_assign vs erase 竞态）。
-/// 子进程的宽限等待与强杀才放到后台线程。
+/// disconnect() 必须**同步**执行：AgentClient 在 drop 时反注册 custom action，
+/// 若放到后台，旧 agent 的反注册可能晚于新 agent 的注册、误删新条目。
 pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(), String> {
     info!("stop_agent_impl called for instance: {}", instance_id);
 
@@ -1006,18 +993,13 @@ pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(
         children.len()
     );
 
-    // 同步断开所有 client：确保 custom 反注册发生在新 agent 注册之前
     for client in &clients {
         let _ = client.disconnect();
     }
     drop(clients); // Drop 在此同步执行 clear_custom_registration()
 
-    // 子进程收尾放到后台：等待其自然退出，绝不强制 kill。
-    // MXU 无法得知 agent 正在做什么（保存文件 / 落盘缓存 / 执行关键操作），
-    // 强杀可能导致数据损坏。disconnect() 已发送 ShutDownRequest，
-    // agent 会在完成收尾后自行退出；若长时间未退出说明它仍在工作中。
-    // 每个 child 最多等待 30 秒，超时后停止等待并记日志，不再强制 kill。
-    // 进程残留由 agent 侧 parentwatch（MXU 退出时自尽）兜底。
+    // 后台等待子进程自然退出，绝不强杀（可能正在落盘关键数据）；
+    // 每个 child 限时 30s，超时放弃等待，残留由 agent 侧 parentwatch 兜底
     thread::spawn(move || {
         for (i, mut child) in children.into_iter().enumerate() {
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);

--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -821,31 +821,27 @@ pub async fn start_tasks_impl(
     }
 
     // 确保 agent 存活并同步（幂等：存活且同步则直接复用）
+    // 统一处理 None / Some([]) / Some(non-empty) 三种情况：
+    // - 空配置 → ensure_agents 内部自动调用 stop_agent_impl 清理旧进程
+    // - 有配置 → 正常复用或重建
     debug!("[start_tasks] Checking agent configs...");
     let pi_envs = pi_envs.unwrap_or_default();
-    if let Some(configs) = agent_configs {
-        if !configs.is_empty() {
-            info!("[start_tasks] Ensuring {} agent(s)...", configs.len());
-            ensure_agents(
-                &app,
-                maa_state,
-                &instance_id,
-                &configs,
-                &tasker,
-                &resource,
-                &controller,
-                &cwd,
-                tcp_compat_mode,
-                &pi_envs,
-            )
-            .await?;
-            info!("[start_tasks] Agent(s) ensured successfully");
-        } else {
-            debug!("[start_tasks] Agent configs list is empty, skipping agent setup");
-        }
-    } else {
-        debug!("[start_tasks] No agent configs, skipping agent setup");
-    }
+    let configs = agent_configs.unwrap_or_default();
+    info!("[start_tasks] Ensuring {} agent(s)...", configs.len());
+    ensure_agents(
+        &app,
+        maa_state,
+        &instance_id,
+        &configs,
+        &tasker,
+        &resource,
+        &controller,
+        &cwd,
+        tcp_compat_mode,
+        &pi_envs,
+    )
+    .await?;
+    info!("[start_tasks] Agent(s) ensured successfully");
 
     // 遥测：整批运行开始（仅首批；追加批次沿用已有 Transaction）
     // 必须在 post_task 之前，否则首个任务的开始回调会早于 Transaction 创建、丢掉它的 Span
@@ -1020,9 +1016,11 @@ pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(
     // MXU 无法得知 agent 正在做什么（保存文件 / 落盘缓存 / 执行关键操作），
     // 强杀可能导致数据损坏。disconnect() 已发送 ShutDownRequest，
     // agent 会在完成收尾后自行退出；若长时间未退出说明它仍在工作中。
+    // 每个 child 最多等待 30 秒，超时后停止等待并记日志，不再强制 kill。
     // 进程残留由 agent 侧 parentwatch（MXU 退出时自尽）兜底。
     thread::spawn(move || {
         for (i, mut child) in children.into_iter().enumerate() {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
             loop {
                 match child.try_wait() {
                     Ok(Some(_)) => {
@@ -1030,6 +1028,14 @@ pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(
                         break;
                     }
                     Ok(None) => {
+                        if std::time::Instant::now() > deadline {
+                            warn!(
+                                "Background: Agent #{} did not exit within 30s after disconnect, \
+                                 giving up wait (process will be cleaned up by parentwatch on MXU exit)",
+                                i
+                            );
+                            break;
+                        }
                         thread::sleep(std::time::Duration::from_millis(200));
                     }
                     Err(e) => {

--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -10,6 +10,7 @@ use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use tokio::sync::Mutex as TokioMutex;
 
 use chrono::Local;
 use tauri::{Emitter, Manager, State};
@@ -512,6 +513,201 @@ async fn start_single_agent(
     }).await.map_err(|e| e.to_string())?
 }
 
+/// 确保 agent 进程存活且与 tasker 同步。
+/// 幂等：如果已有存活且同步的 agent，直接返回。
+/// 三态：复用（存活+同步）→ 重挂（存活+代际不符）→ 重建（有进程已退出/空）
+async fn ensure_agents(
+    app: &tauri::AppHandle,
+    maa_state: &Arc<MaaState>,
+    instance_id: &str,
+    agent_configs: &[AgentConfig],
+    tasker: &Tasker,
+    resource: &Resource,
+    controller: &Controller,
+    cwd: &str,
+    tcp_compat_mode: bool,
+    pi_envs: &HashMap<String, String>,
+) -> Result<(), String> {
+    info!(
+        "[ensure_agents] Checking agents for instance: {}",
+        instance_id
+    );
+
+    // per-instance 启动锁，防止并发 ensure_agents 双 spawn
+    let start_lock = {
+        let mut locks = maa_state
+            .agent_start_locks
+            .lock()
+            .map_err(|e| e.to_string())?;
+        locks
+            .entry(instance_id.to_string())
+            .or_insert_with(|| Arc::new(TokioMutex::new(())))
+            .clone()
+    };
+    let _guard = start_lock.lock().await;
+
+    let (all_alive, tasker_ok, resource_ok) = {
+        let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
+        let instance = instances.get_mut(instance_id).ok_or("Instance not found")?;
+
+        // 没有 agent_configs 或为空 → 停止旧 agent 并返回
+        if agent_configs.is_empty() {
+            drop(instances);
+            debug!("[ensure_agents] Agent configs is empty, stopping old agents");
+            stop_agent_impl(maa_state, instance_id)?;
+            return Ok(());
+        }
+
+        let alive = !instance.agent_clients.is_empty()
+            && instance.agent_clients.len() == agent_configs.len()
+            && instance.agent_children.len() == agent_configs.len()
+            && instance.agent_clients.iter().all(|c| c.connected())
+            && instance
+                .agent_children
+                .iter_mut()
+                .all(|c| match c.try_wait() {
+                    Ok(None) => true,
+                    _ => false,
+                });
+
+        let t_ok = instance.agent_tasker_generation == instance.tasker_generation;
+        let r_ok = instance.agent_resource_generation == instance.resource_generation;
+
+        (alive, t_ok, r_ok)
+    };
+
+    if all_alive && tasker_ok && resource_ok {
+        debug!("[ensure_agents] All agents alive and synchronized, reusing");
+        return Ok(());
+    }
+
+    // === Resource 变更：保留进程，只做 re-bind + re-connect + re-register ===
+    // AgentClient::bind(new_resource) 会先 clear_custom_registration() 再换 bound_res_，
+    // 然后 connect() 发送 StartUpRequest 让 AgentServer 重新上报 custom 列表，
+    // 最后 register_sinks() 迁移事件 sink。全程不调用 disconnect()，避免发送 ShutDownRequest。
+    if all_alive && !resource_ok {
+        info!("[ensure_agents] Resource changed, re-binding agents...");
+
+        let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
+        let instance = instances.get_mut(instance_id).ok_or("Instance not found")?;
+
+        for client in &mut instance.agent_clients {
+            client
+                .bind(resource.clone())
+                .map_err(|e| format!("Failed to re-bind resource: {}", e))?;
+            client
+                .connect()
+                .map_err(|e| format!("Failed to re-connect agent: {}", e))?;
+            client
+                .register_sinks(resource.clone(), controller.clone(), tasker.clone())
+                .map_err(|e| format!("Failed to re-register agent sinks: {}", e))?;
+        }
+
+        instance.agent_tasker_generation = instance.tasker_generation;
+        instance.agent_resource_generation = instance.resource_generation;
+
+        info!("[ensure_agents] Agents re-bound and re-connected successfully");
+        return Ok(());
+    }
+
+    // === 进程已退出 / 空 → 完整重建 ===
+    if !all_alive {
+        info!("[ensure_agents] Agents not fully alive, full rebuild...");
+        stop_agent_impl(maa_state, instance_id)?;
+
+        info!(
+            "[ensure_agents] Spawning {} new agent(s)...",
+            agent_configs.len()
+        );
+        let pi_envs = Arc::new(pi_envs.clone());
+
+        let mut new_clients = Vec::new();
+        let mut new_children = Vec::new();
+
+        for (idx, config) in agent_configs.iter().enumerate() {
+            let res_clone = resource.clone();
+            let ctrl_clone = controller.clone();
+            let tsk_clone = tasker.clone();
+            let app_handle = app.clone();
+            let inst_id = instance_id.to_string();
+            let cwd_clone = cwd.to_string();
+            let pi_envs_clone = Arc::clone(&pi_envs);
+
+            match start_single_agent(
+                app_handle,
+                config.clone(),
+                idx,
+                inst_id,
+                cwd_clone,
+                tcp_compat_mode,
+                res_clone,
+                ctrl_clone,
+                tsk_clone,
+                pi_envs_clone,
+            )
+            .await
+            {
+                Ok((client, child)) => {
+                    new_clients.push(client);
+                    new_children.push(child);
+                }
+                Err(e) => {
+                    error!(
+                        "[ensure_agents] Agent #{} failed to start: {}, cleaning up...",
+                        idx, e
+                    );
+                    for client in &new_clients {
+                        let _ = client.disconnect();
+                    }
+                    for mut child in new_children {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                    }
+                    return Err(format!("Agent start failed: {}", e));
+                }
+            }
+        }
+
+        // 存回 instance
+        {
+            let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
+            if let Some(instance) = instances.get_mut(instance_id) {
+                instance.agent_clients = new_clients;
+                instance.agent_children = new_children;
+                instance.agent_tasker_generation = instance.tasker_generation;
+                instance.agent_resource_generation = instance.resource_generation;
+            }
+        }
+
+        info!(
+            "[ensure_agents] All {} agent(s) started successfully",
+            agent_configs.len()
+        );
+        return Ok(());
+    }
+
+    // === 仅 tasker 代际不符（resource 没变、进程存活）→ 只重挂 sink ===
+    // 注意：此时 resource_ok 为 true、all_alive 为 true，只有 tasker_ok 为 false
+    info!("[ensure_agents] Agents alive, tasker changed, re-registering sinks");
+
+    {
+        let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
+        let instance = instances.get_mut(instance_id).ok_or("Instance not found")?;
+
+        for client in &mut instance.agent_clients {
+            client
+                .register_sinks(resource.clone(), controller.clone(), tasker.clone())
+                .map_err(|e| format!("Failed to re-register agent sinks: {}", e))?;
+        }
+
+        instance.agent_tasker_generation = instance.tasker_generation;
+        // resource_generation 不变
+    }
+
+    info!("[ensure_agents] Agent sinks re-registered successfully");
+    Ok(())
+}
+
 /// 启动任务的核心实现（Tauri invoke 和 HTTP handler 共享）
 pub async fn start_tasks_impl(
     app: tauri::AppHandle,
@@ -607,6 +803,7 @@ pub async fn start_tasks_impl(
             debug!("[start_tasks] Resource and controller bound");
 
             instance.tasker = Some(t);
+            instance.tasker_generation += 1;
             debug!("[start_tasks] Tasker created and stored");
         } else {
             debug!("[start_tasks] Using existing initialized tasker");
@@ -623,82 +820,32 @@ pub async fn start_tasks_impl(
         return Err("Tasker not properly initialized".to_string());
     }
 
-    // 启动所有 Agent（如果配置了）
+    // 确保 agent 存活并同步（幂等：存活且同步则直接复用）
     debug!("[start_tasks] Checking agent configs...");
-    let pi_envs = Arc::new(pi_envs.unwrap_or_default());
+    let pi_envs = pi_envs.unwrap_or_default();
     if let Some(configs) = agent_configs {
-        if configs.is_empty() {
-            debug!("[start_tasks] Agent configs list is empty, skipping agent setup");
+        if !configs.is_empty() {
+            info!("[start_tasks] Ensuring {} agent(s)...", configs.len());
+            ensure_agents(
+                &app,
+                maa_state,
+                &instance_id,
+                &configs,
+                &tasker,
+                &resource,
+                &controller,
+                &cwd,
+                tcp_compat_mode,
+                &pi_envs,
+            )
+            .await?;
+            info!("[start_tasks] Agent(s) ensured successfully");
         } else {
-            info!("[start_tasks] Starting {} agent(s)...", configs.len());
-
-            // 用于收集所有成功启动的 agent，失败时需要回滚清理
-            let mut new_clients = Vec::new();
-            let mut new_children = Vec::new();
-
-            for (idx, config) in configs.iter().enumerate() {
-                let res_clone = resource.clone();
-                let ctrl_clone = controller.clone();
-                let tasker_clone = tasker.clone();
-                let app_handle = app.clone();
-                let inst_id = instance_id.clone();
-                let cwd_clone = cwd.clone();
-                let pi_envs_clone = Arc::clone(&pi_envs);
-
-                match start_single_agent(
-                    app_handle,
-                    config.clone(),
-                    idx,
-                    inst_id,
-                    cwd_clone,
-                    tcp_compat_mode,
-                    res_clone,
-                    ctrl_clone,
-                    tasker_clone,
-                    pi_envs_clone,
-                )
-                .await
-                {
-                    Ok((client, child)) => {
-                        new_clients.push(client);
-                        new_children.push(child);
-                    }
-                    Err(e) => {
-                        error!(
-                            "[start_tasks] Agent #{} failed to start: {}, cleaning up previously started agents...",
-                            idx, e
-                        );
-
-                        // 回滚：清理已启动的 agent
-                        for client in &new_clients {
-                            let _ = client.disconnect();
-                        }
-                        for mut child in new_children {
-                            let _ = child.kill();
-                            let _ = child.wait();
-                        }
-                        return Err(format!("Agent start failed: {}", e));
-                    }
-                }
-            }
-
-            // 保存所有 agent 状态到 instance
-            let mut instances = maa_state.instances.lock().map_err(|e| e.to_string())?;
-            if let Some(instance) = instances.get_mut(&instance_id) {
-                instance.agent_clients.extend(new_clients);
-                instance.agent_children.extend(new_children);
-            }
-
-            info!(
-                "[start_tasks] All {} agent(s) started successfully",
-                configs.len()
-            );
-
-            info!("[start_tasks] Tasks started with agent(s)");
+            debug!("[start_tasks] Agent configs list is empty, skipping agent setup");
         }
     } else {
         debug!("[start_tasks] No agent configs, skipping agent setup");
-    };
+    }
 
     // 遥测：整批运行开始（仅首批；追加批次沿用已有 Transaction）
     // 必须在 post_task 之前，否则首个任务的开始回调会早于 Transaction 创建、丢掉它的 Span
@@ -832,7 +979,13 @@ pub async fn maa_start_tasks(
     .await
 }
 
-/// 停止所有 Agent 的核心实现（Tauri invoke 和 HTTP handler 共享）
+/// 停止所有 Agent（Tauri invoke 和 HTTP handler 共享）。
+///
+/// 注意：disconnect() 必须在这里**同步**执行完毕再返回——
+/// AgentClient 在 drop 时会清理其注册的 custom action/recognition，
+/// 若把 disconnect 放到后台线程，旧 agent 的反注册可能晚于新 agent 的注册，
+/// 把新 agent 的同名 custom 条目删掉（insert_or_assign vs erase 竞态）。
+/// 子进程的宽限等待与强杀才放到后台线程。
 pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(), String> {
     info!("stop_agent_impl called for instance: {}", instance_id);
 
@@ -852,45 +1005,38 @@ pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(
     }
 
     info!(
-        "[stop_agent] Stopping {} agent client(s) and {} child process(es) in background...",
+        "[stop_agent] Stopping {} agent client(s) and {} child process(es)...",
         clients.len(),
         children.len()
     );
 
+    // 同步断开所有 client：确保 custom 反注册发生在新 agent 注册之前
+    for client in &clients {
+        let _ = client.disconnect();
+    }
+    drop(clients); // Drop 在此同步执行 clear_custom_registration()
+
+    // 子进程收尾放到后台：等待其自然退出，绝不强制 kill。
+    // MXU 无法得知 agent 正在做什么（保存文件 / 落盘缓存 / 执行关键操作），
+    // 强杀可能导致数据损坏。disconnect() 已发送 ShutDownRequest，
+    // agent 会在完成收尾后自行退出；若长时间未退出说明它仍在工作中。
+    // 进程残留由 agent 侧 parentwatch（MXU 退出时自尽）兜底。
     thread::spawn(move || {
-        for client in clients {
-            let _ = client.disconnect();
-        }
-
         for (i, mut child) in children.into_iter().enumerate() {
-            debug!("Waiting for agent process #{} to exit...", i);
-
-            let start = std::time::Instant::now();
-            let timeout = std::time::Duration::from_secs(5);
-            let mut exited = false;
-
-            while start.elapsed() < timeout {
+            loop {
                 match child.try_wait() {
                     Ok(Some(_)) => {
-                        exited = true;
+                        info!("Background: Agent #{} child process exited", i);
                         break;
                     }
                     Ok(None) => {
-                        thread::sleep(std::time::Duration::from_millis(100));
+                        thread::sleep(std::time::Duration::from_millis(200));
                     }
                     Err(e) => {
-                        error!("Error waiting for agent #{}: {}", i, e);
+                        warn!("Background: Agent #{} wait failed: {}", i, e);
                         break;
                     }
                 }
-            }
-
-            if !exited {
-                warn!("Agent process #{} did not exit in time, killing it...", i);
-                let _ = child.kill();
-                let _ = child.wait();
-            } else {
-                info!("Background: Agent #{} child process exited", i);
             }
         }
     });

--- a/src-tauri/src/commands/maa_core.rs
+++ b/src-tauri/src/commands/maa_core.rs
@@ -331,6 +331,7 @@ fn update_instance_controller(
         instance.controller = Some(controller);
         instance.controller_config = Some(new_config.clone());
         instance.tasker = None;
+        instance.tasker_generation += 1;
 
         old_config.filter(|old| {
             *old != new_config
@@ -1305,6 +1306,8 @@ pub fn maa_destroy_resource(
     // 销毁旧的资源
     instance.resource = None;
     instance.tasker = None;
+    instance.tasker_generation += 1;
+    instance.resource_generation += 1;
 
     Ok(())
 }
@@ -1376,6 +1379,7 @@ pub fn run_task_impl(
             .map_err(|e| e.to_string())?;
 
         instance.tasker = Some(tasker);
+        instance.tasker_generation += 1;
     }
 
     let tasker = instance.tasker.as_ref().unwrap();

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -242,16 +242,9 @@ pub struct InstanceRuntime {
     /// 当前控制器的配置（用于 ControllerPool 引用管理）
     pub controller_config: Option<ControllerConfig>,
     pub tasker: Option<Tasker>,
-    /// 每次重建 tasker 时递增，用于 agent 检测"tasker 已换过，需重挂 sink"
     pub tasker_generation: u64,
-    /// 上次 agent 注册 sink 时捕获的 tasker_generation 值
-    /// 相等 → sink 链仍有效；不等 → 需要重挂
     pub agent_tasker_generation: u64,
-    /// 每次替换 resource 时递增。Resource 变更会连带重建 tasker，
-    /// 但 agent 的 custom recognition/action 注册在旧 Resource 上，
-    /// 无法仅靠重挂 sink 迁移，必须完整重建 agent。
     pub resource_generation: u64,
-    /// 上次拉起 agent 时捕获的 resource_generation 值
     pub agent_resource_generation: u64,
     pub agent_clients: Vec<AgentClient>,
     pub agent_children: Vec<Child>,
@@ -376,8 +369,7 @@ pub struct MaaState {
     pub log_buffer: Mutex<LogBuffer>,
     /// 后端统一截图服务（确保每实例只有一份 post_screencap 在运行）
     pub screenshot_service: crate::screenshot_service::ScreenshotService,
-    /// per-instance agent 启动锁，防止并发 ensure_agents 双 spawn
-    /// tokio::sync::Mutex 可在 async 上下文跨 await 持有（std MutexGuard 是 !Send）
+    /// per-instance 启动锁，防止并发 ensure_agents 双 spawn
     pub agent_start_locks: Mutex<HashMap<String, Arc<TokioMutex<()>>>>,
 }
 

--- a/src-tauri/src/commands/types.rs
+++ b/src-tauri/src/commands/types.rs
@@ -5,8 +5,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::process::Child;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use tokio::sync::Mutex as TokioMutex;
 
 use serde::{Deserialize, Serialize};
 
@@ -241,6 +242,17 @@ pub struct InstanceRuntime {
     /// 当前控制器的配置（用于 ControllerPool 引用管理）
     pub controller_config: Option<ControllerConfig>,
     pub tasker: Option<Tasker>,
+    /// 每次重建 tasker 时递增，用于 agent 检测"tasker 已换过，需重挂 sink"
+    pub tasker_generation: u64,
+    /// 上次 agent 注册 sink 时捕获的 tasker_generation 值
+    /// 相等 → sink 链仍有效；不等 → 需要重挂
+    pub agent_tasker_generation: u64,
+    /// 每次替换 resource 时递增。Resource 变更会连带重建 tasker，
+    /// 但 agent 的 custom recognition/action 注册在旧 Resource 上，
+    /// 无法仅靠重挂 sink 迁移，必须完整重建 agent。
+    pub resource_generation: u64,
+    /// 上次拉起 agent 时捕获的 resource_generation 值
+    pub agent_resource_generation: u64,
     pub agent_clients: Vec<AgentClient>,
     pub agent_children: Vec<Child>,
     /// 当前运行的任务 ID 列表（用于刷新后恢复状态）
@@ -364,6 +376,9 @@ pub struct MaaState {
     pub log_buffer: Mutex<LogBuffer>,
     /// 后端统一截图服务（确保每实例只有一份 post_screencap 在运行）
     pub screenshot_service: crate::screenshot_service::ScreenshotService,
+    /// per-instance agent 启动锁，防止并发 ensure_agents 双 spawn
+    /// tokio::sync::Mutex 可在 async 上下文跨 await 持有（std MutexGuard 是 !Send）
+    pub agent_start_locks: Mutex<HashMap<String, Arc<TokioMutex<()>>>>,
 }
 
 impl MaaState {


### PR DESCRIPTION
- fix #329

每次 start_tasks 都会无条件 spawn 新 go-service/cpp-algo 子进程， 任务结束后进程不退出，且每个新进程都在同一个 Tasker 上重复注册
sink 回调，导致：
- 进程数随运行次数线性增长
- 每个进程每次冷加载（maaend的navmesh / YOLO / 地图缓存等）
- taskfail / aspectratio 等 sink 重复触发

改动：
1. InstanceRuntime 增加 tasker_generation / resource_generation 字段， 用于 agent 检测 tasker 或 resource 是否已重建
2. 新增 ensure_agents() 幂等函数，三态决策：
   - 存活+同步 → 直接复用，不 spawn
   - Resource 改变 → bind(new) + connect() + register_sinks() 保留进程
   - 仅 tasker 改变 → 只重挂 sink
   - 进程退出/空 → 全量重建
3. start_tasks_impl 改用 ensure_agents()
4. stop_agent_impl 同步执行 disconnect()，避免旧 agent 反注册覆盖新 agent
5. 所有 tasker/resource 重建点递增对应代际字段
6. tokio::sync::Mutex per-instance 启动锁防并发双 spawn
7. 用户点停止时仅 graceful disconnect，不强杀进程

## Sourcery 摘要

使智能体生命周期管理具备幂等性，以便任务启动时复用现有进程、同步资源和 tasker 的变更，并优雅地关闭智能体。

Bug 修复：
- 防止重复启动任务时生成重复的智能体进程或注册重复的事件接收器。
- 确保智能体关闭时以同步方式断开连接，并避免强制终止进程，从而防止过期注册干扰替代智能体。

增强功能：
- 通过复用已同步的进程、在需要时重新绑定资源、在 tasker 变更后刷新接收器，以及仅在进程不可用时重建智能体，使智能体生命周期管理具备幂等性。
- 跟踪 tasker 和资源的代际，并串行化每个实例的智能体启动，以保持智能体同步并防止并发重复生成进程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make agent lifecycle management idempotent so task starts reuse existing processes, synchronize resource and tasker changes, and shut agents down gracefully.

Bug Fixes:
- Prevent repeated task starts from spawning duplicate agent processes or registering duplicate event sinks.
- Ensure agent shutdown disconnects synchronously and avoids forcibly killing processes, preventing stale registrations from interfering with replacement agents.

Enhancements:
- Make agent lifecycle management idempotent by reusing synchronized processes, rebinding resources when needed, refreshing sinks after tasker changes, and rebuilding agents only when processes are unavailable.
- Track tasker and resource generations and serialize per-instance agent startup to keep agents synchronized and prevent concurrent duplicate spawns.

</details>

## Sourcery 总结

使代理生命周期管理具备幂等性，从而在任务启动时复用现有进程、同步变更，并优雅地关闭代理。

错误修复：
- 防止重复启动任务生成重复的代理进程或注册重复的事件接收器。
- 确保代理关闭时同步断开连接，并避免强制终止进程，从而防止过时的注册信息干扰替代代理。

增强功能：
- 通过复用已同步的进程、同步资源和任务器变更，并仅在代理不可用时重建代理，使代理启动具备幂等性。
- 跟踪任务器和资源的代际，并串行化每个实例的代理启动，以防止并发生成重复进程。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使代理生命周期管理具备幂等性，以便任务启动时复用现有进程、同步运行时变更，并优雅地关闭代理。

Bug 修复：
- 防止重复启动任务生成重复的代理进程或注册重复的事件接收器。
- 在关闭期间同步断开代理连接，并避免强制终止其进程，从而防止过时的注册信息影响替换后的代理。

增强功能：
- 使代理启动具备幂等性：复用已同步的进程，在运行时版本发生变化时更新资源或接收器，并仅在代理不可用时重建代理。
- 跟踪任务器版本和资源版本，并串行化每个实例的代理启动，以防止并发生成重复进程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make agent lifecycle management idempotent so task starts reuse existing processes, synchronize runtime changes, and shut agents down gracefully.

Bug Fixes:
- Prevent repeated task starts from spawning duplicate agent processes or registering duplicate event sinks.
- Synchronously disconnect agents during shutdown and avoid force-killing their processes, preventing stale registrations from affecting replacement agents.

Enhancements:
- Make agent startup idempotent by reusing synchronized processes, updating resources or sinks when runtime generations change, and rebuilding agents only when unavailable.
- Track tasker and resource generations and serialize per-instance agent startup to prevent concurrent duplicate spawns.

</details>

</details>