### PR TITLE
feat: 实现 PI v2.10.1 checkbox 最小/最大选择数限制

### DIFF
--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -43,6 +43,10 @@ import { splitTasksIntoThreeSegments } from '@/utils/taskSegmentation';
 import { startGlobalCallbackListener } from '@/components/connection/callbackCache';
 import { stopInstanceTasks } from '@/services/taskStopService';
 import { buildPiEnvVars } from '@/utils/piEnv';
+import {
+  formatCheckboxCountViolation,
+  validateInstanceCheckboxCounts,
+} from '@/utils/checkboxOptionValidation';
 
 const log = loggers.ui;
 
@@ -81,6 +85,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
     registerCtrlIdName,
     screenshotFrameRate,
     setShowAddTaskPanel,
+    addLog,
     tcpCompatMode,
     maaVersion,
   } = useAppStore();
@@ -232,6 +237,40 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
         setIsStarting(true);
 
         try {
+          const compatibleEnabledTasks = enabledTasks.filter((task) => {
+            const specialTask = getMxuSpecialTask(task.taskName);
+            const pretask = isPretaskName(task.taskName)
+              ? getPretaskItem(projectInterface, task.taskName)
+              : undefined;
+            const taskDef =
+              specialTask?.taskDef ||
+              (pretask ? buildPretaskDef(pretask) : undefined) ||
+              projectInterface?.task.find((item) => item.name === task.taskName);
+            return isTaskCompatible(taskDef, currentControllerName, currentResourceName);
+          });
+          const checkboxViolations = validateInstanceCheckboxCounts(
+            compatibleEnabledTasks,
+            projectInterface,
+            currentControllerName,
+            currentResourceName,
+            useAppStore.getState().globalOptionValues,
+          );
+          if (checkboxViolations.length > 0) {
+            for (const violation of checkboxViolations) {
+              const message = formatCheckboxCountViolation(
+                violation,
+                compatibleEnabledTasks,
+                projectInterface,
+                translations,
+                t,
+              );
+              log.warn(`[${instanceName}] ${message}`);
+              addLog(instanceId, { type: 'error', message });
+            }
+            setIsStarting(false);
+            return;
+          }
+
           // v2.7.0: 连接 Controller 前执行 pretask（如游戏设置）
           // pretask 以伪任务形式存在于任务列表中，此处从已启用任务中筛出。
           const enabledPretasks = enabledTasks
@@ -441,6 +480,7 @@ function InstanceCard({ instanceId, instanceName, isActive, onSelect }: Instance
       registerTaskIdName,
       registerEntryTaskName,
       setShowAddTaskPanel,
+      addLog,
       translations,
       tcpCompatMode,
     ],

--- a/src/components/OptionEditor.tsx
+++ b/src/components/OptionEditor.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { getInterfaceLangKey } from '@/i18n';
 import { findSwitchCase } from '@/utils/optionHelpers';
+import { getCheckboxMaxCount, getCheckboxMinCount } from '@/utils/checkboxOptionValidation';
 import { SwitchButton, TextInput, FileInput, TimeInput, HotkeyInput } from './FormControls';
 import { Tooltip } from './ui/Tooltip';
 
@@ -593,6 +594,19 @@ export function OptionEditor({
   if (optionDef.type === 'checkbox') {
     const selectedCases =
       effectiveValue?.type === 'checkbox' ? effectiveValue.caseNames : optionDef.default_case || [];
+    const selectedCount = new Set(selectedCases).size;
+    const minCount = getCheckboxMinCount(optionDef);
+    const maxCount = getCheckboxMaxCount(optionDef);
+    const isBelowMinimum = selectedCount < minCount;
+    const isAtMaximum = maxCount !== undefined && selectedCount >= maxCount;
+    const countConstraint =
+      minCount > 0 && maxCount !== undefined
+        ? t('optionEditor.checkboxCountRange', { min: minCount, max: maxCount })
+        : minCount > 0
+          ? t('optionEditor.checkboxCountMinimum', { min: minCount })
+          : maxCount !== undefined
+            ? t('optionEditor.checkboxCountMaximum', { max: maxCount })
+            : null;
 
     return (
       <div
@@ -619,12 +633,13 @@ export function OptionEditor({
               ? t(caseItem.label || caseItem.name)
               : resolveI18nText(caseItem.label, langKey) || caseItem.name;
             const isChecked = selectedCases.includes(caseItem.name);
+            const isCaseDisabled = effectiveDisabled || (!isChecked && isAtMaximum);
             return (
               <button
                 key={caseItem.name}
                 type="button"
                 onClick={() => {
-                  if (effectiveDisabled) return;
+                  if (isCaseDisabled) return;
                   const newCases = isChecked
                     ? selectedCases.filter((n) => n !== caseItem.name)
                     : [...selectedCases, caseItem.name];
@@ -633,15 +648,20 @@ export function OptionEditor({
                     caseNames: newCases,
                   });
                 }}
-                disabled={effectiveDisabled}
+                disabled={isCaseDisabled}
                 className={clsx(
                   'px-2 py-1.5 text-xs rounded border transition-colors min-w-0',
                   isChecked
                     ? 'bg-accent text-white border-accent'
                     : 'bg-bg-primary text-text-secondary border-border hover:border-accent hover:text-accent',
-                  effectiveDisabled && 'opacity-60 cursor-not-allowed',
+                  isCaseDisabled && 'opacity-60 cursor-not-allowed',
                 )}
-                title={caseLabel}
+                title={
+                  !isChecked && isAtMaximum
+                    ? `${caseLabel} — ${t('optionEditor.checkboxMaximumReached', { max: maxCount })}`
+                    : caseLabel
+                }
+                aria-pressed={isChecked}
               >
                 <span className="flex items-center gap-1.5 min-w-0">
                   {caseItem.icon && (
@@ -657,6 +677,27 @@ export function OptionEditor({
             );
           })}
         </div>
+        {countConstraint && (
+          <div
+            className={clsx(
+              'flex items-center gap-1 text-xs',
+              isBelowMinimum ? 'text-error' : 'text-text-muted',
+            )}
+          >
+            {isBelowMinimum && <AlertCircle className="w-3 h-3 flex-shrink-0" />}
+            <span>
+              {isBelowMinimum
+                ? t('optionEditor.checkboxMinimumRequired', {
+                    min: minCount,
+                    count: selectedCount,
+                  })
+                : t('optionEditor.checkboxSelectedCount', {
+                    count: selectedCount,
+                    constraint: countConstraint,
+                  })}
+            </span>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -64,6 +64,10 @@ import { isTaskSelectedForRun, filterTasksForRun } from '@/utils/taskRunFilter';
 import { isTauri } from '@/utils/paths';
 import { onStateChanged } from '@/services/wsService';
 import { buildPiEnvVars } from '@/utils/piEnv';
+import {
+  formatCheckboxCountViolation,
+  validateInstanceCheckboxCounts,
+} from '@/utils/checkboxOptionValidation';
 
 const log = loggers.task;
 const PRE_ACTION_CANCELLED_ERROR = 'MXU_PRE_ACTION_CANCELLED';
@@ -391,6 +395,28 @@ export function Toolbar({ showAddPanel, onToggleAddPanel, className }: ToolbarPr
           type: 'error',
           message: t('taskList.noCompatibleTasks'),
         });
+        return false;
+      }
+
+      const checkboxViolations = validateInstanceCheckboxCounts(
+        compatibleTasks,
+        projectInterface,
+        controllerName,
+        resourceName,
+        useAppStore.getState().globalOptionValues,
+      );
+      if (checkboxViolations.length > 0) {
+        for (const violation of checkboxViolations) {
+          const message = formatCheckboxCountViolation(
+            violation,
+            compatibleTasks,
+            projectInterface,
+            translations,
+            t,
+          );
+          log.warn(`实例 ${targetInstance.name}: ${message}`);
+          addLog(targetId, { type: 'error', message });
+        }
         return false;
       }
 

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -224,6 +224,12 @@ export default {
     taskSkippedController: 'Task "{{taskName}}" does not support current controller',
     taskSkippedResource: 'Task "{{taskName}}" does not support current resource',
     noCompatibleTasks: 'No tasks compatible with current controller and resource',
+    checkboxTaskScope: 'task "{{task}}"',
+    checkboxGlobalScope: 'global settings',
+    checkboxMinimumNotMet:
+      'Option "{{option}}" in {{scope}} requires at least {{min}} selections; currently {{count}}',
+    checkboxMaximumExceeded:
+      'Option "{{option}}" in {{scope}} allows at most {{max}} selections; currently {{count}}',
     // Auto connect
     autoConnect: {
       searching: 'Searching devices...',
@@ -361,6 +367,12 @@ export default {
     hotkeyCapturing: 'Press keys...',
     expandOptions: 'Expand sub-options',
     collapseOptions: 'Collapse sub-options',
+    checkboxCountRange: 'at least {{min}}, at most {{max}}',
+    checkboxCountMinimum: 'at least {{min}}',
+    checkboxCountMaximum: 'at most {{max}}',
+    checkboxSelectedCount: '{{count}} selected ({{constraint}})',
+    checkboxMinimumRequired: 'Select at least {{min}} (currently {{count}})',
+    checkboxMaximumReached: 'You can select at most {{max}}',
   },
 
   // Preset

--- a/src/i18n/locales/ja-JP.ts
+++ b/src/i18n/locales/ja-JP.ts
@@ -218,6 +218,12 @@ export default {
     stopTasks: '実行停止',
     startingTasks: '開始中...',
     stoppingTasks: '停止中...',
+    checkboxTaskScope: 'タスク「{{task}}」',
+    checkboxGlobalScope: 'グローバル設定',
+    checkboxMinimumNotMet:
+      '{{scope}}のオプション「{{option}}」は少なくとも {{min}} 個必要です（現在 {{count}} 個）',
+    checkboxMaximumExceeded:
+      '{{scope}}のオプション「{{option}}」は最大 {{max}} 個までです（現在 {{count}} 個）',
     // 自動接続関連
     autoConnect: {
       searching: 'デバイスを検索中...',
@@ -356,6 +362,12 @@ export default {
     hotkeyCapturing: 'キーを押してください...',
     expandOptions: '子オプションを展開',
     collapseOptions: '子オプションを折りたたむ',
+    checkboxCountRange: '{{min}} 個以上、{{max}} 個以下',
+    checkboxCountMinimum: '{{min}} 個以上',
+    checkboxCountMaximum: '{{max}} 個以下',
+    checkboxSelectedCount: '{{count}} 個選択中（{{constraint}}）',
+    checkboxMinimumRequired: '少なくとも {{min}} 個選択してください（現在 {{count}} 個）',
+    checkboxMaximumReached: '選択できるのは最大 {{max}} 個です',
   },
 
   // プリセット

--- a/src/i18n/locales/ko-KR.ts
+++ b/src/i18n/locales/ko-KR.ts
@@ -215,6 +215,12 @@ export default {
     stopTasks: '실행 중지',
     startingTasks: '시작 중...',
     stoppingTasks: '중지 중...',
+    checkboxTaskScope: '작업 「{{task}}」',
+    checkboxGlobalScope: '전역 설정',
+    checkboxMinimumNotMet:
+      '{{scope}}의 옵션 「{{option}}」은(는) 최소 {{min}}개가 필요합니다 (현재 {{count}}개)',
+    checkboxMaximumExceeded:
+      '{{scope}}의 옵션 「{{option}}」은(는) 최대 {{max}}개까지 가능합니다 (현재 {{count}}개)',
     // 자동 연결 관련
     autoConnect: {
       searching: '기기 검색 중...',
@@ -351,6 +357,12 @@ export default {
     hotkeyCapturing: '키를 누르세요...',
     expandOptions: '하위 옵션 펼치기',
     collapseOptions: '하위 옵션 접기',
+    checkboxCountRange: '최소 {{min}}개, 최대 {{max}}개',
+    checkboxCountMinimum: '최소 {{min}}개',
+    checkboxCountMaximum: '최대 {{max}}개',
+    checkboxSelectedCount: '{{count}}개 선택됨 ({{constraint}})',
+    checkboxMinimumRequired: '최소 {{min}}개를 선택하세요 (현재 {{count}}개)',
+    checkboxMaximumReached: '최대 {{max}}개까지 선택할 수 있습니다',
   },
 
   // 프리셋

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -216,6 +216,12 @@ export default {
     taskSkippedController: '任务 "{{taskName}}" 不支持当前控制器',
     taskSkippedResource: '任务 "{{taskName}}" 不支持当前资源',
     noCompatibleTasks: '没有兼容当前控制器和资源的任务',
+    checkboxTaskScope: '任务「{{task}}」',
+    checkboxGlobalScope: '全局设置',
+    checkboxMinimumNotMet:
+      '{{scope}}的选项「{{option}}」至少需要选择 {{min}} 项，当前选择了 {{count}} 项',
+    checkboxMaximumExceeded:
+      '{{scope}}的选项「{{option}}」最多只能选择 {{max}} 项，当前选择了 {{count}} 项',
     // 自动连接相关
     autoConnect: {
       searching: '搜索设备...',
@@ -350,6 +356,12 @@ export default {
     hotkeyCapturing: '按下快捷键...',
     expandOptions: '展开子选项',
     collapseOptions: '收起子选项',
+    checkboxCountRange: '至少 {{min}} 项，最多 {{max}} 项',
+    checkboxCountMinimum: '至少 {{min}} 项',
+    checkboxCountMaximum: '最多 {{max}} 项',
+    checkboxSelectedCount: '已选择 {{count}} 项（{{constraint}}）',
+    checkboxMinimumRequired: '至少选择 {{min}} 项（当前 {{count}} 项）',
+    checkboxMaximumReached: '最多只能选择 {{max}} 项',
   },
 
   // 预设配置

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -212,6 +212,12 @@ export default {
     stopTasks: '停止任務',
     startingTasks: '啟動中...',
     stoppingTasks: '停止中...',
+    checkboxTaskScope: '任務「{{task}}」',
+    checkboxGlobalScope: '全域設定',
+    checkboxMinimumNotMet:
+      '{{scope}}的選項「{{option}}」至少需要選擇 {{min}} 項，目前選擇了 {{count}} 項',
+    checkboxMaximumExceeded:
+      '{{scope}}的選項「{{option}}」最多只能選擇 {{max}} 項，目前選擇了 {{count}} 項',
     // 自動連接相关
     autoConnect: {
       searching: '搜尋裝置...',
@@ -346,6 +352,12 @@ export default {
     hotkeyCapturing: '按下快捷鍵...',
     expandOptions: '展開子選項',
     collapseOptions: '收起子選項',
+    checkboxCountRange: '至少 {{min}} 項，最多 {{max}} 項',
+    checkboxCountMinimum: '至少 {{min}} 項',
+    checkboxCountMaximum: '最多 {{max}} 項',
+    checkboxSelectedCount: '已選擇 {{count}} 項（{{constraint}}）',
+    checkboxMinimumRequired: '至少選擇 {{min}} 項（目前 {{count}} 項）',
+    checkboxMaximumReached: '最多只能選擇 {{max}} 項',
   },
 
   // 預設設定

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -284,6 +284,10 @@ export interface CheckboxOption {
   resource?: string[];
   cases: CaseItem[];
   default_case?: string[];
+  /** v2.10.1: 最少选择数量，默认 0 */
+  min_count?: number;
+  /** v2.10.1: 最大选择数量，缺省表示不限制 */
+  max_count?: number;
 }
 
 export interface SwitchOption {

--- a/src/utils/checkboxOptionValidation.ts
+++ b/src/utils/checkboxOptionValidation.ts
@@ -1,0 +1,277 @@
+import { createDefaultOptionValue, sanitizeOptionValue } from '@/stores/helpers';
+import type {
+  CheckboxOption,
+  OptionDefinition,
+  OptionValue,
+  ProjectInterface,
+  SelectedTask,
+} from '@/types/interface';
+import { getPretaskItem, isPretaskName } from '@/types/pretasks';
+import { getMxuSpecialTask, isMxuSpecialTask } from '@/types/specialTasks';
+import type { TFunction } from 'i18next';
+import { findSwitchCase } from './optionHelpers';
+
+export interface CheckboxCountViolation {
+  optionKey: string;
+  selectedCount: number;
+  minCount: number;
+  maxCount?: number;
+  kind: 'min' | 'max';
+  taskId?: string;
+  taskName?: string;
+}
+
+export function getCheckboxMinCount(optionDef: CheckboxOption): number {
+  return optionDef.min_count ?? 0;
+}
+
+export function getCheckboxMaxCount(optionDef: CheckboxOption): number | undefined {
+  return optionDef.max_count;
+}
+
+function resolveInterfaceLabel(
+  label: string | undefined,
+  fallback: string,
+  translations?: Record<string, string>,
+): string {
+  if (!label) return fallback;
+  if (!label.startsWith('$')) return label;
+  return translations?.[label.slice(1)] ?? label.slice(1);
+}
+
+export function formatCheckboxCountViolation(
+  violation: CheckboxCountViolation,
+  tasks: SelectedTask[],
+  projectInterface: ProjectInterface | null,
+  translations: Record<string, string> | undefined,
+  t: TFunction,
+): string {
+  const selectedTask = violation.taskId
+    ? tasks.find((task) => task.id === violation.taskId)
+    : undefined;
+  const specialTask = selectedTask ? getMxuSpecialTask(selectedTask.taskName) : undefined;
+  const pretask =
+    selectedTask && isPretaskName(selectedTask.taskName)
+      ? getPretaskItem(projectInterface, selectedTask.taskName)
+      : undefined;
+  const taskDef = selectedTask
+    ? specialTask?.taskDef ||
+      (pretask
+        ? {
+            label: pretask.label || pretask.name || pretask.exec,
+            name: pretask.name || pretask.exec,
+          }
+        : projectInterface?.task.find((item) => item.name === selectedTask.taskName))
+    : undefined;
+  const taskLabel =
+    selectedTask?.customName ||
+    (specialTask
+      ? t(taskDef?.label || taskDef?.name || selectedTask?.taskName || violation.taskName || '')
+      : resolveInterfaceLabel(
+          taskDef?.label,
+          taskDef?.name || selectedTask?.taskName || '',
+          translations,
+        ));
+  const optionDef =
+    specialTask?.optionDefs[violation.optionKey] || projectInterface?.option?.[violation.optionKey];
+  const optionLabel = specialTask
+    ? t(optionDef?.label || violation.optionKey)
+    : resolveInterfaceLabel(optionDef?.label, violation.optionKey, translations);
+  const scope = selectedTask
+    ? t('taskList.checkboxTaskScope', { task: taskLabel })
+    : t('taskList.checkboxGlobalScope');
+
+  return violation.kind === 'min'
+    ? t('taskList.checkboxMinimumNotMet', {
+        scope,
+        option: optionLabel,
+        min: violation.minCount,
+        count: violation.selectedCount,
+      })
+    : t('taskList.checkboxMaximumExceeded', {
+        scope,
+        option: optionLabel,
+        max: violation.maxCount,
+        count: violation.selectedCount,
+      });
+}
+
+function isOptionIncompatible(
+  optionDef: OptionDefinition,
+  controllerName?: string,
+  resourceName?: string,
+): boolean {
+  if (
+    optionDef.controller &&
+    optionDef.controller.length > 0 &&
+    (!controllerName || !optionDef.controller.includes(controllerName))
+  ) {
+    return true;
+  }
+  return Boolean(
+    optionDef.resource &&
+    optionDef.resource.length > 0 &&
+    (!resourceName || !optionDef.resource.includes(resourceName)),
+  );
+}
+
+function validateOptionKeys(
+  optionKeys: string[],
+  optionValues: Record<string, OptionValue>,
+  allOptions: Record<string, OptionDefinition>,
+  controllerName: string | undefined,
+  resourceName: string | undefined,
+  context: Pick<CheckboxCountViolation, 'taskId' | 'taskName'>,
+): CheckboxCountViolation[] {
+  const violations: CheckboxCountViolation[] = [];
+  const visited = new Set<string>();
+
+  const visit = (optionKey: string) => {
+    if (visited.has(optionKey)) return;
+    visited.add(optionKey);
+
+    const optionDef = allOptions[optionKey];
+    if (!optionDef || isOptionIncompatible(optionDef, controllerName, resourceName)) return;
+
+    const savedValue = optionValues[optionKey];
+    const optionValue =
+      (savedValue && sanitizeOptionValue(optionKey, savedValue, allOptions)) ||
+      createDefaultOptionValue(optionDef);
+
+    if (optionDef.type === 'checkbox' && optionValue.type === 'checkbox') {
+      const selectedCount = new Set(optionValue.caseNames).size;
+      const minCount = getCheckboxMinCount(optionDef);
+      const maxCount = getCheckboxMaxCount(optionDef);
+
+      if (selectedCount < minCount) {
+        violations.push({
+          optionKey,
+          selectedCount,
+          minCount,
+          maxCount,
+          kind: 'min',
+          ...context,
+        });
+      } else if (maxCount !== undefined && selectedCount > maxCount) {
+        violations.push({
+          optionKey,
+          selectedCount,
+          minCount,
+          maxCount,
+          kind: 'max',
+          ...context,
+        });
+      }
+
+      return;
+    }
+
+    if (optionDef.type === 'switch' && optionValue.type === 'switch') {
+      findSwitchCase(optionDef.cases, optionValue.value)?.option?.forEach(visit);
+      return;
+    }
+
+    if ((!optionDef.type || optionDef.type === 'select') && optionValue.type === 'select') {
+      optionDef.cases
+        .find((caseDef) => caseDef.name === optionValue.caseName)
+        ?.option?.forEach(visit);
+    }
+  };
+
+  optionKeys.forEach(visit);
+  return violations;
+}
+
+/**
+ * 校验一次启动中实际会使用到的 checkbox 选项。
+ * 调用方应先过滤掉与当前控制器/资源不兼容的任务。
+ */
+export function validateInstanceCheckboxCounts(
+  tasks: SelectedTask[],
+  projectInterface: ProjectInterface | null,
+  controllerName?: string,
+  resourceName?: string,
+  globalOptionValues: Record<string, OptionValue> = {},
+): CheckboxCountViolation[] {
+  if (!projectInterface) return [];
+
+  const violations: CheckboxCountViolation[] = [];
+  const ordinaryTasks = tasks.filter(
+    (task) => !isMxuSpecialTask(task.taskName) && !isPretaskName(task.taskName),
+  );
+
+  if (
+    ordinaryTasks.length > 0 &&
+    projectInterface.option &&
+    projectInterface.global_option?.length
+  ) {
+    violations.push(
+      ...validateOptionKeys(
+        projectInterface.global_option,
+        globalOptionValues,
+        projectInterface.option,
+        controllerName,
+        resourceName,
+        {},
+      ),
+    );
+  }
+
+  for (const task of tasks) {
+    const specialTask = getMxuSpecialTask(task.taskName);
+    if (specialTask) {
+      violations.push(
+        ...validateOptionKeys(
+          specialTask.taskDef.option ?? [],
+          task.optionValues,
+          specialTask.optionDefs,
+          controllerName,
+          resourceName,
+          { taskId: task.id, taskName: task.taskName },
+        ),
+      );
+      continue;
+    }
+
+    if (isPretaskName(task.taskName)) {
+      const pretask = getPretaskItem(projectInterface, task.taskName);
+      if (pretask?.option && projectInterface.option) {
+        violations.push(
+          ...validateOptionKeys(
+            pretask.option,
+            task.optionValues,
+            projectInterface.option,
+            controllerName,
+            resourceName,
+            { taskId: task.id, taskName: task.taskName },
+          ),
+        );
+      }
+      continue;
+    }
+
+    const taskDef = projectInterface.task.find((item) => item.name === task.taskName);
+    if (!taskDef || !projectInterface.option) continue;
+
+    const resourceOptionKeys =
+      projectInterface.resource.find((item) => item.name === resourceName)?.option ?? [];
+    const controllerOptionKeys =
+      projectInterface.controller.find((item) => item.name === controllerName)?.option ?? [];
+    const optionKeys = [
+      ...new Set([...resourceOptionKeys, ...controllerOptionKeys, ...(taskDef.option ?? [])]),
+    ];
+
+    violations.push(
+      ...validateOptionKeys(
+        optionKeys,
+        task.optionValues,
+        projectInterface.option,
+        controllerName,
+        resourceName,
+        { taskId: task.id, taskName: task.taskName },
+      ),
+    );
+  }
+
+  return violations;
+}

--- a/src/utils/piEnv.ts
+++ b/src/utils/piEnv.ts
@@ -60,7 +60,7 @@ export function buildPiEnvVars(context: PiEnvContext): Record<string, string> {
 
   const envs: Record<string, string> = {};
 
-  envs.PI_INTERFACE_VERSION = 'v2.5.0';
+  envs.PI_INTERFACE_VERSION = 'v2.10.1';
   envs.PI_CLIENT_NAME = 'MXU';
   envs.PI_CLIENT_VERSION = typeof __MXU_VERSION__ !== 'undefined' ? __MXU_VERSION__ : 'unknown';
   envs.PI_CLIENT_LANGUAGE = getInterfaceLangKey(language);


### PR DESCRIPTION
## Sourcery 摘要

在选项编辑和任务启动验证中强制执行 PI v2.10.1 复选框选择限制。

新功能：
- 为复选框选项添加最小和最大选择数量限制，提供本地化的数量提示，并在达到最大数量时禁用其他选项。
- 在任务执行前验证适用的任务、控制器、资源和全局选项的复选框限制，并在日志和 UI 中报告违规情况。

增强功能：
- 支持嵌套选项验证，以及针对普通、特殊和预任务配置的兼容性感知复选框限制检查。

维护工作：
- 将 PI 接口版本更新至 v2.10.1。为支持的语言添加复选框选择限制的本地化消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce PI v2.10.1 checkbox selection limits in option editing and task startup validation.

New Features:
- Add minimum and maximum selection constraints for checkbox options, with localized count guidance and disabled choices when the maximum is reached.
- Validate checkbox constraints for applicable task, controller, resource, and global options before task execution, reporting violations in logs and the UI.

Enhancements:
- Support nested option validation and compatibility-aware checkbox constraint checks across ordinary, special, and pretask configurations.

Chores:
- Update the PI interface version to v2.10.1. Add localized messages for checkbox selection limits across supported languages.

</details>