### PR TITLE
fix: 任务结束后清理旧 agent 进程，避免跨轮累积

### DIFF
--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -852,16 +852,20 @@ pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(
     }
 
     info!(
-        "[stop_agent] Stopping {} agent client(s) and {} child process(es) in background...",
+        "[stop_agent] Stopping {} agent client(s) and {} child process(es)...",
         clients.len(),
         children.len()
     );
 
-    thread::spawn(move || {
-        for client in clients {
-            let _ = client.disconnect();
-        }
+    // 同步断开所有 client：确保 custom 反注册在返回前完成，
+    // 避免旧 agent 的反注册晚于新 agent 的注册，误删新 agent 的同名 custom 条目。
+    for client in &clients {
+        let _ = client.disconnect();
+    }
+    drop(clients); // Drop 同步执行 clear_custom_registration()
 
+    // 子进程收尾放到后台：等待自然退出，超时强杀兜底，避免进程泄漏。
+    thread::spawn(move || {
         for (i, mut child) in children.into_iter().enumerate() {
             debug!("Waiting for agent process #{} to exit...", i);
 

--- a/src-tauri/src/commands/utils.rs
+++ b/src-tauri/src/commands/utils.rs
@@ -141,6 +141,14 @@ pub fn handle_task_callback(
     emit_state_changed(app, instance_id, "task-progress");
     if all_done {
         emit_state_changed(app, instance_id, "tasks-completed");
+
+        // 实例内全部任务结束后清理旧 agent，避免 agent 进程跨轮累积
+        if let Err(e) = super::maa_agent::stop_agent_impl(maa_state, instance_id) {
+            log::warn!(
+                "[handle_task_callback] Failed to stop agents after tasks completed: {}",
+                e
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## 问题（#329）

每次 startTasks 都会无条件 spawn 新的 agent 子进程，任务结束后旧进程不回收，导致：

- agent 进程数随运行次数线性增长
- 同一 Tasker 的事件被多个残留进程重复消费
- 每个残留进程不清理，内存持续上涨

## 改动

1. `handle_task_callback`：实例内全部任务结束后（all_done）调用 `stop_agent_impl` 清理本实例的旧 agent
2. `stop_agent_impl`：`disconnect()` 改为同步执行，修复"旧 agent 反注册晚于新 agent 注册、误删新 agent 的 custom 条目"的竞态；子进程收尾保留超时强杀兜底，避免泄漏

## 为什么是"清理"而不是"复用"（与 #330 的区别）

下游还有大量不同开发者维护的 MaaXXX 类似项目

它们的功能都是基于这个 **每次运行新开进程** 的实际行为上开发、测试、发布出来的

由于长期无人发现此问题，这个 bug 事实上可能已经成了结构设计的一部分

如果真的进行改动（复用已有 agent ），无法确认下游其他项目是否会出现某些功能依赖此 bug 而导致完全不可用的情况

所以 cleanup 旧的 agent 是对当前状况下保证向后兼容的最小修复

本 PR 在保留当前事实语义的情况下清理旧 agent 进程，不影响兼容性

---

## Sourcery 总结

在任务全部结束时清理 agent 资源，防止跨轮累积并确保新旧 agent 注册状态一致。

**错误修复：**
- 在实例内所有任务完成后自动停止并清理旧 agent，避免 agent 进程跨轮累积。
- 同步完成 agent client 断开和 custom 注册清理，避免旧 agent 的延迟反注册误删新 agent 条目。

**功能增强：**
- 将子进程退出等待和超时强杀保留为后台收尾，减少任务完成时的阻塞并防止进程泄漏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在任务全部结束时清理 agent 资源，防止跨轮累积并确保新旧 agent 注册状态一致。

Bug Fixes:
- 在实例内所有任务完成后自动停止并清理旧 agent，避免 agent 进程跨轮累积。
- 同步完成 agent client 断开和 custom 注册清理，避免旧 agent 的延迟反注册误删新 agent 条目。

Enhancements:
- 将子进程退出等待和超时强杀保留为后台收尾，减少任务完成时的阻塞并防止进程泄漏。

</details>