### PR TITLE
fix: 任务面板等宽自适应布局并完整显示任务名

### DIFF
--- a/src/components/AddTaskPanel.tsx
+++ b/src/components/AddTaskPanel.tsx
@@ -38,6 +38,9 @@ import clsx from 'clsx';
 
 const log = loggers.task;
 
+// 按面板实际宽度排列等宽列；auto-fill 保留空列，使不同任务数的分组仍然对齐。
+const taskGridClassName = 'grid grid-cols-[repeat(auto-fill,minmax(min(100%,14rem),1fr))] gap-2';
+
 /** 任务按钮组件：支持 hover 显示 description tooltip */
 function TaskButton({
   task,
@@ -113,7 +116,7 @@ function TaskButton({
       <button
         onClick={() => !disabled && onClick()}
         className={clsx(
-          'relative flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors text-left',
+          'relative flex min-w-0 items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors text-left',
           disabled
             ? 'bg-bg-secondary/50 text-text-muted border border-border/50 cursor-not-allowed opacity-60'
             : 'bg-bg-secondary hover:bg-bg-hover text-text-primary border border-border hover:border-accent',
@@ -133,7 +136,7 @@ function TaskButton({
           </span>
         )}
         <Plus className={clsx('w-4 h-4 shrink-0', disabled ? 'text-text-muted' : 'text-accent')} />
-        <span className="flex-1 truncate">{label}</span>
+        <span className="min-w-0 flex-1 whitespace-normal [overflow-wrap:anywhere]">{label}</span>
         {count > 0 && (
           <span
             className={clsx(
@@ -492,7 +495,7 @@ export function AddTaskPanel() {
   const renderTaskGrid = (tasks: TaskItem[]) => {
     if (tasks.length === 0) return null;
     return (
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-2">
+      <div className={taskGridClassName}>
         {tasks.map((task) => {
           const count = taskCounts[task.name] || 0;
           const label = resolveI18nText(task.label, langKey) || task.name;
@@ -523,7 +526,7 @@ export function AddTaskPanel() {
   const renderPretaskGrid = (items: PretaskItem[]) => {
     if (items.length === 0) return null;
     return (
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8 gap-2">
+      <div className={taskGridClassName}>
         {items.map((item) => {
           const taskDef = buildPretaskDef(item);
           const taskName = pretaskName(item);


### PR DESCRIPTION
修改MXU添加任务面板的任务条宽度自适应功能，这是原本和修改后的对比图
<img width="1214" height="261" alt="image" src="https://github.com/user-attachments/assets/54c70b7c-b630-4d84-9fae-e5cb4ef94b20" />
<img width="1214" height="395" alt="image" src="https://github.com/user-attachments/assets/eedc0bdf-8677-4804-ba68-94c5ddd421ea" />

## Sourcery 总结

优化添加任务面板的自适应布局，使任务按钮等宽排列并完整显示任务名称。

错误修复：
- 让添加任务面板中的任务名称在窄列或较长文本下完整换行显示，避免被截断。

改进：
- 将任务和前置任务列表调整为基于面板宽度的等宽自适应网格，并保持不同分组的列布局对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化添加任务面板的自适应布局，使任务按钮等宽排列并完整显示任务名称。

Bug Fixes:
- 让添加任务面板中的任务名称在窄列或较长文本下完整换行显示，避免被截断。

Enhancements:
- 将任务和前置任务列表调整为基于面板宽度的等宽自适应网格，并保持不同分组的列布局对齐。

</details>