### PR TITLE
style: 优化mirror酱下载速度样式

### DIFF
--- a/src/components/UpdateInfoCard.tsx
+++ b/src/components/UpdateInfoCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronRight, RefreshCw, PackageCheck, Globe } from 'lucide-react';
+import { ChevronRight, RefreshCw, PackageCheck, Globe, Zap } from 'lucide-react';
 import {
   useAppStore,
   SLOW_DOWNLOAD_DURATION_MS,
@@ -255,7 +255,16 @@ export function DownloadProgressBar({
               : ''}
         </span>
         {downloadStatus === 'downloading' && downloadProgress && downloadProgress.speed > 0 && (
-          <span>{formatSpeed(downloadProgress.speed)}</span>
+          <span
+            className={clsx(
+              'flex items-center gap-1',
+              downloadSource === 'mirrorchyan' &&
+                'text-[#D6782B] [.dark_&]:text-[#FFC061] font-medium',
+            )}
+          >
+            {downloadSource === 'mirrorchyan' && <Zap className="w-3 h-3 shrink-0 fill-current" />}
+            {formatSpeed(downloadProgress.speed)}
+          </span>
         )}
         {showActions && downloadStatus === 'completed' && onInstallClick && (
           <button


### PR DESCRIPTION
解决客户留存问题，修改下载速度颜色提示

github下载
<img width="1252" height="775" alt="973068050aaf4ed6c175bb0864ee2202" src="https://github.com/user-attachments/assets/5c50fdf2-2a63-4057-aa26-f59f5af78cfe" />

mirror酱下载
<img width="1252" height="775" alt="ba33a498472540381186f90a65ea9262" src="https://github.com/user-attachments/assets/699e6248-971f-4bc3-b056-7624beddb830" />
<img width="1252" height="775" alt="1343538fdfb41b80c795ea1c1c07e83b" src="https://github.com/user-attachments/assets/74de1524-285b-4752-a7bc-bb48de09e72e" />


## Sourcery 摘要

增强 MirrorChyan 下载速度的展示效果，让更快的下载速度更加醒目。

新功能：
- 使用闪电图标和特定来源的样式突出显示 MirrorChyan 的下载速度。

改进：
- 在浅色和深色主题中，提升 MirrorChyan 下载速度的可见性和区分度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance MirrorChyan download speed presentation to make faster downloads more noticeable.

New Features:
- Highlight MirrorChyan download speeds with a lightning icon and source-specific styling.

Enhancements:
- Improve download speed visibility and differentiation for MirrorChyan downloads in light and dark themes.

</details>