### PR TITLE
feat: 保存任务下拉框展开

### DIFF
--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -509,6 +509,8 @@ export const useAppStore = create<AppState>()(
                 t.enabled,
               ),
               optionValues: t.optionValues,
+              expanded: t.expanded,
+              collapsedOptions: t.collapsedOptions,
             })),
             schedulePolicies: instanceToClose.schedulePolicies,
             preActions: instanceToClose.preActions,
@@ -1244,14 +1246,17 @@ export const useAppStore = create<AppState>()(
     importConfig: (config) => {
       const pi = get().projectInterface;
 
-      // 保留当前各实例/任务的运行时状态（纯 UI 状态，不随配置同步）
-      // 这样当其他客户端修改配置触发 importConfig 时，不会意外重置运行状态或折叠任务
+      // 折叠状态本地优先：其他客户端修改配置触发 importConfig 时沿用内存中的值，
+      // 只有冷启动（内存为空）才回落到配置里持久化的值，避免别的端把当前正在看的面板收起来。
+      // 运行状态则纯属本地，不随配置同步。
       const prevRunningByInstance = new Map<string, boolean>();
       const prevExpandedByTask = new Map<string, boolean>();
+      const prevCollapsedByTask = new Map<string, Record<string, boolean> | undefined>();
       for (const inst of get().instances) {
         prevRunningByInstance.set(inst.id, inst.isRunning);
         for (const t of inst.selectedTasks) {
           prevExpandedByTask.set(t.id, t.expanded);
+          prevCollapsedByTask.set(t.id, t.collapsedOptions);
         }
       }
 
@@ -1302,7 +1307,8 @@ export const useAppStore = create<AppState>()(
                 enabled: t.enabled,
                 enabledByController: t.enabledByController,
                 optionValues: t.optionValues,
-                expanded: prevExpandedByTask.get(t.id) ?? false,
+                expanded: prevExpandedByTask.get(t.id) ?? t.expanded ?? false,
+                collapsedOptions: prevCollapsedByTask.get(t.id) ?? t.collapsedOptions,
               };
             }
 
@@ -1329,7 +1335,8 @@ export const useAppStore = create<AppState>()(
                 enabled: t.enabled,
                 enabledByController: t.enabledByController,
                 optionValues: mergedValues,
-                expanded: prevExpandedByTask.get(t.id) ?? false,
+                expanded: prevExpandedByTask.get(t.id) ?? t.expanded ?? false,
+                collapsedOptions: prevCollapsedByTask.get(t.id) ?? t.collapsedOptions,
               };
             }
 
@@ -1356,7 +1363,8 @@ export const useAppStore = create<AppState>()(
               enabled: t.enabled,
               enabledByController: t.enabledByController,
               optionValues: mergedValues,
-              expanded: prevExpandedByTask.get(t.id) ?? false,
+              expanded: prevExpandedByTask.get(t.id) ?? t.expanded ?? false,
+              collapsedOptions: prevCollapsedByTask.get(t.id) ?? t.collapsedOptions,
             };
           });
 
@@ -2153,7 +2161,8 @@ export const useAppStore = create<AppState>()(
           enabled: t.enabled,
           enabledByController: t.enabledByController ? { ...t.enabledByController } : undefined,
           optionValues: restoreOptionValuesFromConfig(t.optionValues, pi, pi?.name),
-          expanded: false,
+          expanded: t.expanded ?? false,
+          collapsedOptions: t.collapsedOptions ? { ...t.collapsedOptions } : undefined,
         })),
         isRunning: false,
         schedulePolicies: normalizeSchedulePolicies(closedInstance),
@@ -2429,6 +2438,8 @@ function generateConfig(): MxuConfig {
             t.enabled,
           ),
           optionValues: t.optionValues,
+          expanded: t.expanded,
+          collapsedOptions: t.collapsedOptions,
         })),
       ),
       schedulePolicies: inst.schedulePolicies,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -23,6 +23,10 @@ export interface SavedTask {
   /** 各控制器独立的勾选状态（旧配置中不存在时按 enabled 初始化） */
   enabledByController?: Record<string, boolean>;
   optionValues: Record<string, OptionValue>;
+  /** 任务卡片是否展开；缺省 = 收起，向后兼容 */
+  expanded?: boolean;
+  /** 各选项的子选项折叠状态（optionKey → 是否折叠）；缺省 = 展开，向后兼容 */
+  collapsedOptions?: Record<string, boolean>;
 }
 
 // 保存的设备信息


### PR DESCRIPTION
避免选项越来越长杂乱
opus 5.0
<img width="1471" height="1026" alt="image" src="https://github.com/user-attachments/assets/d9dcca3a-dc88-4e83-b4fa-3c5f7219ac97" />
close https://github.com/MaaEnd/MaaEnd/issues/4964

## Sourcery 总结

在配置保存、恢复和同步过程中，持久化并保留任务和选项的展开状态。

新功能：
- 在保存的配置中持久化任务卡片展开状态和各选项的折叠状态。

错误修复：
- 从其他客户端导入或同步配置时，保留本地任务和选项面板的可见状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist and preserve task and option expansion states across configuration saves, restores, and synchronization.

New Features:
- Persist task card expansion and per-option collapse states in saved configurations.

Bug Fixes:
- Preserve local task and option panel visibility states when configurations are imported or synchronized from other clients.

</details>