### PR TITLE
fix: 适配 Agent 优雅关闭语义，避免终态事件在转发给 Agent 前被截断

### DIFF
--- a/src-tauri/src/commands/maa_agent.rs
+++ b/src-tauri/src/commands/maa_agent.rs
@@ -527,6 +527,13 @@ pub async fn start_tasks_impl(
 ) -> Result<Vec<i64>, String> {
     info!("start_tasks_impl called");
 
+    // 仅新一次运行时清理上一轮残留 agent（reset_state=false 的追加批次
+    // 复用现有 agent，不能断开）。常态下上一轮已由任务结束时的同步
+    // disconnect 清理，此处为幂等兜底：防收尾超时/卡死时的进程残留
+    if reset_state {
+        let _ = stop_agent_impl(maa_state, &instance_id);
+    }
+
     info!("instance_id: {}", instance_id);
     info!("tasks: {:?}", tasks);
     info!("agent_configs: {:?}", agent_configs);
@@ -857,20 +864,16 @@ pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(
         children.len()
     );
 
-    // 同步断开所有 client：确保 custom 反注册在返回前完成，
-    // 避免旧 agent 的反注册晚于新 agent 的注册，误删新 agent 的同名 custom 条目。
-    for client in &clients {
-        let _ = client.disconnect();
-    }
-    drop(clients); // Drop 同步执行 clear_custom_registration()
-
-    // 子进程收尾放到后台：等待自然退出，超时强杀兜底，避免进程泄漏。
+    // 先启动强杀看门狗，再同步断开：disconnect 等 ShutDownResponse 期间若
+    // agent 收尾卡死（RPC 超时默认不设限），看门狗到期杀进程 → socket 断开 →
+    // 阻塞中的 disconnect 立即报错返回，调用线程不会被永久钉死。
+    // 正常路径 agent 收尾完自行退出，看门狗轮询立即收获、不会触发 kill。
     thread::spawn(move || {
         for (i, mut child) in children.into_iter().enumerate() {
             debug!("Waiting for agent process #{} to exit...", i);
 
             let start = std::time::Instant::now();
-            let timeout = std::time::Duration::from_secs(5);
+            let timeout = std::time::Duration::from_secs(15);
             let mut exited = false;
 
             while start.elapsed() < timeout {
@@ -898,6 +901,15 @@ pub fn stop_agent_impl(maa_state: &Arc<MaaState>, instance_id: &str) -> Result<(
             }
         }
     });
+
+    // 同步断开所有 client：确保 custom 反注册在返回前完成，
+    // 避免旧 agent 的反注册晚于新 agent 的注册，误删新 agent 的同名 custom 条目。
+    // disconnect 由框架保证先排空事件转发再发 ShutDownRequest，并等待
+    // agent 收尾完成（ShutDownResponse）后返回。
+    for client in &clients {
+        let _ = client.disconnect();
+    }
+    drop(clients); // Drop 同步执行 clear_custom_registration()
 
     Ok(())
 }

--- a/src-tauri/src/commands/utils.rs
+++ b/src-tauri/src/commands/utils.rs
@@ -6,6 +6,7 @@ use super::types::{MaaCallbackEvent, MaaState, StateChangedEvent};
 use crate::ws_broadcast::{WsBroadcast, WsEvent};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::thread;
 use tauri::{AppHandle, Emitter, Manager};
 
 /// 发送回调事件到前端（Tauri WebView + WebSocket 浏览器客户端）
@@ -142,13 +143,21 @@ pub fn handle_task_callback(
     if all_done {
         emit_state_changed(app, instance_id, "tasks-completed");
 
-        // 实例内全部任务结束后清理旧 agent，避免 agent 进程跨轮累积
-        if let Err(e) = super::maa_agent::stop_agent_impl(maa_state, instance_id) {
-            log::warn!(
-                "[handle_task_callback] Failed to stop agents after tasks completed: {}",
-                e
-            );
-        }
+        // 实例内全部任务结束后清理旧 agent，避免 agent 进程跨轮累积。
+        // 挪到后台线程执行：disconnect 会同步等待 agent 收尾完成
+        // （ShutDownResponse，可达数秒），而本回调运行在框架事件分发
+        // 线程上，阻塞它会卡住后续所有事件。收尾顺序由 disconnect
+        // 内部保证，mem::take 幂等，无需额外延迟或守卫。
+        let maa_state = Arc::clone(maa_state);
+        let instance_id = instance_id.to_string();
+        thread::spawn(move || {
+            if let Err(e) = super::maa_agent::stop_agent_impl(&maa_state, &instance_id) {
+                log::warn!(
+                    "[handle_task_callback] Failed to stop agents after tasks completed: {}",
+                    e
+                );
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## 背景
#331 在任务结束瞬间同步断开 Agent IPC 会话，导致 Tasker.Task.Failed / Tasker.Task.Succeeded 终态事件在转发给 agent 前被截断，依赖终态事件的下游功能（失败通知、失败反馈提示等）失效

## 改动
本 PR 对 agent 生命周期管理做三点调整，为 Agent 优雅关闭语义做适配：

1、任务结束后的清理移至后台线程（handle_task_callback）

disconnect 会同步等待 agent 收尾（可达数秒），而该回调运行在框架事件分发线程上，阻塞它会卡住后续所有事件

2、强杀看门狗前置（stop_agent_impl）

先启动 15s 看门狗再 disconnect
因为 agent 收尾存在卡死的情况
卡死时看门狗杀进程、socket 断开，阻塞中的 disconnect 立即报错返回，调用线程不会被永久钉死
正常情况下 agent 收尾完会自行退出，看门狗不触发

3、启动前同步清理残留（start_tasks_impl，仅 reset_state = true）

防进程累积，追加批次（reset_state = false）复用现有 agent，不受影响

---

上述功能依赖于 MaaFramework 侧的优雅关闭改动 https://github.com/MaaXYZ/MaaFramework/pull/1469 ，届时 agent 可在收尾（如等待失败通知发出）完成后自行退出

在 MaaFramework 侧合入前，本 PR 行为与现状等效（agent 断开后 5s→15s 被回收，对新启动的 agent 无干扰）
可独立先行合并

## Summary by Sourcery

适配 Agent 优雅关闭流程，确保终态事件可靠转发并避免 Agent 残留或关闭阻塞。

Bug Fixes:
- 确保任务终态事件在 Agent 关闭前完成转发，避免失败通知和反馈提示等下游功能失效。

Enhancements:
- 将任务完成后的 Agent 清理移至后台执行，避免阻塞框架事件分发线程。
- 调整 Agent 关闭流程并延长强杀兜底时间，以支持优雅收尾并防止异常情况下线程或进程永久挂起。
- 在新一轮任务启动前清理残留 Agent，同时保留追加批次对现有 Agent 的复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

适配 Agent 优雅关闭流程，确保终态事件可靠转发并避免 Agent 残留或关闭阻塞。

Bug Fixes:
- 确保任务终态事件在 Agent 关闭前完成转发，避免失败通知和反馈提示等下游功能失效。

Enhancements:
- 将任务完成后的 Agent 清理移至后台执行，避免阻塞框架事件分发线程。
- 调整 Agent 关闭流程并延长强杀兜底时间，以支持优雅收尾并防止异常情况下线程或进程永久挂起。
- 在新一轮任务启动前清理残留 Agent，同时保留追加批次对现有 Agent 的复用。

</details>