### PR TITLE
revert: 开始任务后禁止切换顶部状态栏

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -173,7 +173,6 @@ export function TabBar() {
   };
 
   const langKey = getInterfaceLangKey(language);
-  const topBarLocked = instances.some((inst) => inst.isRunning);
 
   // 右键菜单处理
   const handleTabContextMenu = useCallback(
@@ -381,14 +380,7 @@ export function TabBar() {
   return (
     <div className="flex items-center h-10 bg-bg-secondary border-b border-border select-none">
       {/* 标签页区域 */}
-      <div
-        id="tab-bar-area"
-        className={clsx(
-          'flex-1 flex items-center h-full overflow-x-auto',
-          topBarLocked && 'pointer-events-none',
-        )}
-        aria-disabled={topBarLocked}
-      >
+      <div id="tab-bar-area" className="flex-1 flex items-center h-full overflow-x-auto">
         {instances.map((instance, index) => {
           const isAnimatingIn = animatingTabIds.includes(instance.id);
           const isClosing = closingTabIds.includes(instance.id);
@@ -401,7 +393,7 @@ export function TabBar() {
                 else tabRefs.current.delete(instance.id);
               }}
               onMouseDown={(e) => handleMouseDown(e, index)}
-              onClick={() => !topBarLocked && !isClosing && setActiveInstance(instance.id)}
+              onClick={() => !isClosing && setActiveInstance(instance.id)}
               onDoubleClick={(e) => handleDoubleClick(e, instance.id, instance.name)}
               onContextMenu={(e) => handleTabContextMenu(e, instance.id, instance.name)}
               onAnimationEnd={() => {
@@ -411,7 +403,6 @@ export function TabBar() {
               }}
               className={clsx(
                 'group flex items-center gap-1 h-full px-2 cursor-pointer border-r border-border min-w-[120px] max-w-[200px]',
-                topBarLocked && 'cursor-not-allowed opacity-70',
                 instance.id === activeInstanceId
                   ? 'bg-bg-primary text-accent border-b-2 border-b-accent'
                   : 'bg-bg-tertiary text-text-secondary hover:bg-bg-hover border-b-2 border-b-transparent',
@@ -512,11 +503,7 @@ export function TabBar() {
         {/* 新建标签按钮 */}
         <button
           onClick={handleNewTab}
-          disabled={topBarLocked}
-          className={clsx(
-            'flex items-center justify-center w-8 h-full transition-colors',
-            topBarLocked ? 'cursor-not-allowed opacity-50' : 'hover:bg-bg-hover',
-          )}
+          className="flex items-center justify-center w-8 h-full hover:bg-bg-hover transition-colors"
           title={t('titleBar.newTab')}
         >
           <Plus className="w-4 h-4 text-text-secondary" />
@@ -534,15 +521,10 @@ export function TabBar() {
         {(updateInfo?.hasUpdate || updateInfo?.errorCode || downloadStatus === 'downloading') && (
           <button
             ref={bellButtonRef}
-            onClick={() => !topBarLocked && setShowUpdatePanel(!showUpdatePanel)}
-            disabled={topBarLocked}
+            onClick={() => setShowUpdatePanel(!showUpdatePanel)}
             className={clsx(
               'relative p-2 rounded-md transition-colors',
-              topBarLocked
-                ? 'cursor-not-allowed opacity-50'
-                : showUpdatePanel
-                  ? 'bg-accent/10'
-                  : 'hover:bg-bg-hover',
+              showUpdatePanel ? 'bg-accent/10' : 'hover:bg-bg-hover',
             )}
             title={
               updateInfo?.hasUpdate
@@ -575,15 +557,12 @@ export function TabBar() {
         {recentlyClosed.length > 0 && (
           <button
             ref={recentlyClosedButtonRef}
-            onClick={() => !topBarLocked && setShowRecentlyClosedPanel(!showRecentlyClosedPanel)}
-            disabled={topBarLocked}
+            onClick={() => setShowRecentlyClosedPanel(!showRecentlyClosedPanel)}
             className={clsx(
               'p-2 rounded-md transition-colors',
-              topBarLocked
-                ? 'cursor-not-allowed opacity-50'
-                : showRecentlyClosedPanel
-                  ? 'bg-accent/10 text-accent'
-                  : 'hover:bg-bg-hover text-text-secondary',
+              showRecentlyClosedPanel
+                ? 'bg-accent/10 text-accent'
+                : 'hover:bg-bg-hover text-text-secondary',
             )}
             title={t('recentlyClosed.title')}
           >
@@ -591,27 +570,18 @@ export function TabBar() {
           </button>
         )}
         <button
-          onClick={() => !topBarLocked && toggleDashboardView()}
-          disabled={topBarLocked}
+          onClick={toggleDashboardView}
           className={clsx(
             'p-2 rounded-md transition-colors',
-            topBarLocked
-              ? 'cursor-not-allowed opacity-50'
-              : dashboardView
-                ? 'bg-accent/10 text-accent'
-                : 'hover:bg-bg-hover text-text-secondary',
+            dashboardView ? 'bg-accent/10 text-accent' : 'hover:bg-bg-hover text-text-secondary',
           )}
           title={t('dashboard.toggle')}
         >
           <LayoutGrid className="w-4 h-4" />
         </button>
         <button
-          onClick={() => !topBarLocked && toggleTheme()}
-          disabled={topBarLocked}
-          className={clsx(
-            'p-2 rounded-md transition-colors',
-            topBarLocked ? 'cursor-not-allowed opacity-50' : 'hover:bg-bg-hover',
-          )}
+          onClick={toggleTheme}
+          className="p-2 rounded-md hover:bg-bg-hover transition-colors"
           title={
             resolveThemeMode(theme) === 'light' ? t('settings.themeDark') : t('settings.themeLight')
           }
@@ -623,12 +593,8 @@ export function TabBar() {
           )}
         </button>
         <button
-          onClick={() => !topBarLocked && setCurrentPage('settings')}
-          disabled={topBarLocked}
-          className={clsx(
-            'p-2 rounded-md transition-colors',
-            topBarLocked ? 'cursor-not-allowed opacity-50' : 'hover:bg-bg-hover',
-          )}
+          onClick={() => setCurrentPage('settings')}
+          className="p-2 rounded-md hover:bg-bg-hover transition-colors"
           title={t('titleBar.settings')}
         >
           <Settings className="w-4 h-4 text-text-secondary" />


### PR DESCRIPTION
<img width="1477" height="386" alt="image" src="https://github.com/user-attachments/assets/5750feab-ad39-43fe-8f2d-c479f4c41483" />
close #274 
避免影响多开

## Sourcery 总结

启动任务后，仍可使用顶部导航和控件。

错误修复：
- 恢复在另一个实例运行时切换标签页和使用顶部栏控件的功能，避免多个实例之间相互干扰。

增强功能：
- 移除运行中实例锁定，以及顶部导航栏的禁用样式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow top-bar navigation and controls to remain usable after starting a task.

Bug Fixes:
- Restore the ability to switch tabs and use top-bar controls while another instance is running, avoiding interference with multiple instances.

Enhancements:
- Remove the running-instance lock and disabled styling from the top navigation bar.

</details>