### PR TITLE
fix: 自动清理运行日志默认改为关闭

### DIFF
--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -235,7 +235,7 @@ export const useAppStore = create<AppState>()(
     backgroundOpacity: 50,
     confirmBeforeDelete: false,
     maxLogsPerInstance: DEFAULT_MAX_LOGS_PER_INSTANCE,
-    autoClearLogsOnLaunch: true,
+    autoClearLogsOnLaunch: false,
     helpImproveSoftware: true,
     customAccents: [],
     setTheme: (theme) => {
@@ -1469,7 +1469,7 @@ export const useAppStore = create<AppState>()(
         backgroundOpacity: effectiveBgOpacity,
         confirmBeforeDelete: config.settings.confirmBeforeDelete ?? false,
         maxLogsPerInstance: config.settings.maxLogsPerInstance ?? DEFAULT_MAX_LOGS_PER_INSTANCE,
-        autoClearLogsOnLaunch: config.settings.autoClearLogsOnLaunch ?? true,
+        autoClearLogsOnLaunch: config.settings.autoClearLogsOnLaunch ?? false,
         // 默认开启；调试 / 开发版本强制关闭
         helpImproveSoftware: isTelemetryBlockedByBuild(get().projectInterface)
           ? false

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -243,7 +243,7 @@ export const defaultConfig: MxuConfig = {
     language: 'system',
     confirmBeforeDelete: false,
     maxLogsPerInstance: DEFAULT_MAX_LOGS_PER_INSTANCE,
-    autoClearLogsOnLaunch: true,
+    autoClearLogsOnLaunch: false,
     windowSize: defaultWindowSize,
     mirrorChyan: defaultMirrorChyanSettings,
     helpImproveSoftware: true,


### PR DESCRIPTION
将 `autoClearLogsOnLaunch` 默认值从 `true` 改为 `false`，避免每次启动把日志清完用户找不到