### PR TITLE
feat: add mute and unmute power actions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3166,6 +3166,7 @@ dependencies = [
  "tokio",
  "tower-http 0.5.2",
  "urlencoding",
+ "windows 0.61.3",
  "winsafe",
  "zip",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -81,3 +81,10 @@ winsafe = { version = "0.0.28", features = [
     "gdi",
     "user"
 ] }
+windows = { version = "0.61.3", features = [
+    "Win32_Media_Audio",
+    "Win32_Media_Audio_Endpoints",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_Variant",
+] }

--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -927,11 +927,9 @@ fn execute_power_set_mute(muted: bool) -> bool {
         use std::process::Command;
 
         let mute_value = if muted { "1" } else { "0" };
-        let amixer_value = if muted { "mute" } else { "unmute" };
-        let commands: [(&str, &[&str]); 3] = [
+        let commands: [(&str, &[&str]); 2] = [
             ("wpctl", &["set-mute", "@DEFAULT_AUDIO_SINK@", mute_value]),
             ("pactl", &["set-sink-mute", "@DEFAULT_SINK@", mute_value]),
-            ("amixer", &["set", "Master", amixer_value]),
         ];
 
         for (program, args) in commands {

--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -580,7 +580,7 @@ fn kill_process_by_name(name: &str) -> bool {
 const MXU_POWER_ACTION: &str = "MXU_POWER_ACTION";
 
 /// MXU_POWER custom action 回调函数
-/// 从 custom_action_param 中读取 power_action，执行关机/重启/息屏/睡眠操作
+/// 从 custom_action_param 中读取 power_action，执行关机/重启/息屏/睡眠/静音操作
 fn mxu_power_action_fn(
     _ctx: &maa_framework::context::Context,
     args: &maa_framework::custom::ActionArgs,
@@ -608,6 +608,8 @@ fn mxu_power_action_fn(
         "restart" => execute_power_restart(),
         "screenoff" => execute_power_screenoff(),
         "sleep" => execute_power_sleep(),
+        "mute" => execute_power_set_mute(true),
+        "unmute" => execute_power_set_mute(false),
         _ => {
             warn!("[MXU_POWER] Unknown power action: {}", action);
             false
@@ -830,6 +832,141 @@ fn execute_power_sleep() -> bool {
                 false
             }
         }
+    }
+}
+
+fn execute_power_set_mute(muted: bool) -> bool {
+    #[cfg(windows)]
+    {
+        use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
+        use windows::Win32::Media::Audio::{
+            eConsole, eRender, IMMDeviceEnumerator, MMDeviceEnumerator,
+        };
+        use windows::Win32::System::Com::{
+            CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_MULTITHREADED,
+        };
+
+        struct ComUninitializeGuard(bool);
+
+        impl Drop for ComUninitializeGuard {
+            fn drop(&mut self) {
+                if self.0 {
+                    unsafe { CoUninitialize() };
+                }
+            }
+        }
+
+        let _com_guard =
+            ComUninitializeGuard(unsafe { CoInitializeEx(None, COINIT_MULTITHREADED).is_ok() });
+        let result: windows::core::Result<()> = (|| unsafe {
+            let enumerator: IMMDeviceEnumerator =
+                CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)?;
+            let device = enumerator.GetDefaultAudioEndpoint(eRender, eConsole)?;
+            let endpoint_volume: IAudioEndpointVolume = device.Activate(CLSCTX_ALL, None)?;
+            endpoint_volume.SetMute(muted, std::ptr::null())?;
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => {
+                info!(
+                    "[MXU_POWER] Audio {} (Windows)",
+                    if muted { "muted" } else { "unmuted" }
+                );
+                true
+            }
+            Err(e) => {
+                log::error!(
+                    "[MXU_POWER] Failed to {} audio (Windows): {}",
+                    if muted { "mute" } else { "unmute" },
+                    e
+                );
+                false
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+
+        let script = if muted {
+            "set volume with output muted"
+        } else {
+            "set volume without output muted"
+        };
+        match Command::new("osascript").args(["-e", script]).status() {
+            Ok(status) if status.success() => {
+                info!(
+                    "[MXU_POWER] Audio {} (macOS)",
+                    if muted { "muted" } else { "unmuted" }
+                );
+                true
+            }
+            Ok(status) => {
+                log::error!(
+                    "[MXU_POWER] Failed to {} audio (macOS), exit status: {}",
+                    if muted { "mute" } else { "unmute" },
+                    status
+                );
+                false
+            }
+            Err(e) => {
+                log::error!(
+                    "[MXU_POWER] Failed to {} audio (macOS): {}",
+                    if muted { "mute" } else { "unmute" },
+                    e
+                );
+                false
+            }
+        }
+    }
+
+    #[cfg(not(any(windows, target_os = "macos")))]
+    {
+        use std::process::Command;
+
+        let mute_value = if muted { "1" } else { "0" };
+        let amixer_value = if muted { "mute" } else { "unmute" };
+        let commands: [(&str, &[&str]); 3] = [
+            ("wpctl", &["set-mute", "@DEFAULT_AUDIO_SINK@", mute_value]),
+            ("pactl", &["set-sink-mute", "@DEFAULT_SINK@", mute_value]),
+            ("amixer", &["set", "Master", amixer_value]),
+        ];
+
+        for (program, args) in commands {
+            match Command::new(program).args(args).status() {
+                Ok(status) if status.success() => {
+                    info!(
+                        "[MXU_POWER] Audio {} (Linux, {})",
+                        if muted { "muted" } else { "unmuted" },
+                        program
+                    );
+                    return true;
+                }
+                Ok(status) => warn!(
+                    "[MXU_POWER] {} failed to {} audio, exit status: {}",
+                    program,
+                    if muted { "mute" } else { "unmute" },
+                    status
+                ),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    info!("[MXU_POWER] {} is unavailable, trying fallback", program)
+                }
+                Err(e) => warn!(
+                    "[MXU_POWER] Failed to run {} while trying to {} audio: {}",
+                    program,
+                    if muted { "mute" } else { "unmute" },
+                    e
+                ),
+            }
+        }
+
+        log::error!(
+            "[MXU_POWER] Failed to {} audio: no supported Linux audio control succeeded",
+            if muted { "mute" } else { "unmute" }
+        );
+        false
     }
 }
 

--- a/src-tauri/src/mxu_actions.rs
+++ b/src-tauri/src/mxu_actions.rs
@@ -580,7 +580,7 @@ fn kill_process_by_name(name: &str) -> bool {
 const MXU_POWER_ACTION: &str = "MXU_POWER_ACTION";
 
 /// MXU_POWER custom action 回调函数
-/// 从 custom_action_param 中读取 power_action，执行关机/重启/息屏/睡眠/静音操作
+/// 从 custom_action_param 中读取 power_action，执行关机/重启/息屏/睡眠/静音/取消静音操作
 fn mxu_power_action_fn(
     _ctx: &maa_framework::context::Context,
     args: &maa_framework::custom::ActionArgs,

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -201,6 +201,8 @@ export default {
       restart: 'Restart',
       screenoff: 'Turn Off Screen',
       sleep: 'Sleep',
+      mute: 'Mute',
+      unmute: 'Unmute',
     },
   },
 

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -199,6 +199,8 @@ export default {
       restart: '再起動',
       screenoff: '画面オフ',
       sleep: 'スリープ',
+      mute: 'ミュート',
+      unmute: 'ミュート解除',
     },
   },
 

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -197,6 +197,8 @@ export default {
       restart: '재시작',
       screenoff: '화면 끄기',
       sleep: '절전 모드',
+      mute: '음소거',
+      unmute: '음소거 해제',
     },
   },
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -194,6 +194,8 @@ export default {
       restart: '重启',
       screenoff: '息屏',
       sleep: '睡眠',
+      mute: '静音',
+      unmute: '解除静音',
     },
   },
 

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -194,6 +194,8 @@ export default {
       restart: '重新啟動',
       screenoff: '關閉螢幕',
       sleep: '睡眠',
+      mute: '靜音',
+      unmute: '取消靜音',
     },
   },
 

--- a/src/types/specialTasks.ts
+++ b/src/types/specialTasks.ts
@@ -468,7 +468,7 @@ const MXU_POWER_TASK_DEF_INTERNAL: TaskItem = {
   },
 };
 
-// MXU_POWER 下拉选项定义（关机/重启/息屏/睡眠）
+// MXU_POWER 下拉选项定义（关机/重启/息屏/睡眠/静音/解除静音）
 const MXU_POWER_OPTION_DEF_INTERNAL: SelectOption = {
   type: 'select',
   label: 'specialTask.power.optionLabel',
@@ -513,6 +513,28 @@ const MXU_POWER_OPTION_DEF_INTERNAL: SelectOption = {
         [MXU_POWER_ENTRY]: {
           custom_action_param: {
             power_action: 'sleep',
+          },
+        },
+      },
+    },
+    {
+      name: 'mute',
+      label: 'specialTask.power.mute',
+      pipeline_override: {
+        [MXU_POWER_ENTRY]: {
+          custom_action_param: {
+            power_action: 'mute',
+          },
+        },
+      },
+    },
+    {
+      name: 'unmute',
+      label: 'specialTask.power.unmute',
+      pipeline_override: {
+        [MXU_POWER_ENTRY]: {
+          custom_action_param: {
+            power_action: 'unmute',
           },
         },
       },


### PR DESCRIPTION
Closes #337

## Summary

- Add explicit **Mute** and **Unmute** cases to the existing computer power task.
- Set the default output device mute state on Windows, macOS, and Linux.
- Add translations for all five built-in locales.

The actions set a deterministic state instead of toggling it, so task behavior does not depend on the computer's previous mute state.

## Implementation

- Windows: Core Audio `IAudioEndpointVolume::SetMute` on the default render/console endpoint.
- macOS: `osascript` with explicit output mute state.
- Linux: `wpctl`, with a `pactl` fallback.

No new task or UI component is introduced; the two cases are added to the existing operation-type selector.

## Testing

- Prettier check passed.
- `cargo fmt --check` passed.
- TypeScript type check passed.
- Vite production build passed.
- Windows x86_64 production Rust build with Tauri custom protocol passed.
- Manually tested both actions with MaaEnd v2.4.0 on Windows x64.

Linux and macOS behavior has not been manually exercised locally; their platform branches are intended to be covered by the repository's cross-platform CI builds.

## Sourcery 摘要

为跨平台添加“静音”和“取消静音”电源操作，并本地化任务选项。

新功能：
- 为现有的计算机电源任务添加明确的“静音”和“取消静音”操作。
- 支持在 Windows、macOS 和 Linux 上设置默认音频输出的静音状态。
- 在所有五种支持的语言环境中本地化新操作。

增强功能：
- 通过设置请求的静音状态，而不是切换当前状态，使音频操作具有确定性。

构建：
- 添加静音控制所需的 Windows 音频和 COM API 依赖项。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为计算机电源任务添加跨平台且具有确定性的静音和取消静音操作。

新功能：
- 为现有的计算机电源任务添加明确的“静音”和“取消静音”操作。
- 支持在 Windows、macOS 和 Linux 上设置默认音频输出的静音状态。

改进：
- 通过设置请求的静音状态，而不是切换当前状态，使音频控制具有确定性。

构建：
- 添加静音控制所需的 Windows 音频和 COM 依赖项。

维护：
- 在所有受支持的语言环境中本地化新增操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add deterministic cross-platform mute and unmute actions to the computer power task.

New Features:
- Add explicit Mute and Unmute actions to the existing computer power task.
- Support setting the default audio output mute state across Windows, macOS, and Linux.

Enhancements:
- Make audio control deterministic by setting the requested mute state rather than toggling the current state.

Build:
- Add the Windows audio and COM dependencies required for mute control.

Chores:
- Localize the new actions in all supported locales.

</details>

</details>